### PR TITLE
Responsive Resizing

### DIFF
--- a/assets/css/locuszoom.scss
+++ b/assets/css/locuszoom.scss
@@ -105,3 +105,9 @@ $namespace: "lz";
   }
 
 }
+
+.#{$namespace}-container-responsive {
+  width: 100%;
+  display: inline-block;
+  overflow: hidden;
+}

--- a/assets/css/locuszoom.scss
+++ b/assets/css/locuszoom.scss
@@ -106,6 +106,11 @@ $namespace: "lz";
 
 }
 
+.#{$namespace}-container {
+  display: inline-block;
+  overflow: hidden;
+}
+
 .#{$namespace}-container-responsive {
   width: 100%;
   display: inline-block;

--- a/assets/js/app/Instance.js
+++ b/assets/js/app/Instance.js
@@ -77,10 +77,10 @@ LocusZoom.Instance.prototype.setDimensions = function(width, height){
     // Set the layout height to a discrete value, by passed argument or responsive logic using the aspect ratio
     if (!isNaN(height) && height >= 0){
         this.layout.height = Math.max(Math.round(+height), this.layout.min_height);
-    } else if (this.svg && this.layout.resizable == "responsive"){
+    } else if (this.layout.resizable == "responsive"){
         this.layout.height = this.layout.width / this.layout.aspect_ratio;
     }
-    // Keep aspect ratio in agreement with width and height
+    // Keep aspect ratio and dimensions in agreement
     this.layout.aspect_ratio = this.layout.width / this.layout.height;
     // Apply layout width and height as discrete values or viewbox values
     if (this.svg != null){

--- a/assets/js/app/Instance.js
+++ b/assets/js/app/Instance.js
@@ -68,19 +68,21 @@ LocusZoom.Instance.prototype.initializeLayout = function(){
 // Set the layout dimensions for this instance. If an SVG exists, update its dimensions.
 // If any arguments are missing, use values stored in the layout. Keep everything in agreement.
 LocusZoom.Instance.prototype.setDimensions = function(width, height){
-    // Set the layout width to a discrete value, by passed argument or responsive logic
+    // Set discrete layout dimensions based on arguments
     if (!isNaN(width) && width >= 0){
         this.layout.width = Math.max(Math.round(+width), this.layout.min_width);
-    } else if (this.svg && this.layout.resizable == "responsive"){
-        this.layout.width = this.svg.node().parentNode.getBoundingClientRect().width;
     }
-    // Set the layout height to a discrete value, by passed argument or responsive logic using the aspect ratio
     if (!isNaN(height) && height >= 0){
         this.layout.height = Math.max(Math.round(+height), this.layout.min_height);
-    } else if (this.layout.resizable == "responsive"){
+    }
+    // Override discrete values if resizing responsively
+    if (this.layout.resizable == "responsive"){
+        if (this.svg){
+            this.layout.width = this.svg.node().parentNode.getBoundingClientRect().width;
+        }
         this.layout.height = this.layout.width / this.layout.aspect_ratio;
     }
-    // Keep aspect ratio and dimensions in agreement
+    // Keep aspect ratio in agreement with dimensions
     this.layout.aspect_ratio = this.layout.width / this.layout.height;
     // Apply layout width and height as discrete values or viewbox values
     if (this.svg != null){

--- a/assets/js/app/Instance.js
+++ b/assets/js/app/Instance.js
@@ -46,6 +46,18 @@ LocusZoom.Instance = function(id, datasource, layout, state) {
 
 LocusZoom.Instance.prototype.initializeLayout = function(){
 
+    // Sanity check layout values
+    // TODO: Find a way to generally abstract this, maybe into an object that models allowed layout values?
+    if (isNaN(this.layout.width) || this.layout.width <= 0){
+        throw ("Instance layout parameter `width` must be a positive number");
+    }
+    if (isNaN(this.layout.height) || this.layout.height <= 0){
+        throw ("Instance layout parameter `width` must be a positive number");
+    }
+    if (isNaN(this.layout.aspect_ratio) || this.layout.aspect_ratio <= 0){
+        throw ("Instance layout parameter `aspect_ratio` must be a positive number");
+    }
+
     // If this is a responsive layout then set a namespaced/unique onresize event listener on the window
     if (this.layout.resizable == "responsive"){
         this.window_onresize = d3.select(window).on("resize.lz-"+this.id, function(){
@@ -78,9 +90,13 @@ LocusZoom.Instance.prototype.setDimensions = function(width, height){
     // Override discrete values if resizing responsively
     if (this.layout.resizable == "responsive"){
         if (this.svg){
-            this.layout.width = this.svg.node().parentNode.getBoundingClientRect().width;
+            this.layout.width = Math.max(this.svg.node().parentNode.getBoundingClientRect().width, this.layout.min_width);
         }
         this.layout.height = this.layout.width / this.layout.aspect_ratio;
+        if (this.layout.height < this.layout.min_height){
+            this.layout.height = this.layout.min_height;
+            this.layout.width  = this.layout.height * this.layout.aspect_ratio;
+        }
     }
     // Keep aspect ratio in agreement with dimensions
     this.layout.aspect_ratio = this.layout.width / this.layout.height;

--- a/assets/js/app/Instance.js
+++ b/assets/js/app/Instance.js
@@ -162,31 +162,35 @@ LocusZoom.Instance.prototype.initialize = function(){
         },
         initialize: function(){
             // Resize handle
-            this.resize_handle = this.svg.append("g")
-                .attr("id", this.parent.id + ".ui.resize_handle");
-            this.resize_handle.append("path")
-                .attr("class", "lz-ui-resize_handle")
-                .attr("d", "M 0,16, L 16,0, L 16,16 Z");
-            var resize_drag = d3.behavior.drag();
-            //resize_drag.origin(function() { return this; });
-            resize_drag.on("dragstart", function(){
-                this.resize_handle.select("path").attr("class", "lz-ui-resize_handle_dragging");
-                this.is_resize_dragging = true;
-            }.bind(this));
-            resize_drag.on("dragend", function(){
-                this.resize_handle.select("path").attr("class", "lz-ui-resize_handle");
-                this.is_resize_dragging = false;
-            }.bind(this));
-            resize_drag.on("drag", function(){
-                this.setDimensions(this.layout.width + d3.event.dx, this.layout.height + d3.event.dy);
-            }.bind(this.parent));
-            this.resize_handle.call(resize_drag);
+            if (this.parent.layout.resizable == "manual"){
+                this.resize_handle = this.svg.append("g")
+                    .attr("id", this.parent.id + ".ui.resize_handle");
+                this.resize_handle.append("path")
+                    .attr("class", "lz-ui-resize_handle")
+                    .attr("d", "M 0,16, L 16,0, L 16,16 Z");
+                var resize_drag = d3.behavior.drag();
+                //resize_drag.origin(function() { return this; });
+                resize_drag.on("dragstart", function(){
+                    this.resize_handle.select("path").attr("class", "lz-ui-resize_handle_dragging");
+                    this.is_resize_dragging = true;
+                }.bind(this));
+                resize_drag.on("dragend", function(){
+                    this.resize_handle.select("path").attr("class", "lz-ui-resize_handle");
+                    this.is_resize_dragging = false;
+                }.bind(this));
+                resize_drag.on("drag", function(){
+                    this.setDimensions(this.layout.width + d3.event.dx, this.layout.height + d3.event.dy);
+                }.bind(this.parent));
+                this.resize_handle.call(resize_drag);
+            }
             // Render all UI elements
             this.render();
         },
         render: function(){
-            this.resize_handle
-                .attr("transform", "translate(" + (this.parent.layout.width - 17) + ", " + (this.parent.layout.height - 17) + ")");
+            if (this.parent.layout.resizable == "manual"){
+                this.resize_handle
+                    .attr("transform", "translate(" + (this.parent.layout.width - 17) + ", " + (this.parent.layout.height - 17) + ")");
+            }
         }
     };
     this.ui.initialize();

--- a/assets/js/app/Instance.js
+++ b/assets/js/app/Instance.js
@@ -80,6 +80,8 @@ LocusZoom.Instance.prototype.setDimensions = function(width, height){
     } else if (this.svg && this.layout.resizable == "responsive"){
         this.layout.height = this.layout.width / this.layout.aspect_ratio;
     }
+    // Keep aspect ratio in agreement with width and height
+    this.layout.aspect_ratio = this.layout.width / this.layout.height;
     // Apply layout width and height as discrete values or viewbox values
     if (this.svg != null){
         if (this.layout.resizable == "responsive"){

--- a/assets/js/app/Instance.js
+++ b/assets/js/app/Instance.js
@@ -34,6 +34,9 @@ LocusZoom.Instance = function(id, datasource, layout, state) {
     // LocusZoom.Data.Requester
     this.lzd = new LocusZoom.Data.Requester(datasource);
 
+    // Window.onresize listener (responsive layouts only)
+    this.window_onresize = null;
+
     // Initialize the layout
     this.initializeLayout();
 
@@ -42,6 +45,14 @@ LocusZoom.Instance = function(id, datasource, layout, state) {
 };
 
 LocusZoom.Instance.prototype.initializeLayout = function(){
+
+    // If this is a responsive layout then set a namespaced/unique onresize event listener on the window
+    if (this.layout.resizable == "responsive"){
+        this.window_onresize = d3.select(window).on("resize.lz-"+this.id, function(){
+            var clientRect = this.svg.node().parentNode.getBoundingClientRect();
+            this.setDimensions(clientRect.width, clientRect.height);
+        }.bind(this));
+    }
 
     // Set instance dimensions
     this.setDimensions();
@@ -57,18 +68,33 @@ LocusZoom.Instance.prototype.initializeLayout = function(){
 // Set the layout dimensions for this instance. If an SVG exists, update its dimensions.
 // If any arguments are missing, use values stored in the layout. Keep everything in agreement.
 LocusZoom.Instance.prototype.setDimensions = function(width, height){
+    // Set the layout width to a discrete value, by passed argument or responsive logic
     if (!isNaN(width) && width >= 0){
         this.layout.width = Math.max(Math.round(+width), this.layout.min_width);
+    } else if (this.svg && this.layout.resizable == "responsive"){
+        this.layout.width = this.svg.node().parentNode.getBoundingClientRect().width;
     }
+    // Set the layout height to a discrete value, by passed argument or responsive logic using the aspect ratio
     if (!isNaN(height) && height >= 0){
         this.layout.height = Math.max(Math.round(+height), this.layout.min_height);
+    } else if (this.svg && this.layout.resizable == "responsive"){
+        this.layout.height = this.layout.width / this.layout.aspect_ratio;
     }
+    // Apply layout width and height as discrete values or viewbox values
     if (this.svg != null){
-        this.svg.attr("width", this.layout.width).attr("height", this.layout.height);
+        if (this.layout.resizable == "responsive"){
+            this.svg
+                .attr("viewBox", "0 0 " + this.layout.width + " " + this.layout.height)
+                .attr("preserveAspectRatio", "xMinYMin meet");
+        } else {
+            this.svg.attr("width", this.layout.width).attr("height", this.layout.height);
+        }
     }
+    // Reposition all panels
+    this.positionPanels();
+    // If the instance has been initialized then trigger some necessary render functions
     if (this.initialized){
         this.ui.render();
-        this.stackPanels();
     }
     return this;
 };
@@ -87,47 +113,39 @@ LocusZoom.Instance.prototype.addPanel = function(id, layout){
     var panel = new LocusZoom.Panel(id, layout);
     panel.parent = this;
     this.panels[panel.id] = panel;
-    this.stackPanels();
-    return this.panels[panel.id];
-};
 
-// Automatically position panels based on panel positioning rules and values
-// Default behavior: position panels vertically with equally proportioned heights
-// In all cases: bubble minimum panel dimensions up from panels to enforce minimum instance dimensions
-LocusZoom.Instance.prototype.stackPanels = function(){
-
-    var id;
-
-    // First set/enforce minimum instance dimensions based on current panels
+    // Update minimum instance dimensions based on the minimum dimensions of all panels
+    // TODO: This logic assumes panels are always stacked vertically. More sophisticated
+    //       logic to handle arbitrary panel geometries needs to be supported.
     var panel_min_widths = [];
     var panel_min_heights = [];
     for (id in this.panels){
         panel_min_widths.push(this.panels[id].layout.min_width);
         panel_min_heights.push(this.panels[id].layout.min_height);
     }
-    if (panel_min_widths.length){
-        this.layout.min_width = Math.max.apply(null, panel_min_widths);
-    }
-    if (panel_min_heights.length){
-        this.layout.min_height = panel_min_heights.reduce(function(a,b){ return a+b; });
-    }
-    if (this.layout.width < this.layout.min_width || this.layout.height < this.layout.min_height){
-        this.setDimensions(Math.max(this.layout.width, this.layout.min_width),
-                           Math.max(this.layout.height, this.layout.min_height));
-        return;
-    }
+    this.layout.min_width = Math.max.apply(null, panel_min_widths);
+    this.layout.min_height = panel_min_heights.reduce(function(a,b){ return a+b; });
 
-    // Next set proportional and discrete heights of panels
-    var proportional_height = 1 / Object.keys(this.panels).length;
-    var discrete_height = this.layout.height * proportional_height;
-    var panel_idx = 0;
+    // Call setDimensions() in case updated minimums need to be applied, which also calls positionPanels()
+    this.setDimensions();
+
+    return this.panels[panel.id];
+};
+
+// Automatically position panels based on panel positioning rules and values
+// If the plot is resizable then recalculate dimensions and position from proportional values
+LocusZoom.Instance.prototype.positionPanels = function(){
+    var id;
     for (id in this.panels){
-        this.panels[id].layout.proportional_height = proportional_height;
-        this.panels[id].setOrigin(0, panel_idx * discrete_height);
-        this.panels[id].setDimensions(this.layout.width, discrete_height);
-        panel_idx++;
+        if (this.layout.resizable){
+            this.panels[id].layout.width = this.panels[id].layout.proportional_width * this.layout.width;
+            this.panels[id].layout.height = this.panels[id].layout.proportional_height * this.layout.height;
+            this.panels[id].layout.origin.x = this.panels[id].layout.proportional_origin.x * this.layout.width;
+            this.panels[id].layout.origin.y = this.panels[id].layout.proportional_origin.y * this.layout.height;
+        }
+        this.panels[id].setOrigin();
+        this.panels[id].setDimensions();
     }
-
 };
 
 // Create all instance-level objects, initialize all child panels

--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -3,7 +3,7 @@
 /* eslint-disable no-console */
 
 var LocusZoom = {
-    version: "0.3.2"
+    version: "0.3.3"
 };
 
 // Create a new instance by instance class and attach it to a div by ID

--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -257,15 +257,17 @@ LocusZoom.DefaultLayout = {
     min_width: 300,
     min_height: 400,
     resizable: "manual",
+    aspect_ratio: 1,
     panels: {
         positions: {
-            origin: { x: 0, y: 0 },
             width:      700,
             height:     350,
+            origin: { x: 0, y: 0 },
             min_width:  300,
             min_height: 200,
             proportional_width: 1,
             proportional_height: 0.5,
+            proportional_origin: { x: 0, y: 0 },
             margin: { top: 20, right: 20, bottom: 35, left: 50 },
             axes: {
                 x: {
@@ -304,13 +306,14 @@ LocusZoom.DefaultLayout = {
             }
         },
         genes: {
-            origin: { x: 0, y: 350 },
             width:      700,
             height:     350,
+            origin: { x: 0, y: 350 },
             min_width:  300,
             min_height: 200,
             proportional_width: 1,
             proportional_height: 0.5,
+            proportional_origin: { x: 0, y: 0.5 },
             margin: { top: 20, right: 20, bottom: 20, left: 50 },
             data_layers: {
                 genes: {

--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -252,19 +252,19 @@ LocusZoom.DefaultState = {
 
 // Default Layout
 LocusZoom.DefaultLayout = {
-    width: 700,
-    height: 700,
-    min_width: 300,
-    min_height: 400,
-    resizable: "manual",
-    aspect_ratio: 1,
+    width: 800,
+    height: 450,
+    min_width: 400,
+    min_height: 225,
+    resizable: "responsive",
+    aspect_ratio: (16/9),
     panels: {
         positions: {
-            width:      700,
-            height:     350,
+            width: 800,
+            height: 225,
             origin: { x: 0, y: 0 },
-            min_width:  300,
-            min_height: 200,
+            min_width:  400,
+            min_height: 112.5,
             proportional_width: 1,
             proportional_height: 0.5,
             proportional_origin: { x: 0, y: 0 },
@@ -306,11 +306,11 @@ LocusZoom.DefaultLayout = {
             }
         },
         genes: {
-            width:      700,
-            height:     350,
+            width: 800,
+            height: 225,
             origin: { x: 0, y: 350 },
-            min_width:  300,
-            min_height: 200,
+            min_width: 400,
+            min_height: 112.5,
             proportional_width: 1,
             proportional_height: 0.5,
             proportional_origin: { x: 0, y: 0.5 },

--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -3,7 +3,7 @@
 /* eslint-disable no-console */
 
 var LocusZoom = {
-    version: "0.3.1"
+    version: "0.3.2"
 };
 
 // Create a new instance by instance class and attach it to a div by ID
@@ -261,6 +261,7 @@ LocusZoom.DefaultLayout = {
     height: 700,
     min_width: 300,
     min_height: 400,
+    resizable: "manual",
     panels: {
         positions: {
             origin: { x: 0, y: 0 },

--- a/assets/js/app/Panel.js
+++ b/assets/js/app/Panel.js
@@ -45,11 +45,12 @@ LocusZoom.Panel = function(id, layout) {
 LocusZoom.Panel.DefaultLayout = {
     width:  0,
     height: 0,
+    origin: { x: 0, y: 0 },
     min_width: 0,
     min_height: 0,
     proportional_width: 1,
     proportional_height: 1,
-    origin: { x: 0, y: 0 },
+    proportional_origin: { x: 0, y: 0 },
     margin: { top: 0, right: 0, bottom: 0, left: 0 },
     cliparea: {
         height: 0,

--- a/demo.html
+++ b/demo.html
@@ -6,19 +6,52 @@
 
   <script src="https://code.jquery.com/jquery-2.1.4.min.js" type="text/javascript"></script>
 
+  <!-- Necessary includes for LocusZoom -->
   <script src="locuszoom.vendor.min.js" type="text/javascript"></script>
   <script src="locuszoom.app.js" type="text/javascript"></script>
   <link rel="stylesheet" type="text/css" href="locuszoom.css"/>
 
-  <script type="text/javascript">
-    var apiBase = "http://portaldev.sph.umich.edu/api_internal_dev/v1/";
-    var ds = new LocusZoom.DataSources();
-    ds.addSource("base", ["AssociationLZ", {url:apiBase + "single/", params: {analysis: 3}}]);
-    ds.addSource("ld", ["LDLZ" ,apiBase + "pair/LD/"]);
-    ds.addSource("gene", ["GeneLZ", apiBase + "annotation/genes/"]);
+</head>
 
-    // Variable to store our demo instance
-    var demo_instance;
+<body style="background-color: #CCCCCC; margin: 10px;" onload="initPage()">
+  <table border="0" cellspacing="10">
+    <tr>
+      <td>
+        <div>
+          <form>
+            <b>lz-1</b> &middot;
+            <label for="lz-1_region">Region: </label>
+            <input type="text" size=25 id="lz-1_region">
+            <input type="button" id="lz-1_submit" value="Go" onClick="handleFormSubmit('lz-1');" />
+          </form>
+          <br>
+        </div>
+        <div id="lz-1" class="lz-instance" data-region="10:114550452-115067678" style="width: 100%; position: relative; display: inline-block; vertical-align: top; overflow:hidden; padding-bottom: 100%;"></div>
+      </td>
+      <td style="vertical-align:top">
+        <h3>Top Hits</h3>
+        <div id="tophits"></div>
+      </td>
+    </tr>
+  </table>
+
+  <script type="text/javascript">
+
+    // Define LocusZoom Data Sources object
+    var apiBase = "http://portaldev.sph.umich.edu/api_internal_dev/v1/";
+    var data_sources = new LocusZoom.DataSources();
+    data_sources.addSource("base", ["AssociationLZ", {url:apiBase + "single/", params: {analysis: 3}}]);
+    data_sources.addSource("ld", ["LDLZ" ,apiBase + "pair/LD/"]);
+    data_sources.addSource("gene", ["GeneLZ", apiBase + "annotation/genes/"]);
+
+    // Populate the div with a LocusZoom plot using the default layout
+    var demo_instance = LocusZoom.populate("#lz-1", data_sources);
+
+    /**********************************************************************************
+     All of the following code sets up an example form with top hit buttons to jump to
+     different regions in the plot, as an example of some ways to build an app around
+     a single LocusZoom plot.
+    **********************************************************************************/
 
     var topHits = [
       ["16:53819169", "FTO"],
@@ -96,33 +129,11 @@
 
     function initPage() {
       listHits();
-      demo_instance = LocusZoom.populate(".lz-instance", ds);
       populateForms();
       $("#lz-1_hits").html(topHits.map(function(k) {return "<option>" + k + "</option>"}).join(""));
     };
 
   </script>
-</head>
-<body style="background-color: #CCCCCC; margin: 10px;" onload="initPage()">
-  <table border="0" cellspacing="10">
-    <tr>
-      <td>
-        <div>
-          <form>
-            <b>lz-1</b> &middot;
-            <label for="lz-1_region">Region: </label>
-            <input type="text" size=25 id="lz-1_region">
-            <input type="button" id="lz-1_submit" value="Go" onClick="handleFormSubmit('lz-1');" />
-          </form>
-          <br>
-        </div>
-        <div id="lz-1" class="lz-instance" data-region="10:114550452-115067678" style="width: 100%; position: relative; display: inline-block; vertical-align: top; overflow:hidden; padding-bottom: 100%;"></div>
-      </td>
-      <td style="vertical-align:top">
-        <h3>Top Hits</h3>
-        <div id="tophits"></div>
-      </td>
-    </tr>
-  </table>
+
 </body>
 </html>

--- a/demo.html
+++ b/demo.html
@@ -26,7 +26,7 @@
           </form>
           <br>
         </div>
-        <div id="lz-1" class="lz-instance" data-region="10:114550452-115067678" style="width: 100%; position: relative; display: inline-block; vertical-align: top; overflow:hidden; padding-bottom: 100%;"></div>
+        <div id="lz-1" class="lz-locuszoom-container" data-region="10:114550452-115067678"></div>
       </td>
       <td style="vertical-align:top">
         <h3>Top Hits</h3>
@@ -44,8 +44,15 @@
     data_sources.addSource("ld", ["LDLZ" ,apiBase + "pair/LD/"]);
     data_sources.addSource("gene", ["GeneLZ", apiBase + "annotation/genes/"]);
 
+    // Define custom LocusZoom layout object to allow manual resizing.
+    // This will be merged with the default layout (LocusZoom.DefaultLayout)
+    // so we only need to specify the values we want to change.
+    var layout = {
+      resizable: "manual"
+    };
+
     // Populate the div with a LocusZoom plot using the default layout
-    var demo_instance = LocusZoom.populate("#lz-1", data_sources);
+    var demo_instance = LocusZoom.populate("#lz-1", data_sources, layout);
 
     /**********************************************************************************
      All of the following code sets up an example form with top hit buttons to jump to

--- a/demo_responsive.html
+++ b/demo_responsive.html
@@ -37,16 +37,8 @@
     data_sources.addSource("ld", ["LDLZ" ,apiBase + "pair/LD/"]);
     data_sources.addSource("gene", ["GeneLZ", apiBase + "annotation/genes/"]);
 
-    // Define custom LocusZoom layout object.
-    // This will be merged with the default layout (LocusZoom.DefaultLayout)
-    // so we only need to specify the values we want to change.
-    var layout = {
-      resizable: "responsive",
-      aspect_ratio: (16/9),
-    };
-
     // Populate the div with a LocusZoom plot
-    var demo_instance = LocusZoom.populate("#lz-1", data_sources, layout);
+    var demo_instance = LocusZoom.populate("#lz-1", data_sources);
 
     /**********************************************************************************
      All of the following code sets up an example form with top hit buttons to jump to

--- a/demo_responsive.html
+++ b/demo_responsive.html
@@ -1,15 +1,19 @@
 <!doctype html>
 <html lang="en">
+
 <head>
   <meta charset="utf-8">
   <title>LocusZoom Plugin Demo</title>
 
   <script src="https://code.jquery.com/jquery-2.1.4.min.js" type="text/javascript"></script>
 
+  <!-- Necessary includes for LocusZoom -->
   <script src="locuszoom.vendor.min.js" type="text/javascript"></script>
   <script src="locuszoom.app.js" type="text/javascript"></script>
   <link rel="stylesheet" type="text/css" href="locuszoom.css"/>
+
 </head>
+
 <body style="background-color: #CCCCCC; margin: 10px;" onload="initPage()">
   <div style="padding-bottom: 10px;">
     <h3 style="display: inline; padding-right: 30px;">LocusZoom Responsive Demo</h3>

--- a/demo_responsive.html
+++ b/demo_responsive.html
@@ -9,16 +9,46 @@
   <script src="locuszoom.vendor.min.js" type="text/javascript"></script>
   <script src="locuszoom.app.js" type="text/javascript"></script>
   <link rel="stylesheet" type="text/css" href="locuszoom.css"/>
+</head>
+<body style="background-color: #CCCCCC; margin: 10px;" onload="initPage()">
+  <div style="padding-bottom: 10px;">
+    <h3 style="display: inline; padding-right: 30px;">LocusZoom Responsive Demo</h3>
+    <form style="display: inline;">
+      <label for="lz-1_region">Region: </label>
+      <input type="text" size="25" id="lz-1_region">
+      <input type="button" id="lz-1_submit" value="Go" onClick="handleFormSubmit('lz-1');" />
+    </form>
+  </div>
+  <div style="padding-bottom: 10px;">
+    <div id="tophits"></div>
+  </div>
+  <div id="lz-1" class="lz-container-responsive" data-region="10:114550452-115067678"></div>
 
   <script type="text/javascript">
-    var apiBase = "http://portaldev.sph.umich.edu/api_internal_dev/v1/";
-    var ds = new LocusZoom.DataSources();
-    ds.addSource("base", ["AssociationLZ", {url:apiBase + "single/", params: {analysis: 3}}]);
-    ds.addSource("ld", ["LDLZ" ,apiBase + "pair/LD/"]);
-    ds.addSource("gene", ["GeneLZ", apiBase + "annotation/genes/"]);
 
-    // Variable to store our demo instance
-    var demo_instance;
+    // Define LocusZoom Data Sources object
+    var apiBase = "http://portaldev.sph.umich.edu/api_internal_dev/v1/";
+    var data_sources = new LocusZoom.DataSources();
+    data_sources.addSource("base", ["AssociationLZ", {url:apiBase + "single/", params: {analysis: 3}}]);
+    data_sources.addSource("ld", ["LDLZ" ,apiBase + "pair/LD/"]);
+    data_sources.addSource("gene", ["GeneLZ", apiBase + "annotation/genes/"]);
+
+    // Define custom LocusZoom layout object.
+    // This will be merged with the default layout (LocusZoom.DefaultLayout)
+    // so we only need to specify the values we want to change.
+    var layout = {
+      resizable: "responsive",
+      aspect_ratio: (16/9),
+    };
+
+    // Populate the div with a LocusZoom plot
+    var demo_instance = LocusZoom.populate("#lz-1", data_sources, layout);
+
+    /**********************************************************************************
+     All of the following code sets up an example form with top hit buttons to jump to
+     different regions in the plot, as an example of some ways to build an app around
+     a single LocusZoom plot.
+    **********************************************************************************/
 
     var topHits = [
       ["16:53819169", "FTO"],
@@ -89,40 +119,17 @@
     }
 
     function listHits() {
-      $("#tophits").empty().append("<ul>").children(0).append(topHits.map(function(e) {
-        return "<li><a href='javascript:jumpTo(\"" + e[0] + "\");'>" + e[1] + " </a></li>";
+      $("#tophits").empty().append(topHits.map(function(e) {
+        return "<button onclick='javascript:jumpTo(\"" + e[0] + "\");'>" + e[1] + " </button>";
       }))
     }
 
     function initPage() {
       listHits();
-      demo_instance = LocusZoom.populate(".lz-instance", ds);
       populateForms();
-      $("#lz-1_hits").html(topHits.map(function(k) {return "<option>" + k + "</option>"}).join(""));
     };
 
   </script>
-</head>
-<body style="background-color: #CCCCCC; margin: 10px;" onload="initPage()">
-  <table border="0" cellspacing="10">
-    <tr>
-      <td>
-        <div>
-          <form>
-            <b>lz-1</b> &middot;
-            <label for="lz-1_region">Region: </label>
-            <input type="text" size=25 id="lz-1_region">
-            <input type="button" id="lz-1_submit" value="Go" onClick="handleFormSubmit('lz-1');" />
-          </form>
-          <br>
-        </div>
-        <div id="lz-1" class="lz-instance" data-region="10:114550452-115067678" style="width: 100%; position: relative; display: inline-block; vertical-align: top; overflow:hidden; padding-bottom: 100%;"></div>
-      </td>
-      <td style="vertical-align:top">
-        <h3>Top Hits</h3>
-        <div id="tophits"></div>
-      </td>
-    </tr>
-  </table>
+
 </body>
 </html>

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -798,10 +798,11 @@ LocusZoom.Instance.prototype.setDimensions = function(width, height){
     // Set the layout height to a discrete value, by passed argument or responsive logic using the aspect ratio
     if (!isNaN(height) && height >= 0){
         this.layout.height = Math.max(Math.round(+height), this.layout.min_height);
-    } else if (this.svg && this.layout.resizable == "responsive"){
+    } else if (this.layout.resizable == "responsive"){
         this.layout.height = this.layout.width / this.layout.aspect_ratio;
     }
-    // Keep aspect ratio in agreement with width and height
+    console.log(this.layout);
+    // Keep aspect ratio and dimensions in agreement
     this.layout.aspect_ratio = this.layout.width / this.layout.height;
     // Apply layout width and height as discrete values or viewbox values
     if (this.svg != null){
@@ -819,6 +820,8 @@ LocusZoom.Instance.prototype.setDimensions = function(width, height){
     if (this.initialized){
         this.ui.render();
     }
+    console.log(this.layout);
+    console.log("DONE");
     return this;
 };
 

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -17,7 +17,7 @@
 /* eslint-disable no-console */
 
 var LocusZoom = {
-    version: "0.3.2"
+    version: "0.3.3"
 };
 
 // Create a new instance by instance class and attach it to a div by ID
@@ -270,7 +270,7 @@ LocusZoom.DefaultLayout = {
     height: 700,
     min_width: 300,
     min_height: 400,
-    resizable: false,
+    resizable: "manual",
     panels: {
         positions: {
             origin: { x: 0, y: 0 },

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -789,20 +789,21 @@ LocusZoom.Instance.prototype.initializeLayout = function(){
 // Set the layout dimensions for this instance. If an SVG exists, update its dimensions.
 // If any arguments are missing, use values stored in the layout. Keep everything in agreement.
 LocusZoom.Instance.prototype.setDimensions = function(width, height){
-    // Set the layout width to a discrete value, by passed argument or responsive logic
+    // Set discrete layout dimensions based on arguments
     if (!isNaN(width) && width >= 0){
         this.layout.width = Math.max(Math.round(+width), this.layout.min_width);
-    } else if (this.svg && this.layout.resizable == "responsive"){
-        this.layout.width = this.svg.node().parentNode.getBoundingClientRect().width;
     }
-    // Set the layout height to a discrete value, by passed argument or responsive logic using the aspect ratio
     if (!isNaN(height) && height >= 0){
         this.layout.height = Math.max(Math.round(+height), this.layout.min_height);
-    } else if (this.layout.resizable == "responsive"){
+    }
+    // Override discrete values if resizing responsively
+    if (this.layout.resizable == "responsive"){
+        if (this.svg){
+            this.layout.width = this.svg.node().parentNode.getBoundingClientRect().width;
+        }
         this.layout.height = this.layout.width / this.layout.aspect_ratio;
     }
-    console.log(this.layout);
-    // Keep aspect ratio and dimensions in agreement
+    // Keep aspect ratio in agreement with dimensions
     this.layout.aspect_ratio = this.layout.width / this.layout.height;
     // Apply layout width and height as discrete values or viewbox values
     if (this.svg != null){
@@ -820,8 +821,6 @@ LocusZoom.Instance.prototype.setDimensions = function(width, height){
     if (this.initialized){
         this.ui.render();
     }
-    console.log(this.layout);
-    console.log("DONE");
     return this;
 };
 

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -801,6 +801,8 @@ LocusZoom.Instance.prototype.setDimensions = function(width, height){
     } else if (this.svg && this.layout.resizable == "responsive"){
         this.layout.height = this.layout.width / this.layout.aspect_ratio;
     }
+    // Keep aspect ratio in agreement with width and height
+    this.layout.aspect_ratio = this.layout.width / this.layout.height;
     // Apply layout width and height as discrete values or viewbox values
     if (this.svg != null){
         if (this.layout.resizable == "responsive"){

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -271,15 +271,17 @@ LocusZoom.DefaultLayout = {
     min_width: 300,
     min_height: 400,
     resizable: "manual",
+    aspect_ratio: 1,
     panels: {
         positions: {
-            origin: { x: 0, y: 0 },
             width:      700,
             height:     350,
+            origin: { x: 0, y: 0 },
             min_width:  300,
             min_height: 200,
             proportional_width: 1,
             proportional_height: 0.5,
+            proportional_origin: { x: 0, y: 0 },
             margin: { top: 20, right: 20, bottom: 35, left: 50 },
             axes: {
                 x: {
@@ -318,13 +320,14 @@ LocusZoom.DefaultLayout = {
             }
         },
         genes: {
-            origin: { x: 0, y: 350 },
             width:      700,
             height:     350,
+            origin: { x: 0, y: 350 },
             min_width:  300,
             min_height: 200,
             proportional_width: 1,
             proportional_height: 0.5,
+            proportional_origin: { x: 0, y: 0.5 },
             margin: { top: 20, right: 20, bottom: 20, left: 50 },
             data_layers: {
                 genes: {
@@ -752,6 +755,9 @@ LocusZoom.Instance = function(id, datasource, layout, state) {
     // LocusZoom.Data.Requester
     this.lzd = new LocusZoom.Data.Requester(datasource);
 
+    // Window.onresize listener (responsive layouts only)
+    this.window_onresize = null;
+
     // Initialize the layout
     this.initializeLayout();
 
@@ -760,6 +766,14 @@ LocusZoom.Instance = function(id, datasource, layout, state) {
 };
 
 LocusZoom.Instance.prototype.initializeLayout = function(){
+
+    // If this is a responsive layout then set a namespaced/unique onresize event listener on the window
+    if (this.layout.resizable == "responsive"){
+        this.window_onresize = d3.select(window).on("resize.lz-"+this.id, function(){
+            var clientRect = this.svg.node().parentNode.getBoundingClientRect();
+            this.setDimensions(clientRect.width, clientRect.height);
+        }.bind(this));
+    }
 
     // Set instance dimensions
     this.setDimensions();
@@ -775,18 +789,33 @@ LocusZoom.Instance.prototype.initializeLayout = function(){
 // Set the layout dimensions for this instance. If an SVG exists, update its dimensions.
 // If any arguments are missing, use values stored in the layout. Keep everything in agreement.
 LocusZoom.Instance.prototype.setDimensions = function(width, height){
+    // Set the layout width to a discrete value, by passed argument or responsive logic
     if (!isNaN(width) && width >= 0){
         this.layout.width = Math.max(Math.round(+width), this.layout.min_width);
+    } else if (this.svg && this.layout.resizable == "responsive"){
+        this.layout.width = this.svg.node().parentNode.getBoundingClientRect().width;
     }
+    // Set the layout height to a discrete value, by passed argument or responsive logic using the aspect ratio
     if (!isNaN(height) && height >= 0){
         this.layout.height = Math.max(Math.round(+height), this.layout.min_height);
+    } else if (this.svg && this.layout.resizable == "responsive"){
+        this.layout.height = this.layout.width / this.layout.aspect_ratio;
     }
+    // Apply layout width and height as discrete values or viewbox values
     if (this.svg != null){
-        this.svg.attr("width", this.layout.width).attr("height", this.layout.height);
+        if (this.layout.resizable == "responsive"){
+            this.svg
+                .attr("viewBox", "0 0 " + this.layout.width + " " + this.layout.height)
+                .attr("preserveAspectRatio", "xMinYMin meet");
+        } else {
+            this.svg.attr("width", this.layout.width).attr("height", this.layout.height);
+        }
     }
+    // Reposition all panels
+    this.positionPanels();
+    // If the instance has been initialized then trigger some necessary render functions
     if (this.initialized){
         this.ui.render();
-        this.stackPanels();
     }
     return this;
 };
@@ -805,47 +834,39 @@ LocusZoom.Instance.prototype.addPanel = function(id, layout){
     var panel = new LocusZoom.Panel(id, layout);
     panel.parent = this;
     this.panels[panel.id] = panel;
-    this.stackPanels();
-    return this.panels[panel.id];
-};
 
-// Automatically position panels based on panel positioning rules and values
-// Default behavior: position panels vertically with equally proportioned heights
-// In all cases: bubble minimum panel dimensions up from panels to enforce minimum instance dimensions
-LocusZoom.Instance.prototype.stackPanels = function(){
-
-    var id;
-
-    // First set/enforce minimum instance dimensions based on current panels
+    // Update minimum instance dimensions based on the minimum dimensions of all panels
+    // TODO: This logic assumes panels are always stacked vertically. More sophisticated
+    //       logic to handle arbitrary panel geometries needs to be supported.
     var panel_min_widths = [];
     var panel_min_heights = [];
     for (id in this.panels){
         panel_min_widths.push(this.panels[id].layout.min_width);
         panel_min_heights.push(this.panels[id].layout.min_height);
     }
-    if (panel_min_widths.length){
-        this.layout.min_width = Math.max.apply(null, panel_min_widths);
-    }
-    if (panel_min_heights.length){
-        this.layout.min_height = panel_min_heights.reduce(function(a,b){ return a+b; });
-    }
-    if (this.layout.width < this.layout.min_width || this.layout.height < this.layout.min_height){
-        this.setDimensions(Math.max(this.layout.width, this.layout.min_width),
-                           Math.max(this.layout.height, this.layout.min_height));
-        return;
-    }
+    this.layout.min_width = Math.max.apply(null, panel_min_widths);
+    this.layout.min_height = panel_min_heights.reduce(function(a,b){ return a+b; });
 
-    // Next set proportional and discrete heights of panels
-    var proportional_height = 1 / Object.keys(this.panels).length;
-    var discrete_height = this.layout.height * proportional_height;
-    var panel_idx = 0;
+    // Call setDimensions() in case updated minimums need to be applied, which also calls positionPanels()
+    this.setDimensions();
+
+    return this.panels[panel.id];
+};
+
+// Automatically position panels based on panel positioning rules and values
+// If the plot is resizable then recalculate dimensions and position from proportional values
+LocusZoom.Instance.prototype.positionPanels = function(){
+    var id;
     for (id in this.panels){
-        this.panels[id].layout.proportional_height = proportional_height;
-        this.panels[id].setOrigin(0, panel_idx * discrete_height);
-        this.panels[id].setDimensions(this.layout.width, discrete_height);
-        panel_idx++;
+        if (this.layout.resizable){
+            this.panels[id].layout.width = this.panels[id].layout.proportional_width * this.layout.width;
+            this.panels[id].layout.height = this.panels[id].layout.proportional_height * this.layout.height;
+            this.panels[id].layout.origin.x = this.panels[id].layout.proportional_origin.x * this.layout.width;
+            this.panels[id].layout.origin.y = this.panels[id].layout.proportional_origin.y * this.layout.height;
+        }
+        this.panels[id].setOrigin();
+        this.panels[id].setDimensions();
     }
-
 };
 
 // Create all instance-level objects, initialize all child panels
@@ -1047,11 +1068,12 @@ LocusZoom.Panel = function(id, layout) {
 LocusZoom.Panel.DefaultLayout = {
     width:  0,
     height: 0,
+    origin: { x: 0, y: 0 },
     min_width: 0,
     min_height: 0,
     proportional_width: 1,
     proportional_height: 1,
-    origin: { x: 0, y: 0 },
+    proportional_origin: { x: 0, y: 0 },
     margin: { top: 0, right: 0, bottom: 0, left: 0 },
     cliparea: {
         height: 0,

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -17,7 +17,7 @@
 /* eslint-disable no-console */
 
 var LocusZoom = {
-    version: "0.3.1"
+    version: "0.3.2"
 };
 
 // Create a new instance by instance class and attach it to a div by ID
@@ -275,6 +275,7 @@ LocusZoom.DefaultLayout = {
     height: 700,
     min_width: 300,
     min_height: 400,
+    resizable: false,
     panels: {
         positions: {
             origin: { x: 0, y: 0 },
@@ -884,31 +885,35 @@ LocusZoom.Instance.prototype.initialize = function(){
         },
         initialize: function(){
             // Resize handle
-            this.resize_handle = this.svg.append("g")
-                .attr("id", this.parent.id + ".ui.resize_handle");
-            this.resize_handle.append("path")
-                .attr("class", "lz-ui-resize_handle")
-                .attr("d", "M 0,16, L 16,0, L 16,16 Z");
-            var resize_drag = d3.behavior.drag();
-            //resize_drag.origin(function() { return this; });
-            resize_drag.on("dragstart", function(){
-                this.resize_handle.select("path").attr("class", "lz-ui-resize_handle_dragging");
-                this.is_resize_dragging = true;
-            }.bind(this));
-            resize_drag.on("dragend", function(){
-                this.resize_handle.select("path").attr("class", "lz-ui-resize_handle");
-                this.is_resize_dragging = false;
-            }.bind(this));
-            resize_drag.on("drag", function(){
-                this.setDimensions(this.layout.width + d3.event.dx, this.layout.height + d3.event.dy);
-            }.bind(this.parent));
-            this.resize_handle.call(resize_drag);
+            if (this.parent.layout.resizable == "manual"){
+                this.resize_handle = this.svg.append("g")
+                    .attr("id", this.parent.id + ".ui.resize_handle");
+                this.resize_handle.append("path")
+                    .attr("class", "lz-ui-resize_handle")
+                    .attr("d", "M 0,16, L 16,0, L 16,16 Z");
+                var resize_drag = d3.behavior.drag();
+                //resize_drag.origin(function() { return this; });
+                resize_drag.on("dragstart", function(){
+                    this.resize_handle.select("path").attr("class", "lz-ui-resize_handle_dragging");
+                    this.is_resize_dragging = true;
+                }.bind(this));
+                resize_drag.on("dragend", function(){
+                    this.resize_handle.select("path").attr("class", "lz-ui-resize_handle");
+                    this.is_resize_dragging = false;
+                }.bind(this));
+                resize_drag.on("drag", function(){
+                    this.setDimensions(this.layout.width + d3.event.dx, this.layout.height + d3.event.dy);
+                }.bind(this.parent));
+                this.resize_handle.call(resize_drag);
+            }
             // Render all UI elements
             this.render();
         },
         render: function(){
-            this.resize_handle
-                .attr("transform", "translate(" + (this.parent.layout.width - 17) + ", " + (this.parent.layout.height - 17) + ")");
+            if (this.parent.layout.resizable == "manual"){
+                this.resize_handle
+                    .attr("transform", "translate(" + (this.parent.layout.width - 17) + ", " + (this.parent.layout.height - 17) + ")");
+            }
         }
     };
     this.ui.initialize();

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -266,19 +266,19 @@ LocusZoom.DefaultState = {
 
 // Default Layout
 LocusZoom.DefaultLayout = {
-    width: 700,
-    height: 700,
-    min_width: 300,
-    min_height: 400,
-    resizable: "manual",
-    aspect_ratio: 1,
+    width: 800,
+    height: 450,
+    min_width: 400,
+    min_height: 225,
+    resizable: "responsive",
+    aspect_ratio: (16/9),
     panels: {
         positions: {
-            width:      700,
-            height:     350,
+            width: 800,
+            height: 225,
             origin: { x: 0, y: 0 },
-            min_width:  300,
-            min_height: 200,
+            min_width:  400,
+            min_height: 112.5,
             proportional_width: 1,
             proportional_height: 0.5,
             proportional_origin: { x: 0, y: 0 },
@@ -320,11 +320,11 @@ LocusZoom.DefaultLayout = {
             }
         },
         genes: {
-            width:      700,
-            height:     350,
+            width: 800,
+            height: 225,
             origin: { x: 0, y: 350 },
-            min_width:  300,
-            min_height: 200,
+            min_width: 400,
+            min_height: 112.5,
             proportional_width: 1,
             proportional_height: 0.5,
             proportional_origin: { x: 0, y: 0.5 },
@@ -767,6 +767,18 @@ LocusZoom.Instance = function(id, datasource, layout, state) {
 
 LocusZoom.Instance.prototype.initializeLayout = function(){
 
+    // Sanity check layout values
+    // TODO: Find a way to generally abstract this, maybe into an object that models allowed layout values?
+    if (isNaN(this.layout.width) || this.layout.width <= 0){
+        throw ("Instance layout parameter `width` must be a positive number");
+    }
+    if (isNaN(this.layout.height) || this.layout.height <= 0){
+        throw ("Instance layout parameter `width` must be a positive number");
+    }
+    if (isNaN(this.layout.aspect_ratio) || this.layout.aspect_ratio <= 0){
+        throw ("Instance layout parameter `aspect_ratio` must be a positive number");
+    }
+
     // If this is a responsive layout then set a namespaced/unique onresize event listener on the window
     if (this.layout.resizable == "responsive"){
         this.window_onresize = d3.select(window).on("resize.lz-"+this.id, function(){
@@ -799,9 +811,13 @@ LocusZoom.Instance.prototype.setDimensions = function(width, height){
     // Override discrete values if resizing responsively
     if (this.layout.resizable == "responsive"){
         if (this.svg){
-            this.layout.width = this.svg.node().parentNode.getBoundingClientRect().width;
+            this.layout.width = Math.max(this.svg.node().parentNode.getBoundingClientRect().width, this.layout.min_width);
         }
         this.layout.height = this.layout.width / this.layout.aspect_ratio;
+        if (this.layout.height < this.layout.min_height){
+            this.layout.height = this.layout.min_height;
+            this.layout.width  = this.layout.height * this.layout.aspect_ratio;
+        }
     }
     // Keep aspect ratio in agreement with dimensions
     this.layout.aspect_ratio = this.layout.width / this.layout.height;

--- a/locuszoom.css
+++ b/locuszoom.css
@@ -65,3 +65,8 @@
   .lz-locuszoom rect.lz-gene.lz-exon {
     stroke: #000099;
     stroke-width: 1; }
+
+.lz-container-responsive {
+  width: 100%;
+  display: inline-block;
+  overflow: hidden; }

--- a/locuszoom.css
+++ b/locuszoom.css
@@ -66,6 +66,10 @@
     stroke: #000099;
     stroke-width: 1; }
 
+.lz-container {
+  display: inline-block;
+  overflow: hidden; }
+
 .lz-container-responsive {
   width: 100%;
   display: inline-block;

--- a/test/Instance.js
+++ b/test/Instance.js
@@ -58,25 +58,26 @@ describe('LocusZoom.Instance', function(){
     describe("Configuration API", function() {
         beforeEach(function() {
             d3.select("body").append("div").attr("id", "instance_id");
-            this.instance = LocusZoom.populate("#instance_id");
+            var layout = { resizable: "manual" };
+            this.instance = LocusZoom.populate("#instance_id", {}, layout);
         });
         it('should allow setting dimensions, bounded by layout minimums', function(){
             this.instance.setDimensions(563, 681);
-            this.instance.layout.should.have.property('width').which.is.exactly(563);
-            this.instance.layout.should.have.property('height').which.is.exactly(681);
-            this.instance.layout.should.have.property('aspect_ratio').which.is.exactly(563/681);
+            this.instance.layout.width.should.be.exactly(563);
+            this.instance.layout.height.should.be.exactly(681);
+            this.instance.layout.aspect_ratio.should.be.exactly(563/681);
             this.instance.setDimensions(1320.3, -50);
-            this.instance.layout.should.have.property('width').which.is.exactly(1320);
-            this.instance.layout.should.have.property('height').which.is.exactly(681);
-            this.instance.layout.should.have.property('aspect_ratio').which.is.exactly(1320/681);
+            this.instance.layout.width.should.be.exactly(1320);
+            this.instance.layout.height.should.be.exactly(681);
+            this.instance.layout.aspect_ratio.should.be.exactly(1320/681);
             this.instance.setDimensions("q", 0);
-            this.instance.layout.should.have.property('width').which.is.exactly(1320);
-            this.instance.layout.should.have.property('height').which.is.exactly(LocusZoom.DefaultLayout.min_height);
-            this.instance.layout.should.have.property('aspect_ratio').which.is.exactly(1320/LocusZoom.DefaultLayout.min_height);
+            this.instance.layout.width.should.be.exactly(1320);
+            this.instance.layout.height.should.be.exactly(LocusZoom.DefaultLayout.min_height);
+            this.instance.layout.aspect_ratio.should.be.exactly(1320/LocusZoom.DefaultLayout.min_height);
             this.instance.setDimensions(0, 0);
-            this.instance.layout.should.have.property('width').which.is.exactly(LocusZoom.DefaultLayout.min_width);
-            this.instance.layout.should.have.property('height').which.is.exactly(LocusZoom.DefaultLayout.min_height);
-            this.instance.layout.should.have.property('aspect_ratio').which.is.exactly(LocusZoom.DefaultLayout.min_width/LocusZoom.DefaultLayout.min_height);
+            this.instance.layout.width.should.be.exactly(LocusZoom.DefaultLayout.min_width);
+            this.instance.layout.height.should.be.exactly(LocusZoom.DefaultLayout.min_height);
+            this.instance.layout.aspect_ratio.should.be.exactly(LocusZoom.DefaultLayout.min_width/LocusZoom.DefaultLayout.min_height);
         });
         it('should allow for adding arbitrarily many panels', function(){
             this.instance.addPanel.should.be.a.Function;
@@ -100,6 +101,63 @@ describe('LocusZoom.Instance', function(){
             assert.equal(this.instance.layout.min_height, calculated_min_height);
             this.instance.layout.width.should.not.be.lessThan(this.instance.layout.min_width);
             this.instance.layout.height.should.not.be.lessThan(this.instance.layout.min_height);
+        });
+        it('should allow for responsively setting dimensions using a predefined aspect ratio', function(){
+            this.instance = LocusZoom.populate("#instance_id", {}, { aspect_ratio: 2 });
+            this.instance.layout.aspect_ratio.should.be.exactly(2);
+            assert.equal(this.instance.layout.width/this.instance.layout.height, 2);
+            this.instance.setDimensions(2000);
+            this.instance.layout.aspect_ratio.should.be.exactly(2);
+            assert.equal(this.instance.layout.width/this.instance.layout.height, 2);
+            this.instance.setDimensions(900, 900);
+            this.instance.layout.aspect_ratio.should.be.exactly(2);
+            assert.equal(this.instance.layout.width/this.instance.layout.height, 2);
+        });
+        it('should allow for responsively positioning panels using a proportional dimensions', function(){
+            var responsive_layout = {
+                resizable: "responsive",
+                aspect_ratio: 2,
+                panels: {
+                    positions: { proportional_width: 1, proportional_height: 0.6 },
+                    genes:     { proportional_width: 1, proportional_height: 0.4 }
+                }
+            };
+            this.instance = LocusZoom.populate("#instance_id", {}, responsive_layout);
+            assert.equal(this.instance.layout.panels.positions.height/this.instance.layout.height, 0.6);
+            assert.equal(this.instance.layout.panels.genes.height/this.instance.layout.height, 0.4);
+            this.instance.setDimensions(2000);
+            assert.equal(this.instance.layout.panels.positions.height/this.instance.layout.height, 0.6);
+            assert.equal(this.instance.layout.panels.genes.height/this.instance.layout.height, 0.4);
+            this.instance.setDimensions(900, 900);
+            assert.equal(this.instance.layout.panels.positions.height/this.instance.layout.height, 0.6);
+            assert.equal(this.instance.layout.panels.genes.height/this.instance.layout.height, 0.4);
+            this.instance.setDimensions(100, 100);
+            assert.equal(this.instance.layout.panels.positions.height/this.instance.layout.height, 0.6);
+            assert.equal(this.instance.layout.panels.genes.height/this.instance.layout.height, 0.4);
+        });
+        it('should not allow for a non-numerical / non-positive predefined dimensions', function(){
+            assert.throws(function(){ this.instance = LocusZoom.populate("#instance_id", {}, { width: 0, height: 0 }) });
+            assert.throws(function(){ this.instance = LocusZoom.populate("#instance_id", {}, { width: 20, height: -20 }) });
+            assert.throws(function(){ this.instance = LocusZoom.populate("#instance_id", {}, { width: "foo", height: 40 }) });
+            assert.throws(function(){ this.instance = LocusZoom.populate("#instance_id", {}, { width: 60, height: [1,2] }) });
+        });
+        it('should not allow for a non-numerical / non-positive predefined aspect ratio', function(){
+            assert.throws(function(){
+                var responsive_layout = { resizable: "responsive", aspect_ratio: 0 };
+                this.instance = LocusZoom.populate("#instance_id", {}, responsive_layout);
+            });
+            assert.throws(function(){
+                var responsive_layout = { resizable: "responsive", aspect_ratio: -1 };
+                this.instance = LocusZoom.populate("#instance_id", {}, responsive_layout);
+            });
+            assert.throws(function(){
+                var responsive_layout = { resizable: "responsive", aspect_ratio: "foo" };
+                this.instance = LocusZoom.populate("#instance_id", {}, responsive_layout);
+            });
+            assert.throws(function(){
+                var responsive_layout = { resizable: "responsive", aspect_ratio: [1,2,3] };
+                this.instance = LocusZoom.populate("#instance_id", {}, responsive_layout);
+            });
         });
         it('should track whether it\'s initialized', function(){
             this.instance.initialize.should.be.a.Function;

--- a/test/Instance.js
+++ b/test/Instance.js
@@ -159,7 +159,9 @@ describe('LocusZoom.Instance', function(){
                 this.instance.ui.should.be.an.Object;
                 this.instance.ui.svg.should.be.an.Object;
                 assert.equal(this.instance.ui.svg.html(), this.instance.svg.select("#instance_id\\.ui").html());
-                assert.equal(this.instance.ui.resize_handle.html(), this.instance.svg.select("#instance_id\\.ui\\.resize_handle").html());
+                if (this.instance.layout.resizable == "manual"){
+                    assert.equal(this.instance.ui.resize_handle.html(), this.instance.svg.select("#instance_id\\.ui\\.resize_handle").html());
+                }
             });
             it('should be hidden by default', function(){
                 assert.equal(this.instance.ui.svg.style("display"), "none");

--- a/test/Instance.js
+++ b/test/Instance.js
@@ -64,15 +64,19 @@ describe('LocusZoom.Instance', function(){
             this.instance.setDimensions(563, 681);
             this.instance.layout.should.have.property('width').which.is.exactly(563);
             this.instance.layout.should.have.property('height').which.is.exactly(681);
+            this.instance.layout.should.have.property('aspect_ratio').which.is.exactly(563/681);
             this.instance.setDimensions(1320.3, -50);
             this.instance.layout.should.have.property('width').which.is.exactly(1320);
             this.instance.layout.should.have.property('height').which.is.exactly(681);
+            this.instance.layout.should.have.property('aspect_ratio').which.is.exactly(1320/681);
             this.instance.setDimensions("q", 0);
             this.instance.layout.should.have.property('width').which.is.exactly(1320);
             this.instance.layout.should.have.property('height').which.is.exactly(LocusZoom.DefaultLayout.min_height);
+            this.instance.layout.should.have.property('aspect_ratio').which.is.exactly(1320/LocusZoom.DefaultLayout.min_height);
             this.instance.setDimensions(0, 0);
             this.instance.layout.should.have.property('width').which.is.exactly(LocusZoom.DefaultLayout.min_width);
             this.instance.layout.should.have.property('height').which.is.exactly(LocusZoom.DefaultLayout.min_height);
+            this.instance.layout.should.have.property('aspect_ratio').which.is.exactly(LocusZoom.DefaultLayout.min_width/LocusZoom.DefaultLayout.min_height);
         });
         it('should allow for adding arbitrarily many panels', function(){
             this.instance.addPanel.should.be.a.Function;

--- a/test/Panel.js
+++ b/test/Panel.js
@@ -113,8 +113,8 @@ describe('LocusZoom.Panel', function(){
             this.panel.layout.origin.x.should.be.exactly(0);
             this.panel.layout.origin.y.should.be.exactly(0);
             this.panel.setOrigin(700, 800);
-            this.panel.layout.origin.x.should.be.exactly(500);
-            this.panel.layout.origin.y.should.be.exactly(600);
+            this.panel.layout.origin.x.should.be.exactly(400);
+            this.panel.layout.origin.y.should.be.exactly(225);
         });
         it('should allow setting margin, which sets cliparea origin and dimensions', function(){
             this.panel.setMargin(1, 2, 3, 4);


### PR DESCRIPTION
# Overview

This branch is built to address #41. In a nutshell, a layout should support making a plot discretely sized with no ability to resize, manually resizable (by way of a UI element), or *responsively* resizable (in that it expands to fill its available space).

## New layout parameters

### `resizable`

The `resizable` parameter is defined at the instance/plot level. This can be "manual", "responsive", or null/false.

### `aspect_ratio`

For resizable plots, since container width is typically bounded by window width but height is theoretically infinite, an `aspect_ratio` value can be defined to keep a specific aspect ratio for the plot as it resizes. This is a numerical value defined as width / height. So, for example, a square aspect ratio would be `1` and a 16:9 aspect ratio would be `1.7777777` (16/9).

### `proportional_origin`

Another other major change is that panels now have `proportional_origin` in addition to `proportional_width` and `proportional_height`. In general the proportional geometry values are used whenever a layout is resizable by either method, because at that point predefined discrete dimensions and origins may only be valid when the plot is first loaded (and in the case of a responsive plot, may immediately be overwritten during initialization). The `proportional_origin` is similar to the `origin` in that has `x` and `y` parameters, but these are expressed as multipliers applied to the dimensions of the plot. So, for example, this:

```javascript
proportional_origin: { x: 0.25, y: 0.5 }
```

Would position a panel 1/4 of the plot width from the left edge of the plot and 1/2 of the plot height from the top of the plot. As the plot is resized (by either method) the proportional origin would stay constant while the discrete origin would likely change.

## CSS

Responsive plots really only make sense inside a containing element that has the right CSS to expand to fill space. A new namespaced class has been added to make this easier for implementers: `lz-container-responsive`.

## Demo Responsive

Finally, I reworked the existing demo.html into a new demo_responsive.html (this exists in addition to the original). This demo page demonstrates how to build a responsive LocusZoom plot and applies some conventions that ultimately would be good to apply to the original demo as well (for example: clear separation of LocusZoom config code from demo-specific logic, illustration of applying a partial layout, etc.)