### PR TITLE
Unique Panel IDs

### DIFF
--- a/assets/js/app/Instance.js
+++ b/assets/js/app/Instance.js
@@ -68,12 +68,27 @@ LocusZoom.Instance.prototype.setDimensions = function(width, height){
 };
 
 // Create a new panel by panel class
-LocusZoom.Instance.prototype.addPanel = function(PanelClass){
+// Optionally take an id string (use base ID on panel class if not provided)
+// Ensure panel has a unique ID as it is added.
+LocusZoom.Instance.prototype.addPanel = function(PanelClass, id){
     if (typeof PanelClass !== "function"){
-        return false;
+        throw "Invalid PanelClass passed to LocusZoom.Instance.prototype.addPanel()";
     }
     var panel = new PanelClass();
     panel.parent = this;
+    if (typeof id !== "string"){
+        panel.id = panel.base_id;
+    } else {
+        panel.base_id = id;
+        panel.id = id;
+    }
+    if (typeof this._panels[panel.id] == "object"){
+        var inc = 0;
+        while (typeof this._panels[panel.base_id + "_" + inc] == "object"){
+            inc++;
+        }
+        panel.id = panel.base_id + "_" + inc;
+    }
     this._panels[panel.id] = panel;
     this.stackPanels();
     return this._panels[panel.id];

--- a/assets/js/app/Panel.js
+++ b/assets/js/app/Panel.js
@@ -328,7 +328,7 @@ LocusZoom.PositionsPanel = function(){
   
     LocusZoom.Panel.apply(this, arguments);   
 
-    this.id = "positions";
+    this.base_id = "positions";
     this.view.min_width = 300;
     this.view.min_height = 200;
 
@@ -362,7 +362,7 @@ LocusZoom.GenesPanel = function(){
     
     LocusZoom.Panel.apply(this, arguments);
 
-    this.id = "genes";
+    this.base_id = "genes";
     this.view.min_width = 300;
     this.view.min_height = 200;
 

--- a/test/Instance.js
+++ b/test/Instance.js
@@ -70,6 +70,16 @@ describe('LocusZoom.Instance', function(){
             this.instance._panels.should.have.property(panel.id).which.is.exactly(panel);
             this.instance._panels[panel.id].should.have.property("parent").which.is.exactly(this.instance);
         });
+        it('should allow for adding panels with arbitrary ids', function(){
+            var panel = this.instance.addPanel(LocusZoom.PositionsPanel, "foo");
+            this.instance._panels.should.have.property("foo").which.is.exactly(panel);
+        });
+        it('should allow for adding arbitrarily many panels of the same type', function(){
+            this.instance.addPanel(LocusZoom.PositionsPanel);
+            this.instance.addPanel(LocusZoom.PositionsPanel);
+            this.instance.addPanel(LocusZoom.PositionsPanel);
+            Object.keys(this.instance._panels).should.have.length(3);
+        });
         it('should enforce minimum dimensions based on its panels', function(){
             var positions_panel = this.instance.addPanel(LocusZoom.PositionsPanel);
             var genes_panel = this.instance.addPanel(LocusZoom.GenesPanel);


### PR DESCRIPTION
Right now panel classes define an ID (e.g. `positions` or `genes`), and since panels are added to an instance using the id as a key-based index it's impossible to add two panels of the same class to an instance.

This branch addresses this problem by doing the following:

* Let `Instance.addPanel()` optionally take a second argument which is an ID string (to allow devs to specify their own IDs).
* Panel class definitions no longer impose an ID but a "base ID" (same value as before) that can be used in generating a meaningful unique ID but is not, itself, an ID.
* `Instance.addPanel()` logic takes either the supplied ID string or the base ID on the panel class as a starting point, and if a panel with the same ID already exists adds an incrementing integer to the end of the ID until a unique ID is found.

So, for example, doing something like this:

```javascript
instance.addPanel(LocusZoom.PositionsPanel);
instance.addPanel(LocusZoom.PositionsPanel);
instance.addPanel(LocusZoom.PositionsPanel);
```

Used to fail silently (each added panel would overwrite the previous, all with an ID of `positions`). With this branch you'll now end up with three positions panels and the `_panels` object will look like this:

```
instance {
  ...
  _panels {
    positions:   [ Object ],
    positions_0: [ Object ],
    positions_1: [ Object ]
  }
  ...
}
```

Due to how previously defined panel class IDs have evolved into the newly defined panel base IDs, all previous implementations of LocusZoom that used no more than one panel of any panel class will not show any changed behavior, including the same panel IDs that have always been there persisting.