### PR TITLE
Datainit

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,28 +57,33 @@ Refer to `demo.html` to see an example of how to embed LocusZoom into a page. In
 * `assets/js/locuszoom.app.js` OR `assets/js/locuszoom.app.min.js` (concatenated+minified application logic)
 * `assets/css/locuszoom.css` (stylesheet)
 
-LocusZoom only needs an empty `<div>` tag to create a new instance. The tag may optionally specify a starting region, like so:
+LocusZoom only needs an empty HTML element to create a new instance. (This tag should have an ID defined. This ID will be used as a prfix to construct child elements.) The tag may optionally specify a starting region, like so:
 
 ```html
 <div id="foo" data-region="10:114550452-115067678"></div>
 ```
 
-To populate this `<div>` with a LocusZoom instance:
+You can then bring the element to life with either the `populate()` method (for a single element) or `populateAll` method (for potentially multiple elements). They are defined as
 
 ```javascript
-LocusZoom.addInstanceToDivById(LocusZoom.DefaultInstance, "foo");
+var lz = LocusZoom.populate(selector, datasource, layout, state)
+var lz[] = LocusZoom.populateAll(selector, datasource, layout, state)
 ```
 
-Alternatively, one or more `<div>` tags can share a common class name, and this class can be used to populate multiple LocusZoom instances at once like so:
+The `populate()` method will return the new LocusZoom instance for the first matching element and the `populateAll()` method will always return an array containting instances for each of the matched elements.
 
-```html
-<div id="lz-1" class="lz-instance"></div>
-<div id="lz-2" class="lz-instance"></div>
-...
-```
+Here `selector` is either a reference to a DOM element (eg `document.getElementById("foo")`) or it is string that is a valid [D3 compatiable selector](http://www.w3.org/TR/selectors-api/) (eg `"#foo"`). 
+
+The `datasource` parameter must be a `LocusZoom.DataSources()` object.
+
+The `layout` paramter is not yet implemented.
+
+The `state` parameter is not yet implemented.
+
+We can initialize our sample element with
 
 ```javascript
-LocusZoom.populate("lz-instance");
+var ds = (new LocusZoom.DataSources()).addSource("base",["AssociationLZ", "http://myapi.com/"];
+LocusZoom.populate("#foo");
 ```
 
-Also note that the default LocusZoom instance is `lz-instance`, so in the above example calling just `LocusZoom.populate()` would also work.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The `state` parameter is not yet implemented.
 We can initialize our sample element with
 
 ```javascript
-var ds = (new LocusZoom.DataSources()).addSource("base",["AssociationLZ", "http://myapi.com/"];
-LocusZoom.populate("#foo");
+var ds = (new LocusZoom.DataSources()).addSource("base",["AssociationLZ", "http://myapi.com/"]);
+LocusZoom.populate("#foo", ds);
 ```
 

--- a/assets/js/app/Data.js
+++ b/assets/js/app/Data.js
@@ -13,10 +13,10 @@ LocusZoom.DataSources.prototype.addSource = function(ns, x) {
     function findKnownSource(x) {
         if (!LocusZoom.KnownDataSources) {return null;}
         for(var i=0; i<LocusZoom.KnownDataSources.length; i++) {
-            if (!LocusZoom.KnownDataSources[i].sourcename) {
-                throw("KnownDataSource at position " + i + "does not have a 'sourcename'");
+            if (!LocusZoom.KnownDataSources[i].SOURCE_NAME) {
+                throw("KnownDataSource at position " + i + " does not have a 'SOURCE_NAME' static property");
             }
-            if (LocusZoom.KnownDataSources[i].sourcename == x) {
+            if (LocusZoom.KnownDataSources[i].SOURCE_NAME == x) {
                 return LocusZoom.KnownDataSources[i];
             }
         }
@@ -64,11 +64,11 @@ LocusZoom.Data.Requester = function(sources) {
         fields.forEach(function(field) {
             var parts = field.split(/\:(.*)/);
             if (parts.length==1) {
-                if (typeof requests["position"] == "undefined") {
-                    requests.position = {names:[], fields:[]};
+                if (typeof requests["base"] == "undefined") {
+                    requests.base = {names:[], fields:[]};
                 }
-                requests.position.names.push(field);
-                requests.position.fields.push(field);
+                requests.base.names.push(field);
+                requests.base.fields.push(field);
             } else {
                 if (typeof requests[parts[0]] =="undefined") {
                     requests[parts[0]] = {names:[], fields:[]};
@@ -83,10 +83,10 @@ LocusZoom.Data.Requester = function(sources) {
     this.getData = function(state, fields) {
         var requests = split_requests(fields);
         var promises = Object.keys(requests).map(function(key) {
-            if (!sources[key]) {
+            if (!sources.getSource(key)) {
                 throw("Datasource for namespace " + key + " not found");
             }
-            return sources[key].getData(state, requests[key].fields, requests[key].names);
+            return sources.getSource(key).getData(state, requests[key].fields, requests[key].names);
         });
         //assume the fields are requested in dependent order
         //TODO: better manage dependencies
@@ -132,7 +132,7 @@ LocusZoom.Data.AssociationSource = function(url) {
         };
     };
 };
-LocusZoom.Data.AssociationSource.sourcename = "AssocationLZ";
+LocusZoom.Data.AssociationSource.SOURCE_NAME = "AssocationLZ";
 
 LocusZoom.Data.LDSource = function(url) {
     this.url = url;
@@ -195,7 +195,7 @@ LocusZoom.Data.LDSource = function(url) {
         };
     };
 };
-LocusZoom.Data.LDSource.sourcename = "LDLZ";
+LocusZoom.Data.LDSource.SOURCE_NAME = "LDLZ";
 
 LocusZoom.Data.GeneSource = function(url) {
     this.url = url;
@@ -214,7 +214,7 @@ LocusZoom.Data.GeneSource = function(url) {
         };
     };
 };
-LocusZoom.Data.GeneSource.sourcename = "GeneLZ";
+LocusZoom.Data.GeneSource.SOURCE_NAME = "GeneLZ";
 
 LocusZoom.createResolvedPromise = function() {
     var response = Q.defer();
@@ -226,6 +226,5 @@ LocusZoom.KnownDataSources = [
     LocusZoom.Data.AssociationSource,
     LocusZoom.Data.LDSource,
     LocusZoom.Data.GeneSource];
-LocusZoom.DefaultDataSources = {};
 
 

--- a/assets/js/app/Data.js
+++ b/assets/js/app/Data.js
@@ -41,7 +41,7 @@ LocusZoom.DataSources.prototype.getSource = function(ns) {
 };
 
 LocusZoom.DataSources.prototype.setSources = function(x) {
-    if (LocusZoom.isString(x)) {
+    if (typeof x === "string") {
         x = JSON.parse(x);
     }
     var ds = this;
@@ -100,7 +100,7 @@ LocusZoom.Data.Requester = function(sources) {
 };
 
 LocusZoom.Data.AssociationSource = function(init) {
-    if (LocusZoom.isString(init)) {
+    if (typeof init === "string") {
         this.url = init;
         this.params = {};
     } else {
@@ -146,7 +146,7 @@ LocusZoom.Data.AssociationSource = function(init) {
 LocusZoom.Data.AssociationSource.SOURCE_NAME = "AssociationLZ";
 
 LocusZoom.Data.LDSource = function(init) {
-    if (LocusZoom.isString(init)) {
+    if (typeof init === "string") {
         this.url = init;
         this.params = {};
     } else {
@@ -218,7 +218,7 @@ LocusZoom.Data.LDSource = function(init) {
 LocusZoom.Data.LDSource.SOURCE_NAME = "LDLZ";
 
 LocusZoom.Data.GeneSource = function(init) {
-    if (LocusZoom.isString(init)) {
+    if (typeof init === "string") {
         this.url = init;
         this.params = {};
     } else {

--- a/assets/js/app/Data.js
+++ b/assets/js/app/Data.js
@@ -111,7 +111,6 @@ LocusZoom.Data.AssociationSource = function(init) {
         throw("AssociationSource not initialized with required URL");
     }
     
-    var that=this;
     this.getData = function(state, fields, outnames) {
         ["id","position"].forEach(function(x) {
             if (fields.indexOf(x)==-1) {
@@ -120,8 +119,8 @@ LocusZoom.Data.AssociationSource = function(init) {
             }
         });
         return function (chain) {
-            var analysis = state.analysis || chain.header.analysis || that.params.analysis || 3;
-            var requrl = that.url + "results/?filter=analysis in " + analysis  +
+            var analysis = state.analysis || chain.header.analysis || this.params.analysis || 3;
+            var requrl = this.url + "results/?filter=analysis in " + analysis  +
                 " and chromosome in  '" + state.chr + "'" + 
                 " and position ge " + state.start + 
                 " and position le " + state.end;
@@ -141,7 +140,7 @@ LocusZoom.Data.AssociationSource = function(init) {
                 var res = {header: chain.header || {}, body: records};
                 return res;
             });
-        };
+        }.bind(this);
     };
 };
 LocusZoom.Data.AssociationSource.SOURCE_NAME = "AssociationLZ";
@@ -185,7 +184,6 @@ LocusZoom.Data.LDSource = function(init) {
         }
     };
 
-    var that = this;
     this.getData = function(state, fields, outnames) {
         if (fields.length>1) {
             throw("LD currently only supports one field");
@@ -202,7 +200,7 @@ LocusZoom.Data.LDSource = function(init) {
                 }
                 refVar = chain.body[findSmallestPvalue(chain.body)].id;
             }
-            var requrl = that.url + "results/?filter=reference eq " + refSource + 
+            var requrl = this.url + "results/?filter=reference eq " + refSource + 
                 " and chromosome2 eq '" + state.chr + "'" + 
                 " and position2 ge " + state.start + 
                 " and position2 le " + state.end + 
@@ -214,7 +212,7 @@ LocusZoom.Data.LDSource = function(init) {
                 leftJoin(chain.body, x.data, outnames[0], "rsquare");
                 return chain;   
             });
-        };
+        }.bind(this);
     };
 };
 LocusZoom.Data.LDSource.SOURCE_NAME = "LDLZ";
@@ -231,10 +229,9 @@ LocusZoom.Data.GeneSource = function(init) {
         throw("GeneSource not initialized with required URL");
     }
 
-    var that = this;
     this.getData = function(state, fields, outnames) {
         return function (chain) {
-            var requrl = that.url + "?filter=source in 1" + 
+            var requrl = this.url + "?filter=source in 1" + 
                 " and chrom eq '" + state.chr + "'" + 
                 " and start le " + state.end +
                 " and end ge " + state.start;
@@ -243,7 +240,7 @@ LocusZoom.Data.GeneSource = function(init) {
             }, function(err) {
                 console.log(err);
             });
-        };
+        }.bind(this);
     };
 };
 LocusZoom.Data.GeneSource.SOURCE_NAME = "GeneLZ";

--- a/assets/js/app/Instance.js
+++ b/assets/js/app/Instance.js
@@ -13,7 +13,7 @@
 
 */
 
-LocusZoom.Instance = function(id) {
+LocusZoom.Instance = function(id, datasource, layout, state) {
 
     this.id = id;
     this.parent = LocusZoom;
@@ -24,7 +24,7 @@ LocusZoom.Instance = function(id) {
     this._panels = {};
     
     // The state property stores any instance-wide parameters subject to change via user input
-    this.state = {
+    this.state = state || {
         chr: 0,
         start: 0,
         end: 0
@@ -37,7 +37,7 @@ LocusZoom.Instance = function(id) {
     };
 
     // LocusZoom.Data.Requester
-    this.lzd = new LocusZoom.Data.Requester(LocusZoom.DefaultDataSources);
+    this.lzd = new LocusZoom.Data.Requester(datasource);
     
     return this;
   

--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -210,13 +210,5 @@
         return response.promise;
     };
 
-    exports.isString = function(x) {
-        if (typeof x === "string" || x instanceof String) {
-            return true;
-        } else {
-            return false;
-        }
-    }
-
 })(this.LocusZoom = {});
 

--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -146,5 +146,13 @@
         return response.promise;
     };
 
+    exports.isString = function(x) {
+        if (typeof x === "string" || x instanceof String) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
 })(this.LocusZoom = {});
 

--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -15,9 +15,9 @@
     // Create a new instance by instance class and attach it to a div by ID
     // NOTE: if no InstanceClass is passed then the instance will use the Intance base class.
     //       The DefaultInstance class must be passed explicitly just as any other class that extends Instance.
-    function addInstanceToDivById(id, datasource, layout, state){
+    exports.addInstanceToDivById = function(id, datasource, layout, state){
         // Initialize a new Instance
-        var inst = exports._instances[id] = new layout(id, datasource, layout, state);
+        var inst = LocusZoom._instances[id] = new layout(id, datasource, layout, state);
         // Add an SVG to the div and set its dimensions
         inst.svg = d3.select("div#" + id)
             .append("svg").attr("id", id + "_svg").attr("class", "locuszoom");
@@ -35,18 +35,18 @@
     
     // Automatically detect divs by class and populate them with default LocusZoom instances
     exports.populate = function(selector, datasource, layout, state) {
-        if (typeof selector  === "undefined"){
+        if (typeof selector === "undefined"){
             selector = ".lz-instance";
         }
-        if (typeof layout  === "undefined"){
+        if (typeof layout === "undefined"){
             layout = LocusZoom.DefaultInstance;
         }
-        if (typeof state  === "undefined"){
+        if (typeof state === "undefined"){
             state = {};
         }
         var instance;
         d3.select(selector).each(function(){
-            instance = addInstanceToDivById(this.id, datasource, layout, state);
+            instance = LocusZoom.addInstanceToDivById(this.id, datasource, layout, state);
         });
         return instance;
     };
@@ -54,7 +54,7 @@
     exports.populateAll = function(selector, datasource, layout, state) {
         var instances = [];
         d3.selectAll(selector).each(function(d,i) {
-            instances[i] = exports.populate(this, datasource, layout, state);
+            instances[i] = LocusZoom.populate(this, datasource, layout, state);
         });
         return instances;
     };

--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -15,9 +15,9 @@
     // Create a new instance by instance class and attach it to a div by ID
     // NOTE: if no InstanceClass is passed then the instance will use the Intance base class.
     //       The DefaultInstance class must be passed explicitly just as any other class that extends Instance.
-    function addInstanceToDivById(InstanceClass, id){
+    function addInstanceToDivById(id, datasource, layout, state){
         // Initialize a new Instance
-        var inst = exports._instances[id] = new InstanceClass(id);
+        var inst = exports._instances[id] = new layout(id, datasource, layout, state);
         // Add an SVG to the div and set its dimensions
         inst.svg = d3.select("div#" + id)
             .append("svg").attr("id", id + "_svg").attr("class", "locuszoom");
@@ -34,27 +34,27 @@
     }
     
     // Automatically detect divs by class and populate them with default LocusZoom instances
-    exports.populate = function(selector, datasource, plotdef, state) {
+    exports.populate = function(selector, datasource, layout, state) {
         if (typeof selector  === "undefined"){
             selector = ".lz-instance";
         }
-        if (typeof plotdef  === "undefined"){
-            plotdef = LocusZoom.DefaultInstance;
+        if (typeof layout  === "undefined"){
+            layout = LocusZoom.DefaultInstance;
         }
         if (typeof state  === "undefined"){
             state = {};
         }
         var instance;
         d3.select(selector).each(function(){
-            instance = addInstanceToDivById(plotdef, this.id);
+            instance = addInstanceToDivById(this.id, datasource, layout, state);
         });
         return instance;
     };
 
-    exports.populateAll = function(selector, datasource, plotdef, state) {
+    exports.populateAll = function(selector, datasource, layout, state) {
         var instances = [];
         d3.selectAll(selector).each(function(d,i) {
-            instances[i] = exports.populate(this, datasource, plotdef, state);
+            instances[i] = exports.populate(this, datasource, layout, state);
         });
         return instances;
     };
@@ -86,6 +86,11 @@
         return val;
     }
 
+    // Parse region queries that look like
+    // chr:start-top
+    // chr:center+offset
+    // chr:pos
+    // TODO: handle genes (or send off to API)
     exports.parsePositionQuery = function(x) {
         var chrposoff = /^(\w+):([\d,.]+[kmgbKMGB]*)([-+])([\d,.]+[kmgbKMGB]*)$/;
         var chrpos = /^(\w+):([\d,.]+[kmgbKMGB]*)$/;

--- a/demo.html
+++ b/demo.html
@@ -13,15 +13,9 @@
   <script type="text/javascript">
     var apiBase = "http://portaldev.sph.umich.edu/api_internal_dev/v1/";
     var ds = new LocusZoom.DataSources();
-	ds.addSource("position", new LocusZoom.Data.AssociationSource(apiBase + "single/"));
+	ds.addSource("base", new LocusZoom.Data.AssociationSource(apiBase + "single/"));
 	ds.addSource("ld", new LocusZoom.Data.LDSource(apiBase + "pair/LD/"));
-	ds.addSource("gene", new LocusZoom.Data.GeneSource(apiBase + "annotation/genes"));
-
-    LocusZoom.DefaultDataSources = {
-        position: new LocusZoom.Data.AssociationSource("http://portaldev.sph.umich.edu/api_internal_dev/v1/single/"),
-        ld: new LocusZoom.Data.LDSource("http://portaldev.sph.umich.edu/api_internal_dev/v1/pair/LD/"),
-        gene: new LocusZoom.Data.GeneSource("http://portaldev.sph.umich.edu/api_internal_dev/v1/annotation/genes/")
-    };
+	ds.addSource("gene", new LocusZoom.Data.GeneSource(apiBase + "annotation/genes/"));
 
     var topHits = [
 	["16:53819169", "FTO"],
@@ -105,7 +99,7 @@
 
 	function initPage() {
 		listHits();
-		LocusZoom.populate();
+		LocusZoom.populateAll(".lz-instance", ds);
 		populateForms();
 		$("#lz-1_hits").html(topHits.map(function(k) {return "<option>" + k + "</option>"}).join(""));
 	};

--- a/demo.html
+++ b/demo.html
@@ -13,9 +13,9 @@
   <script type="text/javascript">
     var apiBase = "http://portaldev.sph.umich.edu/api_internal_dev/v1/";
     var ds = new LocusZoom.DataSources();
-	ds.addSource("base", new LocusZoom.Data.AssociationSource(apiBase + "single/"));
-	ds.addSource("ld", new LocusZoom.Data.LDSource(apiBase + "pair/LD/"));
-	ds.addSource("gene", new LocusZoom.Data.GeneSource(apiBase + "annotation/genes/"));
+	ds.addSource("base", ["AssociationLZ", {url:apiBase + "single/", params: {analysis: 3}}]);
+	ds.addSource("ld", ["LDLZ" ,apiBase + "pair/LD/"]);
+	ds.addSource("gene", ["GeneLZ", apiBase + "annotation/genes/"]);
 
     var topHits = [
 	["16:53819169", "FTO"],

--- a/demo.html
+++ b/demo.html
@@ -11,6 +11,12 @@
   <link rel="stylesheet" type="text/css" href="assets/css/locuszoom.css"/>
 
   <script type="text/javascript">
+    var apiBase = "http://portaldev.sph.umich.edu/api_internal_dev/v1/";
+    var ds = new LocusZoom.DataSources();
+	ds.addSource("position", new LocusZoom.Data.AssociationSource(apiBase + "single/"));
+	ds.addSource("ld", new LocusZoom.Data.LDSource(apiBase + "pair/LD/"));
+	ds.addSource("gene", new LocusZoom.Data.GeneSource(apiBase + "annotation/genes"));
+
     LocusZoom.DefaultDataSources = {
         position: new LocusZoom.Data.AssociationSource("http://portaldev.sph.umich.edu/api_internal_dev/v1/single/"),
         ld: new LocusZoom.Data.LDSource("http://portaldev.sph.umich.edu/api_internal_dev/v1/pair/LD/"),

--- a/test/Data.js
+++ b/test/Data.js
@@ -31,9 +31,9 @@ describe('LocusZoom Data', function(){
 
         var TestSource1, TestSource2;
         beforeEach(function() {
-            TestSource1 = function() {};
+            TestSource1 = function(x) {this.init = x};
             TestSource1.SOURCE_NAME = "test1";
-            TestSource2 = function() {};
+            TestSource2 = function(x) {this.init = x};
             TestSource2.SOURCE_NAME = "test2";
             LocusZoom.KnownDataSources = [TestSource1, TestSource2];
         })
@@ -79,6 +79,17 @@ describe('LocusZoom Data', function(){
             ds.keys().should.have.length(2);
             should.exist(ds.getSource("t1"));
             should.exist(ds.getSource("t2"));
+        });
+        it('should pass in initiization values as object', function() {
+            var ds = new LocusZoom.DataSources();
+            ds.setSources({"t1": ["test1", {a:10}], "t2": ["test2", {b:20}]});
+            ds.keys().should.have.length(2);
+            should.exist(ds.getSource("t1").init);
+            should.exist(ds.getSource("t1").init.a);
+            ds.getSource("t1").init.a.should.equal(10);
+            should.exist(ds.getSource("t2").init);
+            should.exist(ds.getSource("t2").init.b);
+            ds.getSource("t2").init.b.should.equal(20);
         });
     });
 });

--- a/test/Data.js
+++ b/test/Data.js
@@ -32,9 +32,9 @@ describe('LocusZoom Data', function(){
         var TestSource1, TestSource2;
         beforeEach(function() {
             TestSource1 = function() {};
-            TestSource1.sourcename = "test1";
+            TestSource1.SOURCE_NAME = "test1";
             TestSource2 = function() {};
-            TestSource2.sourcename = "test2";
+            TestSource2.SOURCE_NAME = "test2";
             LocusZoom.KnownDataSources = [TestSource1, TestSource2];
         })
 

--- a/test/Data.js
+++ b/test/Data.js
@@ -1,0 +1,86 @@
+"use strict";
+
+/**
+  LocusZoom.js Data Test Suite
+  Test LocusZoom Data access objects
+*/
+
+// General Requirements
+var requirejs = require("requirejs");
+var assert = require('assert');
+var should = require("should");
+
+// Load all vendor dependencies and app files before running tests. Order is important!
+beforeEach(function(done){
+    var modules = [
+        './assets/js/vendor/d3.min.js',
+        './assets/js/vendor/q.min.js',
+        './assets/js/app/LocusZoom.js',
+        './assets/js/app/Data.js',
+        './assets/js/app/Instance.js',
+        './assets/js/app/Panel.js',
+        './assets/js/app/DataLayer.js'
+    ];
+    requirejs(modules, function(){
+        done();
+    });
+});
+
+describe('LocusZoom Data', function(){
+    describe("LocusZoom Data Source", function() {
+
+        var TestSource1, TestSource2;
+        beforeEach(function() {
+            TestSource1 = function() {};
+            TestSource1.sourcename = "test1";
+            TestSource2 = function() {};
+            TestSource2.sourcename = "test2";
+            LocusZoom.KnownDataSources = [TestSource1, TestSource2];
+        })
+
+        it('should have a DataSources object', function(){
+            LocusZoom.DataSources.should.be.a.Function();
+        });
+        it('should add source via .addSource - object', function(){
+            var ds = new LocusZoom.DataSources();
+            ds.addSource("t1", new TestSource1());
+            ds.keys().should.have.length(1);
+            should.exist(ds.getSource("t1"));
+        });
+        it("should add source via .addSource - array", function() {
+            var ds = new LocusZoom.DataSources();
+            ds.addSource("t1", ["test1"]);
+            ds.keys().should.have.length(1);
+            should.exist(ds.getSource("t1"));
+        });
+        it('should allow chainable adding', function() {
+            var ds = new LocusZoom.DataSources();
+            ds.addSource("t1", new TestSource1()).addSource("t2", new TestSource1());
+            ds.keys().should.have.length(2);
+        })
+        it('should add sources via setSources() - object', function() {
+            var ds = new LocusZoom.DataSources();
+            ds.setSources({t1:  new TestSource1(), t2:  new TestSource2()});
+            ds.keys().should.have.length(2);
+            should.exist(ds.getSource("t1"));
+            should.exist(ds.getSource("t2"));
+        });
+
+        it('should add sources via setSources() - array', function() {
+            var ds = new LocusZoom.DataSources();
+            ds.setSources({t1: ["test1"], t2: ["test2"]});
+            ds.keys().should.have.length(2);
+            should.exist(ds.getSource("t1"));
+            should.exist(ds.getSource("t2"));
+        });
+        it('should add sources via setSources() - string (JSON)', function() {
+            var ds = new LocusZoom.DataSources();
+            ds.setSources('{"t1": ["test1"], "t2": ["test2"]}');
+            ds.keys().should.have.length(2);
+            should.exist(ds.getSource("t1"));
+            should.exist(ds.getSource("t2"));
+        });
+    });
+});
+
+

--- a/test/LocusZoom.js
+++ b/test/LocusZoom.js
@@ -49,20 +49,20 @@ describe('LocusZoom', function(){
             assert.equal(LocusZoom.formatMegabase(23423456),   "23.42");
             assert.equal(LocusZoom.formatMegabase(1896335235), "1896.34");
         });
-        it('should have a method for adding instances to a div by ID', function(){
-            LocusZoom.addInstanceToDivById.should.be.a.Function();
-            LocusZoom.addInstanceToDivById(LocusZoom.DefaultInstance, "instance_id");
-            LocusZoom._instances["instance_id"].should.be.an.Object();
-            LocusZoom._instances["instance_id"].id.should.be.exactly("instance_id");
-            var svg_selector = d3.select('div#instance_id svg');
-            svg_selector.should.be.an.Object();
-            svg_selector.size().should.be.exactly(1);
-            LocusZoom._instances["instance_id"].svg.should.be.an.Object();
-            assert.equal(LocusZoom._instances["instance_id"].svg[0][0], svg_selector[0][0]);
-        });
+        //it('should have a method for adding instances to a div by ID', function(){
+        //    LocusZoom.addInstanceToDivById.should.be.a.Function();
+        //    LocusZoom.addInstanceToDivById(LocusZoom.DefaultInstance, "instance_id");
+        //    LocusZoom._instances["instance_id"].should.be.an.Object();
+        //    LocusZoom._instances["instance_id"].id.should.be.exactly("instance_id");
+        //    var svg_selector = d3.select('div#instance_id svg');
+        //    svg_selector.should.be.an.Object();
+        //    svg_selector.size().should.be.exactly(1);
+        //    LocusZoom._instances["instance_id"].svg.should.be.an.Object();
+        //    assert.equal(LocusZoom._instances["instance_id"].svg[0][0], svg_selector[0][0]);
+        //});
         it('should have a method for populating divs with instances by class name', function(){
             LocusZoom.populate.should.be.a.Function();
-            LocusZoom.populate("lz");
+            LocusZoom.populateAll("div.lz");
             d3.select('div.lz').each(function(){
                 var div_selector = d3.select(this);
                 var svg_selector = div_selector.select("svg");

--- a/test/LocusZoom.js
+++ b/test/LocusZoom.js
@@ -59,7 +59,7 @@ describe('LocusZoom', function(){
         });
         it('should have a method for adding instances to a div by ID', function(){
             LocusZoom.addInstanceToDivById.should.be.a.Function();
-            LocusZoom.addInstanceToDivById(LocusZoom.DefaultInstance, "instance_id");
+            LocusZoom.addInstanceToDivById("instance_id", {}, LocusZoom.DefaultInstance);
             LocusZoom._instances["instance_id"].should.be.an.Object();
             LocusZoom._instances["instance_id"].id.should.be.exactly("instance_id");
             var svg_selector = d3.select('div#instance_id svg');

--- a/test/LocusZoom.js
+++ b/test/LocusZoom.js
@@ -72,6 +72,34 @@ describe('LocusZoom', function(){
                 assert.equal(LocusZoom._instances[div_selector.attr("id")].svg[0][0], svg_selector[0][0]);
             });
         });
+        describe("Position Queries", function() {
+            it('should have a parsePositionQuery function', function() {
+                LocusZoom.parsePositionQuery.should.be.a.Function();
+            });
+            it("should parse chr:start-end", function() {
+                var test = LocusZoom.parsePositionQuery("10:45000-65000");
+                test.should.have.property("chr","10");
+                test.should.have.property("start",45000);
+                test.should.have.property("end",65000);
+            });
+            it("should parse chr:start+end", function() {
+                var test = LocusZoom.parsePositionQuery("10:45000+5000");
+                test.should.have.property("chr","10");
+                test.should.have.property("start",40000);
+                test.should.have.property("end",50000);
+            });
+            it("should parse kb/mb units", function() {
+                var test = LocusZoom.parsePositionQuery("10:5.5Mb+2k");
+                test.should.have.property("chr","10");
+                test.should.have.property("start",5.5e6-2e3);
+                test.should.have.property("end",5.5e6+2e3);
+            });
+            it("should prase chr:pos", function() {
+                var test = LocusZoom.parsePositionQuery("2:5500");
+                test.should.have.property("chr","2");
+                test.should.have.property("position",5500);
+            });
+        });
         it('should have a method for creating a CORS promise', function(){
             LocusZoom.createCORSPromise.should.be.a.Function();
         });


### PR DESCRIPTION
These changes update the interaction for specifying API data endpoints that are consumed by the data. This introduces a new LocusZoom.DataSources() object that allows for adding namespace/datasource pairs either though chainable .addSource() calls, or through an object literal syntax via .setSource() or via a JSON string.

This also updates the initialization methods populate() and populateAll(). These should be the primary means of create LZ objects. They have more broad support for D3 selectors and have separate paramters for data sources, plot layout, and initial state (though the later two are not yet implemented).