### PR TITLE
Unified Layout with Plot Builder

### DIFF
--- a/assets/js/app/DataLayer.js
+++ b/assets/js/app/DataLayer.js
@@ -61,7 +61,7 @@ LocusZoom.DataLayer = function(id, layout, parent) {
             arrow: null,
             selector: d3.select(this.parent.parent.svg.node().parentNode).append("div")
                 .attr("class", "lz-data_layer-tooltip")
-                .attr("id", this.parent.getBaseId() + ".tooltip." + id)
+                .attr("id", this.getBaseId() + ".tooltip." + id)
         }
         if (this.layout.tooltip.html){
             this.tooltips[id].selector.html(LocusZoom.parseFields(d, this.layout.tooltip.html));

--- a/assets/js/app/DataLayer.js
+++ b/assets/js/app/DataLayer.js
@@ -32,6 +32,10 @@ LocusZoom.DataLayer = function(id, layout, state) {
         return this.parent.parent.id + "." + this.parent.id + "." + this.id;
     };
 
+    this.triggerOnUpdate = function(){
+        this.parent.triggerOnUpdate();
+    };
+
     // Tooltip methods
     this.tooltips = {};
     this.createTooltip = function(d, id){

--- a/assets/js/app/DataLayer.js
+++ b/assets/js/app/DataLayer.js
@@ -13,15 +13,28 @@
 
 */
 
-LocusZoom.DataLayer = function(id, layout) {
+LocusZoom.DataLayer = function(id, layout, parent) {
 
     this.initialized = false;
 
     this.id     = id;
-    this.parent = null;
+    this.parent = parent || null;
     this.svg    = {};
 
     this.layout = LocusZoom.mergeLayouts(layout || {}, LocusZoom.DataLayer.DefaultLayout);
+
+    // Define state parameters specific to this data layer
+    if (this.parent){
+        this.state = this.parent.state;
+        this.state_id = this.parent.id + "." + this.id;
+        this.state[this.state_id] = this.state[this.state_id] || {};
+        if (this.layout.selectable){
+            this.state[this.state_id].selected = this.state[this.state_id].selected || null;
+        }
+    } else {
+        this.state = null;
+        this.state_id = null;
+    }
 
     this.data = [];
     this.metadata = {};
@@ -183,7 +196,7 @@ LocusZoom.DataLayer.prototype.draw = function(){
 LocusZoom.DataLayer.prototype.reMap = function(){
     this.destroyAllTooltips(); // hack - only non-visible tooltips should be destroyed
                                // and then recreated if returning to visibility
-    var promise = this.parent.parent.lzd.getData(this.parent.parent.layout.state, this.layout.fields); //,"ld:best"
+    var promise = this.parent.parent.lzd.getData(this.state, this.layout.fields); //,"ld:best"
     promise.then(function(new_data){
         this.data = new_data.body;
     }.bind(this));

--- a/assets/js/app/DataLayer.js
+++ b/assets/js/app/DataLayer.js
@@ -13,7 +13,7 @@
 
 */
 
-LocusZoom.DataLayer = function(id, layout, state) {
+LocusZoom.DataLayer = function(id, layout) {
 
     this.initialized = false;
 
@@ -22,8 +22,6 @@ LocusZoom.DataLayer = function(id, layout, state) {
     this.svg    = {};
 
     this.layout = LocusZoom.mergeLayouts(layout || {}, LocusZoom.DataLayer.DefaultLayout);
-
-    this.state = LocusZoom.mergeLayouts(state || {}, LocusZoom.DataLayer.DefaultState);
 
     this.data = [];
     this.metadata = {};
@@ -125,9 +123,6 @@ LocusZoom.DataLayer = function(id, layout, state) {
 
 };
 
-LocusZoom.DataLayer.DefaultState = {
-};
-
 LocusZoom.DataLayer.DefaultLayout = {
     type: "",
     fields: []
@@ -188,7 +183,7 @@ LocusZoom.DataLayer.prototype.draw = function(){
 LocusZoom.DataLayer.prototype.reMap = function(){
     this.destroyAllTooltips(); // hack - only non-visible tooltips should be destroyed
                                // and then recreated if returning to visibility
-    var promise = this.parent.parent.lzd.getData(this.parent.parent.state, this.layout.fields); //,"ld:best"
+    var promise = this.parent.parent.lzd.getData(this.parent.parent.layout.state, this.layout.fields); //,"ld:best"
     promise.then(function(new_data){
         this.data = new_data.body;
     }.bind(this));

--- a/assets/js/app/Instance.js
+++ b/assets/js/app/Instance.js
@@ -276,7 +276,7 @@ LocusZoom.Instance.prototype.initialize = function(){
                             this.raise();
                         }.bind(this));
                 } catch (e){
-                    console.warn("LocusZoom tried to render an error message but it's not a string:", message);
+                    console.error("LocusZoom tried to render an error message but it's not a string:", message);
                 }
             }
         },

--- a/assets/js/app/Instance.js
+++ b/assets/js/app/Instance.js
@@ -325,9 +325,9 @@ LocusZoom.Instance.prototype.mapTo = function(chr, start, end){
 
     // Apply new state values
     // TODO: preserve existing state until new state is completely loaded+rendered or aborted?
-    this.layout.state.chr   = +chr;
-    this.layout.state.start = +start;
-    this.layout.state.end   = +end;
+    this.state.chr   = +chr;
+    this.state.start = +start;
+    this.state.end   = +end;
 
     this.remap_promises = [];
     // Trigger reMap on each Panel Layer
@@ -350,5 +350,5 @@ LocusZoom.Instance.prototype.mapTo = function(chr, start, end){
 
 // Refresh an instance's data from sources without changing position
 LocusZoom.Instance.prototype.refresh = function(){
-    this.mapTo(this.layout.state.chr, this.layout.state.start, this.layout.state.end);
+    this.mapTo(this.state.chr, this.state.start, this.state.end);
 };

--- a/assets/js/app/Instance.js
+++ b/assets/js/app/Instance.js
@@ -33,6 +33,9 @@ LocusZoom.Instance = function(id, datasource, layout) {
     } else {
         this.layout = LocusZoom.mergeLayouts(layout, LocusZoom.DefaultLayout);
     }
+
+    // Create a shortcut to the state in the layout on the instance
+    this.state = this.layout.state;
     
     // LocusZoom.Data.Requester
     this.lzd = new LocusZoom.Data.Requester(datasource);
@@ -135,7 +138,7 @@ LocusZoom.Instance.prototype.setDimensions = function(width, height){
 };
 
 // Create a new panel by id and panel class
-LocusZoom.Instance.prototype.addPanel = function(id, layout, state){
+LocusZoom.Instance.prototype.addPanel = function(id, layout){
     if (typeof id !== "string"){
         throw "Invalid panel id passed to LocusZoom.Instance.prototype.addPanel()";
     }
@@ -147,8 +150,7 @@ LocusZoom.Instance.prototype.addPanel = function(id, layout, state){
     }
 
     // Create the Panel and set its parent
-    var panel = new LocusZoom.Panel(id, layout, state);
-    panel.parent = this;
+    var panel = new LocusZoom.Panel(id, layout, this);
     
     // Store the Panel on the Instance
     this.panels[panel.id] = panel;

--- a/assets/js/app/Instance.js
+++ b/assets/js/app/Instance.js
@@ -26,7 +26,13 @@ LocusZoom.Instance = function(id, datasource, layout, state) {
     this.remap_promises = [];
 
     // The layout is a serializable object used to describe the composition of the instance
-    this.layout = LocusZoom.mergeLayouts(layout || {}, LocusZoom.DefaultLayout);
+    // If no layout was passed, use the Standard Layout
+    // Otherwise merge whatever was passed with the Default Layout
+    if (typeof layout == "undefined"){
+        this.layout = LocusZoom.mergeLayouts({}, LocusZoom.StandardLayout);
+    } else {
+        this.layout = LocusZoom.mergeLayouts(layout, LocusZoom.DefaultLayout);
+    }
     
     // The state property stores any parameters subject to change via user input
     this.state = LocusZoom.mergeLayouts(state || {}, LocusZoom.DefaultState);

--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -3,12 +3,12 @@
 /* eslint-disable no-console */
 
 var LocusZoom = {
-    version: "0.3.6"
+    version: "0.3.7"
 };
     
 // Populate a single element with a LocusZoom instance.
 // selector can be a string for a DOM Query or a d3 selector.
-LocusZoom.populate = function(selector, datasource, layout, state) {
+LocusZoom.populate = function(selector, datasource, layout) {
     if (typeof selector == "undefined"){
         throw ("LocusZoom.populate selector not defined");
     }
@@ -23,7 +23,7 @@ LocusZoom.populate = function(selector, datasource, layout, state) {
             this.attr("id", "#lz-" + iterator);
         }
         // Create the instance
-        instance = new LocusZoom.Instance(this.node().id, datasource, layout, state);
+        instance = new LocusZoom.Instance(this.node().id, datasource, layout);
         // Add an SVG to the div and set its dimensions
         instance.svg = d3.select("div#" + instance.id)
             .append("svg")
@@ -35,11 +35,7 @@ LocusZoom.populate = function(selector, datasource, layout, state) {
         instance.initialize();
         // Detect data-region and fill in state values if present
         if (typeof this.node().dataset !== "undefined" && typeof this.node().dataset.region !== "undefined"){
-            var region = LocusZoom.parsePositionQuery(this.node().dataset.region);
-            var attr;
-            for (attr in region){
-                instance.state[attr] = region[attr];
-            }
+            instance.layout.state = LocusZoom.mergeLayouts(LocusZoom.parsePositionQuery(this.node().dataset.region), instance.layout.state);
         }
         // If the instance has defined data sources then trigger its first mapping based on state values
         if (typeof datasource == "object" && Object.keys(datasource).length){
@@ -51,10 +47,10 @@ LocusZoom.populate = function(selector, datasource, layout, state) {
 
 // Populate arbitrarily many elements each with a LocusZoom instance
 // using a common datasource, layout, and/or state
-LocusZoom.populateAll = function(selector, datasource, layout, state) {
+LocusZoom.populateAll = function(selector, datasource, layout) {
     var instances = [];
     d3.selectAll(selector).each(function(d,i) {
-        instances[i] = LocusZoom.populate(this, datasource, layout, state);
+        instances[i] = LocusZoom.populate(this, datasource, layout);
     });
     return instances;
 };
@@ -278,17 +274,10 @@ LocusZoom.parseFields = function (data, html) {
     }
     return html;
 };
-    
-// Default State
-LocusZoom.DefaultState = {
-    chr: 0,
-    start: 0,
-    end: 0,
-    panels: {}
-};
 
 // Default Layout
 LocusZoom.DefaultLayout = {
+    state: {},
     width: 1,
     height: 1,
     min_width: 1,
@@ -300,6 +289,11 @@ LocusZoom.DefaultLayout = {
 
 // Standard Layout
 LocusZoom.StandardLayout = {
+    state: {
+        chr: 0,
+        start: 0,
+        end: 0
+    },
     width: 800,
     height: 450,
     min_width: 400,

--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -16,6 +16,7 @@ LocusZoom.populate = function(selector, datasource, layout, state) {
     d3.select(selector).html("");
     // If state was passed as a fourth argument then merge it with layout (for backward compatibility)
     if (typeof state != "undefined"){
+        console.warn("Warning: state passed to LocusZoom.populate as fourth argument. This behavior is deprecated. Please include state as a parameter of layout");
         var stateful_layout = { state: state };
         var base_layout = layout || {};
         layout = LocusZoom.mergeLayouts(stateful_layout, base_layout);
@@ -59,7 +60,7 @@ LocusZoom.populate = function(selector, datasource, layout, state) {
 LocusZoom.populateAll = function(selector, datasource, layout, state) {
     var instances = [];
     d3.selectAll(selector).each(function(d,i) {
-        instances[i] = LocusZoom.populate(this, datasource, layout);
+        instances[i] = LocusZoom.populate(this, datasource, layout, state);
     });
     return instances;
 };

--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -15,7 +15,7 @@ LocusZoom.populate = function(selector, datasource, layout, state) {
     // Empty the selector of any existing content
     d3.select(selector).html("");
     var instance;
-    d3.select(selector).call(function(container){
+    d3.select(selector).call(function(){
         // Require each containing element have an ID. If one isn't present, create one.
         if (typeof this.node().id == "undefined"){
             var iterator = 0;
@@ -35,7 +35,11 @@ LocusZoom.populate = function(selector, datasource, layout, state) {
         instance.initialize();
         // Detect data-region and fill in state values if present
         if (typeof this.node().dataset !== "undefined" && typeof this.node().dataset.region !== "undefined"){
-            instance.state = LocusZoom.mergeLayouts(LocusZoom.parsePositionQuery(this.node().dataset.region), instance.state);
+            var region = LocusZoom.parsePositionQuery(this.node().dataset.region);
+            var attr;
+            for (attr in region){
+                instance.state[attr] = region[attr];
+            }
         }
         // If the instance has defined data sources then trigger its first mapping based on state values
         if (typeof datasource == "object" && Object.keys(datasource).length){

--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -12,6 +12,8 @@ LocusZoom.populate = function(selector, datasource, layout, state) {
     if (typeof selector == "undefined"){
         throw ("LocusZoom.populate selector not defined");
     }
+    // Empty the selector of any existing content
+    d3.select(selector).html("");
     var instance;
     d3.select(selector).call(function(container){
         // Require each containing element have an ID. If one isn't present, create one.
@@ -283,6 +285,17 @@ LocusZoom.DefaultState = {
 
 // Default Layout
 LocusZoom.DefaultLayout = {
+    width: 1,
+    height: 1,
+    min_width: 1,
+    min_height: 1,
+    resizable: false,
+    aspect_ratio: 1,
+    panels: {}
+};
+
+// Standard Layout
+LocusZoom.StandardLayout = {
     width: 800,
     height: 450,
     min_width: 400,
@@ -354,6 +367,7 @@ LocusZoom.DefaultLayout = {
             proportional_height: 0.5,
             proportional_origin: { x: 0, y: 0.5 },
             margin: { top: 20, right: 20, bottom: 20, left: 50 },
+            axes: {},
             data_layers: {
                 genes: {
                     type: "genes",

--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -8,7 +8,7 @@ var LocusZoom = {
     
 // Populate a single element with a LocusZoom instance.
 // selector can be a string for a DOM Query or a d3 selector.
-LocusZoom.populate = function(selector, datasource, layout) {
+LocusZoom.populate = function(selector, datasource, layout, state) {
     if (typeof selector == "undefined"){
         throw ("LocusZoom.populate selector not defined");
     }
@@ -56,7 +56,7 @@ LocusZoom.populate = function(selector, datasource, layout) {
 
 // Populate arbitrarily many elements each with a LocusZoom instance
 // using a common datasource, layout, and/or state
-LocusZoom.populateAll = function(selector, datasource, layout) {
+LocusZoom.populateAll = function(selector, datasource, layout, state) {
     var instances = [];
     d3.selectAll(selector).each(function(d,i) {
         instances[i] = LocusZoom.populate(this, datasource, layout);

--- a/assets/js/app/Panel.js
+++ b/assets/js/app/Panel.js
@@ -81,7 +81,7 @@ LocusZoom.Panel.prototype.initializeLayout = function(){
 
     // Initialize panel axes
     ["x", "y1", "y2"].forEach(function(axis){
-        if (JSON.stringify(this.layout.axes[axis]) == JSON.stringify({})){
+        if (!Object.keys(this.layout.axes[axis]).length || this.layout.axes[axis].render === false){
             // The default layout sets the axis to an empty object, so set its render boolean here
             this.layout.axes[axis].render = false;
         } else {

--- a/assets/js/app/Panel.js
+++ b/assets/js/app/Panel.js
@@ -198,7 +198,7 @@ LocusZoom.Panel.prototype.initialize = function(){
                             this.raise();
                         }.bind(this));
                 } catch (e){
-                    console.warn("LocusZoom tried to render an error message but it's not a string:", message);
+                    console.error("LocusZoom tried to render an error message but it's not a string:", message);
                 }
             }
         },

--- a/assets/js/app/Panel.js
+++ b/assets/js/app/Panel.js
@@ -23,9 +23,6 @@ LocusZoom.Panel = function(id, layout, state) {
 
     // The layout is a serializable object used to describe the composition of the Panel
     this.layout = LocusZoom.mergeLayouts(layout || {}, LocusZoom.Panel.DefaultLayout);
-
-    // The state property stores any parameters subject to change via user input
-    this.state = LocusZoom.mergeLayouts(state || {}, LocusZoom.Panel.DefaultState);
     
     this.data_layers = {};
     this.data_layer_ids_by_z_index = [];
@@ -50,11 +47,10 @@ LocusZoom.Panel = function(id, layout, state) {
     
 };
 
-LocusZoom.Panel.DefaultState = {
-    data_layers: {}   
-};
-
 LocusZoom.Panel.DefaultLayout = {
+    state: {
+        data_layers: {}   
+    },
     width:  0,
     height: 0,
     origin: { x: 0, y: 0 },
@@ -73,7 +69,7 @@ LocusZoom.Panel.DefaultLayout = {
         x:  {},
         y1: {},
         y2: {}
-    }            
+    }
 };
 
 LocusZoom.Panel.prototype.initializeLayout = function(){
@@ -101,7 +97,7 @@ LocusZoom.Panel.prototype.initializeLayout = function(){
     if (typeof this.layout.data_layers == "object"){
         var data_layer_id;
         for (data_layer_id in this.layout.data_layers){
-            this.addDataLayer(data_layer_id, this.layout.data_layers[data_layer_id], this.state.data_layers[data_layer_id]);
+            this.addDataLayer(data_layer_id, this.layout.data_layers[data_layer_id]);
         }
     }
 
@@ -244,7 +240,7 @@ LocusZoom.Panel.prototype.initialize = function(){
 
 
 // Create a new data layer by layout object
-LocusZoom.Panel.prototype.addDataLayer = function(id, layout, state){
+LocusZoom.Panel.prototype.addDataLayer = function(id, layout){
     if (typeof id !== "string"){
         throw "Invalid data layer id passed to LocusZoom.Panel.prototype.addDataLayer()";
     }
@@ -259,7 +255,7 @@ LocusZoom.Panel.prototype.addDataLayer = function(id, layout, state){
     }
 
     // Create the Data Layer and set its parent 
-    var data_layer = LocusZoom.DataLayers.get(layout.type, id, layout, state);
+    var data_layer = LocusZoom.DataLayers.get(layout.type, id, layout);
     data_layer.parent = this;
 
     // Store the Data Layer on the Panel
@@ -271,7 +267,7 @@ LocusZoom.Panel.prototype.addDataLayer = function(id, layout, state){
         this.xExtent = this.data_layers[data_layer.id].getAxisExtent("x");
     } else {
         this.xExtent = function(){
-            return d3.extent([this.parent.state.start, this.parent.state.end]);
+            return d3.extent([this.parent.layout.state.start, this.parent.layout.state.end]);
         };
     }
     // Generate the yExtent function
@@ -374,7 +370,7 @@ LocusZoom.Panel.prototype.render = function(){
             .attr("transform", "translate(" + this.layout.margin.left + "," + (this.layout.height - this.layout.margin.bottom) + ")")
             .call(this.x_axis);
         if (this.layout.axes.x.label_function){
-            this.layout.axes.x.label = LocusZoom.LabelFunctions.get(this.layout.axes.x.label_function, this.parent.state);
+            this.layout.axes.x.label = LocusZoom.LabelFunctions.get(this.layout.axes.x.label_function, this.parent.layout.state);
         }
         if (this.layout.axes.x.label != null){
             var x_label = this.layout.axes.x.label;
@@ -393,7 +389,7 @@ LocusZoom.Panel.prototype.render = function(){
             .attr("transform", "translate(" + this.layout.margin.left + "," + this.layout.margin.top + ")")
             .call(this.y1_axis);
         if (this.layout.axes.y1.label_function){
-            this.layout.axes.y1.label = LocusZoom.LabelFunctions.get(this.layout.axes.y1.label_function, this.parent.state);
+            this.layout.axes.y1.label = LocusZoom.LabelFunctions.get(this.layout.axes.y1.label_function, this.parent.layout.state);
         }
         if (this.layout.axes.y1.label != null){
             var y1_label = this.layout.axes.y1.label;
@@ -414,7 +410,7 @@ LocusZoom.Panel.prototype.render = function(){
             .attr("transform", "translate(" + (this.layout.width - this.layout.margin.right) + "," + this.layout.margin.top + ")")
             .call(this.y2_axis);
         if (this.layout.axes.y2.label_function){
-            this.layout.axes.y2.label = LocusZoom.LabelFunctions.get(this.layout.axes.y2.label_function, this.parent.state);
+            this.layout.axes.y2.label = LocusZoom.LabelFunctions.get(this.layout.axes.y2.label_function, this.parent.layout.state);
         }
         if (this.layout.axes.y2.label != null){
             var y2_label = this.layout.axes.y2.label;

--- a/assets/js/app/Panel.js
+++ b/assets/js/app/Panel.js
@@ -379,7 +379,7 @@ LocusZoom.Panel.prototype.render = function(){
             .attr("transform", "translate(" + this.layout.margin.left + "," + (this.layout.height - this.layout.margin.bottom) + ")")
             .call(this.x_axis);
         if (this.layout.axes.x.label_function){
-            this.layout.axes.x.label = LocusZoom.LabelFunctions.get(this.layout.axes.x.label_function, this.parent.layout.state);
+            this.layout.axes.x.label = LocusZoom.LabelFunctions.get(this.layout.axes.x.label_function, this.state);
         }
         if (this.layout.axes.x.label != null){
             var x_label = this.layout.axes.x.label;
@@ -398,7 +398,7 @@ LocusZoom.Panel.prototype.render = function(){
             .attr("transform", "translate(" + this.layout.margin.left + "," + this.layout.margin.top + ")")
             .call(this.y1_axis);
         if (this.layout.axes.y1.label_function){
-            this.layout.axes.y1.label = LocusZoom.LabelFunctions.get(this.layout.axes.y1.label_function, this.parent.layout.state);
+            this.layout.axes.y1.label = LocusZoom.LabelFunctions.get(this.layout.axes.y1.label_function, this.state);
         }
         if (this.layout.axes.y1.label != null){
             var y1_label = this.layout.axes.y1.label;
@@ -419,7 +419,7 @@ LocusZoom.Panel.prototype.render = function(){
             .attr("transform", "translate(" + (this.layout.width - this.layout.margin.right) + "," + this.layout.margin.top + ")")
             .call(this.y2_axis);
         if (this.layout.axes.y2.label_function){
-            this.layout.axes.y2.label = LocusZoom.LabelFunctions.get(this.layout.axes.y2.label_function, this.parent.layout.state);
+            this.layout.axes.y2.label = LocusZoom.LabelFunctions.get(this.layout.axes.y2.label_function, this.state);
         }
         if (this.layout.axes.y2.label != null){
             var y2_label = this.layout.axes.y2.label;

--- a/assets/js/app/Panel.js
+++ b/assets/js/app/Panel.js
@@ -39,6 +39,10 @@ LocusZoom.Panel = function(id, layout, state) {
         return this.parent.id + "." + this.id;
     };
 
+    this.triggerOnUpdate = function(){
+        this.parent.triggerOnUpdate();
+    };
+
     // Initialize the layout
     this.initializeLayout();
     
@@ -143,8 +147,6 @@ LocusZoom.Panel.prototype.setMargin = function(top, right, bottom, left){
     this.layout.cliparea.height = this.layout.height - (this.layout.margin.top + this.layout.margin.bottom);
     this.layout.cliparea.origin.x = this.layout.margin.left;
     this.layout.cliparea.origin.y = this.layout.margin.top;
-
-    //console.log(this.layout);
 
     if (this.initialized){ this.render(); }
     return this;
@@ -259,9 +261,6 @@ LocusZoom.Panel.prototype.addDataLayer = function(id, layout, state){
     // Create the Data Layer and set its parent 
     var data_layer = LocusZoom.DataLayers.get(layout.type, id, layout, state);
     data_layer.parent = this;
-
-    // Apply the Data Layer's state to the parent's state
-    data_layer.parent.state.data_layers[data_layer.id] = data_layer.state;
 
     // Store the Data Layer on the Panel
     this.data_layers[data_layer.id] = data_layer;

--- a/assets/js/app/Singletons.js
+++ b/assets/js/app/Singletons.js
@@ -564,20 +564,20 @@ LocusZoom.DataLayers.add("genes", function(id, layout, parent){
             // Determine display range start and end, based on minimum allowable gene display width, bounded by what we can see
             // (range: values in terms of pixels on the screen)
             this.data[g].display_range = {
-                start: this.parent.x_scale(Math.max(d.start, this.parent.parent.layout.state.start)),
-                end:   this.parent.x_scale(Math.min(d.end, this.parent.parent.layout.state.end))
+                start: this.parent.x_scale(Math.max(d.start, this.state.start)),
+                end:   this.parent.x_scale(Math.min(d.end, this.state.end))
             };
             this.data[g].display_range.label_width = this.getLabelWidth(this.data[g].gene_name, this.layout.label_font_size);
             this.data[g].display_range.width = this.data[g].display_range.end - this.data[g].display_range.start;
             // Determine label text anchor (default to middle)
             this.data[g].display_range.text_anchor = "middle";
             if (this.data[g].display_range.width < this.data[g].display_range.label_width){
-                if (d.start < this.parent.parent.layout.state.start){
+                if (d.start < this.state.start){
                     this.data[g].display_range.end = this.data[g].display_range.start
                         + this.data[g].display_range.label_width
                         + this.metadata.horizontal_padding;
                     this.data[g].display_range.text_anchor = "start";
-                } else if (d.end > this.parent.parent.layout.state.end){
+                } else if (d.end > this.state.end){
                     this.data[g].display_range.start = this.data[g].display_range.end
                         - this.data[g].display_range.label_width
                         - this.metadata.horizontal_padding;
@@ -585,12 +585,12 @@ LocusZoom.DataLayers.add("genes", function(id, layout, parent){
                 } else {
                     var centered_margin = ((this.data[g].display_range.label_width - this.data[g].display_range.width) / 2)
                         + this.metadata.horizontal_padding;
-                    if ((this.data[g].display_range.start - centered_margin) < this.parent.x_scale(this.parent.parent.layout.state.start)){
-                        this.data[g].display_range.start = this.parent.x_scale(this.parent.parent.layout.state.start);
+                    if ((this.data[g].display_range.start - centered_margin) < this.parent.x_scale(this.state.start)){
+                        this.data[g].display_range.start = this.parent.x_scale(this.state.start);
                         this.data[g].display_range.end = this.data[g].display_range.start + this.data[g].display_range.label_width;
                         this.data[g].display_range.text_anchor = "start";
-                    } else if ((this.data[g].display_range.end + centered_margin) > this.parent.x_scale(this.parent.parent.layout.state.end)) {
-                        this.data[g].display_range.end = this.parent.x_scale(this.parent.parent.layout.state.end);
+                    } else if ((this.data[g].display_range.end + centered_margin) > this.parent.x_scale(this.state.end)) {
+                        this.data[g].display_range.end = this.parent.x_scale(this.state.end);
                         this.data[g].display_range.start = this.data[g].display_range.end - this.data[g].display_range.label_width;
                         this.data[g].display_range.text_anchor = "end";
                     } else {

--- a/assets/js/app/Singletons.js
+++ b/assets/js/app/Singletons.js
@@ -411,6 +411,8 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, state){
                 var x = this.parent.x_scale(d[this.layout.x_axis.field]);
                 var y_scale = "y"+this.layout.y_axis.axis+"_scale";
                 var y = this.parent[y_scale](d[this.layout.y_axis.field]);
+                if (isNaN(x)){ x = -1000; }
+                if (isNaN(y)){ y = -1000; }
                 return "translate(" + x + "," + y + ")";
             }.bind(this))
             .attr("d", d3.svg.symbol().size(this.layout.point_size).type(this.layout.point_shape))

--- a/assets/js/app/Singletons.js
+++ b/assets/js/app/Singletons.js
@@ -472,7 +472,11 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, state){
             }.bind(this));
             // Apply existing selection from state
             if (this.state.selected_id != null){
-                d3.select("#" + this.state.selected_id).attr("class", "lz-data_layer-scatter-selected");
+                var selected_id = this.state.selected_id;
+                this.state.selected_id = null;
+                var d = d3.select("#" + selected_id).datum();
+                d3.select("#" + selected_id).on("mouseover")(d);
+                d3.select("#" + selected_id).on("click")(d);
             }
         }
         
@@ -804,7 +808,11 @@ LocusZoom.DataLayers.add("genes", function(id, layout, state){
                         }.bind(gene.parent));
                     // Apply existing selection from state
                     if (gene.parent.state.selected_id != null){
-                        d3.select("#" + gene.parent.state.selected_id + "_bounding_box").attr("class", "lz-data_layer-gene lz-bounding_box-selected");
+                        var selected_id = gene.parent.state.selected_id + "_clickarea";
+                        gene.parent.state.selected_id = null;
+                        var d = d3.select("#" + selected_id).datum();
+                        d3.select("#" + selected_id).on("mouseover")(d);
+                        d3.select("#" + selected_id).on("click")(d);
                     }
                 }
 

--- a/assets/js/app/Singletons.js
+++ b/assets/js/app/Singletons.js
@@ -275,14 +275,14 @@ LocusZoom.DataLayers = (function() {
     var obj = {};
     var datalayers = {};
 
-    obj.get = function(name, id, layout) {
+    obj.get = function(name, id, layout, parent) {
         if (!name) {
             return null;
         } else if (datalayers[name]) {
             if (typeof id == "undefined" || typeof layout == "undefined"){
                 throw("id or layout argument missing for data layer [" + name + "]");
             } else {
-                return new datalayers[name](id, layout);
+                return new datalayers[name](id, layout, parent);
             }
         } else {
             throw("data layer [" + name + "] not found");
@@ -324,14 +324,10 @@ LocusZoom.DataLayers = (function() {
   Implements a standard scatter plot
 */
 
-LocusZoom.DataLayers.add("scatter", function(id, layout){
+LocusZoom.DataLayers.add("scatter", function(id, layout, parent){
 
-    LocusZoom.DataLayer.apply(this, arguments);
-
+    // Define a default layout for this DataLayer type and merge it with the passed argument
     this.DefaultLayout = {
-        state: {
-            selected_id: null
-        },
         point_size: 40,
         point_shape: "circle",
         color: "#888888",
@@ -340,8 +336,10 @@ LocusZoom.DataLayers.add("scatter", function(id, layout){
         },
         selectable: true
     };
+    layout = LocusZoom.mergeLayouts(layout, this.DefaultLayout);
 
-    this.layout = LocusZoom.mergeLayouts(layout, this.DefaultLayout);
+    // Apply the arguments to set LocusZoom.DataLayer as the prototype
+    LocusZoom.DataLayer.apply(this, arguments);
 
     // Reimplement the positionTooltip() method to be scatter-specific
     this.positionTooltip = function(id){
@@ -440,37 +438,37 @@ LocusZoom.DataLayers.add("scatter", function(id, layout){
         if (this.layout.selectable && (this.layout.fields.indexOf("id") != -1)){
             selection.on("mouseover", function(d){
                 var id = 's' + d.id.replace(/\W/g,'');
-                if (this.layout.state.selected_id != id){
+                if (this.state[this.state_id].selected != id){
                     d3.select("#" + id).attr("class", "lz-data_layer-scatter-hovered");
                     if (this.layout.tooltip){ this.createTooltip(d, id); }
                 }
             }.bind(this))
             .on("mouseout", function(d){
                 var id = 's' + d.id.replace(/\W/g,'');
-                if (this.layout.state.selected_id != id){
+                if (this.state[this.state_id].selected != id){
                     d3.select("#" + id).attr("class", "lz-data_layer-scatter");
                     if (this.layout.tooltip){ this.destroyTooltip(id); }
                 }
             }.bind(this))
             .on("click", function(d){
                 var id = 's' + d.id.replace(/\W/g,'');
-                if (this.layout.state.selected_id == id){
-                    this.layout.state.selected_id = null;
+                if (this.state[this.state_id].selected == id){
+                    this.state[this.state_id].selected = null;
                     d3.select("#" + id).attr("class", "lz-data_layer-scatter-hovered");
                 } else {
-                    if (this.layout.state.selected_id != null){
-                        d3.select("#" + this.layout.state.selected_id).attr("class", "lz-data_layer-scatter");
-                        if (this.layout.tooltip){ this.destroyTooltip(this.layout.state.selected_id); }
+                    if (this.state[this.state_id].selected != null){
+                        d3.select("#" + this.state[this.state_id].selected).attr("class", "lz-data_layer-scatter");
+                        if (this.layout.tooltip){ this.destroyTooltip(this.state[this.state_id].selected); }
                     }
-                    this.layout.state.selected_id = id;
+                    this.state[this.state_id].selected = id;
                     d3.select("#" + id).attr("class", "lz-data_layer-scatter-selected");
                 }
                 this.triggerOnUpdate();
             }.bind(this));
             // Apply existing selection from state
-            if (this.layout.state.selected_id != null){
-                var selected_id = this.layout.state.selected_id;
-                this.layout.state.selected_id = null;
+            if (this.state[this.state_id].selected != null){
+                var selected_id = this.state[this.state_id].selected;
+                this.state[this.state_id].selected = null;
                 var d = d3.select("#" + selected_id).datum();
                 d3.select("#" + selected_id).on("mouseover")(d);
                 d3.select("#" + selected_id).on("click")(d);
@@ -487,14 +485,10 @@ LocusZoom.DataLayers.add("scatter", function(id, layout){
   Implements a data layer that will render gene tracks
 */
 
-LocusZoom.DataLayers.add("genes", function(id, layout){
+LocusZoom.DataLayers.add("genes", function(id, layout, parent){
 
-    LocusZoom.DataLayer.apply(this, arguments);
-
+    // Define a default layout for this DataLayer type and merge it with the passed argument
     this.DefaultLayout = {
-        state: {
-            selected_id: null
-        },
         label_font_size: 12,
         label_exon_spacing: 4,
         exon_height: 16,
@@ -502,8 +496,10 @@ LocusZoom.DataLayers.add("genes", function(id, layout){
         track_vertical_spacing: 10,
         selectable: true
     };
+    layout = LocusZoom.mergeLayouts(layout, this.DefaultLayout);
 
-    this.layout = LocusZoom.mergeLayouts(layout, this.DefaultLayout);
+    // Apply the arguments to set LocusZoom.DataLayer as the prototype
+    LocusZoom.DataLayer.apply(this, arguments);
     
     // Helper function to sum layout values to derive total height for a single gene track
     this.getTrackHeight = function(){
@@ -774,37 +770,37 @@ LocusZoom.DataLayers.add("genes", function(id, layout){
                     clickarea
                         .on("mouseover", function(d){
                             var id = 'g' + d.gene_name.replace(/\W/g,'');
-                            if (this.layout.state.selected_id != id){
+                            if (this.state[this.state_id].selected != id){
                                 d3.select("#" + id + "_bounding_box").attr("class", "lz-data_layer-gene lz-bounding_box-hovered");
                                 if (this.layout.tooltip){ this.createTooltip(d, id); }
                             }
                         }.bind(gene.parent))
                         .on("mouseout", function(d){
                             var id = 'g' + d.gene_name.replace(/\W/g,'');
-                            if (this.layout.state.selected_id != id){
+                            if (this.state[this.state_id].selected != id){
                                 d3.select("#" + id + "_bounding_box").attr("class", "lz-data_layer-gene lz-bounding_box");
                                 if (this.layout.tooltip){ this.destroyTooltip(id); }
                             }
                         }.bind(gene.parent))
                         .on("click", function(d){
                             var id = 'g' + d.gene_name.replace(/\W/g,'');
-                            if (this.layout.state.selected_id == id){
-                                this.layout.state.selected_id = null;
+                            if (this.state[this.state_id].selected == id){
+                                this.state[this.state_id].selected = null;
                                 d3.select("#" + id + "_bounding_box").attr("class", "lz-data_layer-gene lz-bounding_box-hovered");
                             } else {
-                                if (this.layout.state.selected_id != null){
-                                    d3.select("#" + this.layout.state.selected_id + "_bounding_box").attr("class", "lz-data_layer-gene lz-bounding_box");
-                                    if (this.layout.tooltip){ this.destroyTooltip(this.layout.state.selected_id); }
+                                if (this.state[this.state_id].selected != null){
+                                    d3.select("#" + this.state[this.state_id].selected + "_bounding_box").attr("class", "lz-data_layer-gene lz-bounding_box");
+                                    if (this.layout.tooltip){ this.destroyTooltip(this.state[this.state_id].selected); }
                                 }
-                                this.layout.state.selected_id = id;
+                                this.state[this.state_id].selected = id;
                                 d3.select("#" + id + "_bounding_box").attr("class", "lz-data_layer-gene lz-bounding_box-selected");
                             }
                             this.triggerOnUpdate();
                         }.bind(gene.parent));
                     // Apply existing selection from state
-                    if (gene.parent.layout.state.selected_id != null){
-                        var selected_id = gene.parent.layout.state.selected_id + "_clickarea";
-                        gene.parent.layout.state.selected_id = null;
+                    if (gene.parent.state[gene.parent.state_id].selected != null){
+                        var selected_id = gene.parent.state[gene.parent.state_id].selected + "_clickarea";
+                        gene.parent.state[gene.parent.state_id].selected = null;
                         var d = d3.select("#" + selected_id).datum();
                         d3.select("#" + selected_id).on("mouseover")(d);
                         d3.select("#" + selected_id).on("click")(d);

--- a/assets/js/app/Singletons.js
+++ b/assets/js/app/Singletons.js
@@ -275,15 +275,14 @@ LocusZoom.DataLayers = (function() {
     var obj = {};
     var datalayers = {};
 
-    obj.get = function(name, id, layout, state) {
+    obj.get = function(name, id, layout) {
         if (!name) {
             return null;
         } else if (datalayers[name]) {
             if (typeof id == "undefined" || typeof layout == "undefined"){
                 throw("id or layout argument missing for data layer [" + name + "]");
             } else {
-                state = LocusZoom.mergeLayouts(state || {}, LocusZoom.DataLayer.DefaultState);
-                return new datalayers[name](id, layout, state);
+                return new datalayers[name](id, layout);
             }
         } else {
             throw("data layer [" + name + "] not found");
@@ -325,15 +324,14 @@ LocusZoom.DataLayers = (function() {
   Implements a standard scatter plot
 */
 
-LocusZoom.DataLayers.add("scatter", function(id, layout, state){
+LocusZoom.DataLayers.add("scatter", function(id, layout){
 
     LocusZoom.DataLayer.apply(this, arguments);
 
-    this.DefaultState = {
-        selected_id: null
-    };
-
     this.DefaultLayout = {
+        state: {
+            selected_id: null
+        },
         point_size: 40,
         point_shape: "circle",
         color: "#888888",
@@ -344,7 +342,6 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, state){
     };
 
     this.layout = LocusZoom.mergeLayouts(layout, this.DefaultLayout);
-    this.state = LocusZoom.mergeLayouts(state, this.DefaultState);
 
     // Reimplement the positionTooltip() method to be scatter-specific
     this.positionTooltip = function(id){
@@ -443,37 +440,37 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, state){
         if (this.layout.selectable && (this.layout.fields.indexOf("id") != -1)){
             selection.on("mouseover", function(d){
                 var id = 's' + d.id.replace(/\W/g,'');
-                if (this.state.selected_id != id){
+                if (this.layout.state.selected_id != id){
                     d3.select("#" + id).attr("class", "lz-data_layer-scatter-hovered");
                     if (this.layout.tooltip){ this.createTooltip(d, id); }
                 }
             }.bind(this))
             .on("mouseout", function(d){
                 var id = 's' + d.id.replace(/\W/g,'');
-                if (this.state.selected_id != id){
+                if (this.layout.state.selected_id != id){
                     d3.select("#" + id).attr("class", "lz-data_layer-scatter");
                     if (this.layout.tooltip){ this.destroyTooltip(id); }
                 }
             }.bind(this))
             .on("click", function(d){
                 var id = 's' + d.id.replace(/\W/g,'');
-                if (this.state.selected_id == id){
-                    this.state.selected_id = null;
+                if (this.layout.state.selected_id == id){
+                    this.layout.state.selected_id = null;
                     d3.select("#" + id).attr("class", "lz-data_layer-scatter-hovered");
                 } else {
-                    if (this.state.selected_id != null){
-                        d3.select("#" + this.state.selected_id).attr("class", "lz-data_layer-scatter");
-                        if (this.layout.tooltip){ this.destroyTooltip(this.state.selected_id); }
+                    if (this.layout.state.selected_id != null){
+                        d3.select("#" + this.layout.state.selected_id).attr("class", "lz-data_layer-scatter");
+                        if (this.layout.tooltip){ this.destroyTooltip(this.layout.state.selected_id); }
                     }
-                    this.state.selected_id = id;
+                    this.layout.state.selected_id = id;
                     d3.select("#" + id).attr("class", "lz-data_layer-scatter-selected");
                 }
                 this.triggerOnUpdate();
             }.bind(this));
             // Apply existing selection from state
-            if (this.state.selected_id != null){
-                var selected_id = this.state.selected_id;
-                this.state.selected_id = null;
+            if (this.layout.state.selected_id != null){
+                var selected_id = this.layout.state.selected_id;
+                this.layout.state.selected_id = null;
                 var d = d3.select("#" + selected_id).datum();
                 d3.select("#" + selected_id).on("mouseover")(d);
                 d3.select("#" + selected_id).on("click")(d);
@@ -490,15 +487,14 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, state){
   Implements a data layer that will render gene tracks
 */
 
-LocusZoom.DataLayers.add("genes", function(id, layout, state){
+LocusZoom.DataLayers.add("genes", function(id, layout){
 
     LocusZoom.DataLayer.apply(this, arguments);
 
-    this.DefaultState = {
-        selected_id: null
-    };
-
     this.DefaultLayout = {
+        state: {
+            selected_id: null
+        },
         label_font_size: 12,
         label_exon_spacing: 4,
         exon_height: 16,
@@ -508,7 +504,6 @@ LocusZoom.DataLayers.add("genes", function(id, layout, state){
     };
 
     this.layout = LocusZoom.mergeLayouts(layout, this.DefaultLayout);
-    this.state = LocusZoom.mergeLayouts(state, this.DefaultState);
     
     // Helper function to sum layout values to derive total height for a single gene track
     this.getTrackHeight = function(){
@@ -562,20 +557,20 @@ LocusZoom.DataLayers.add("genes", function(id, layout, state){
             // Determine display range start and end, based on minimum allowable gene display width, bounded by what we can see
             // (range: values in terms of pixels on the screen)
             this.data[g].display_range = {
-                start: this.parent.x_scale(Math.max(d.start, this.parent.parent.state.start)),
-                end:   this.parent.x_scale(Math.min(d.end, this.parent.parent.state.end))
+                start: this.parent.x_scale(Math.max(d.start, this.parent.parent.layout.state.start)),
+                end:   this.parent.x_scale(Math.min(d.end, this.parent.parent.layout.state.end))
             };
             this.data[g].display_range.label_width = this.getLabelWidth(this.data[g].gene_name, this.layout.label_font_size);
             this.data[g].display_range.width = this.data[g].display_range.end - this.data[g].display_range.start;
             // Determine label text anchor (default to middle)
             this.data[g].display_range.text_anchor = "middle";
             if (this.data[g].display_range.width < this.data[g].display_range.label_width){
-                if (d.start < this.parent.parent.state.start){
+                if (d.start < this.parent.parent.layout.state.start){
                     this.data[g].display_range.end = this.data[g].display_range.start
                         + this.data[g].display_range.label_width
                         + this.metadata.horizontal_padding;
                     this.data[g].display_range.text_anchor = "start";
-                } else if (d.end > this.parent.parent.state.end){
+                } else if (d.end > this.parent.parent.layout.state.end){
                     this.data[g].display_range.start = this.data[g].display_range.end
                         - this.data[g].display_range.label_width
                         - this.metadata.horizontal_padding;
@@ -583,12 +578,12 @@ LocusZoom.DataLayers.add("genes", function(id, layout, state){
                 } else {
                     var centered_margin = ((this.data[g].display_range.label_width - this.data[g].display_range.width) / 2)
                         + this.metadata.horizontal_padding;
-                    if ((this.data[g].display_range.start - centered_margin) < this.parent.x_scale(this.parent.parent.state.start)){
-                        this.data[g].display_range.start = this.parent.x_scale(this.parent.parent.state.start);
+                    if ((this.data[g].display_range.start - centered_margin) < this.parent.x_scale(this.parent.parent.layout.state.start)){
+                        this.data[g].display_range.start = this.parent.x_scale(this.parent.parent.layout.state.start);
                         this.data[g].display_range.end = this.data[g].display_range.start + this.data[g].display_range.label_width;
                         this.data[g].display_range.text_anchor = "start";
-                    } else if ((this.data[g].display_range.end + centered_margin) > this.parent.x_scale(this.parent.parent.state.end)) {
-                        this.data[g].display_range.end = this.parent.x_scale(this.parent.parent.state.end);
+                    } else if ((this.data[g].display_range.end + centered_margin) > this.parent.x_scale(this.parent.parent.layout.state.end)) {
+                        this.data[g].display_range.end = this.parent.x_scale(this.parent.parent.layout.state.end);
                         this.data[g].display_range.start = this.data[g].display_range.end - this.data[g].display_range.label_width;
                         this.data[g].display_range.text_anchor = "end";
                     } else {
@@ -779,37 +774,37 @@ LocusZoom.DataLayers.add("genes", function(id, layout, state){
                     clickarea
                         .on("mouseover", function(d){
                             var id = 'g' + d.gene_name.replace(/\W/g,'');
-                            if (this.state.selected_id != id){
+                            if (this.layout.state.selected_id != id){
                                 d3.select("#" + id + "_bounding_box").attr("class", "lz-data_layer-gene lz-bounding_box-hovered");
                                 if (this.layout.tooltip){ this.createTooltip(d, id); }
                             }
                         }.bind(gene.parent))
                         .on("mouseout", function(d){
                             var id = 'g' + d.gene_name.replace(/\W/g,'');
-                            if (this.state.selected_id != id){
+                            if (this.layout.state.selected_id != id){
                                 d3.select("#" + id + "_bounding_box").attr("class", "lz-data_layer-gene lz-bounding_box");
                                 if (this.layout.tooltip){ this.destroyTooltip(id); }
                             }
                         }.bind(gene.parent))
                         .on("click", function(d){
                             var id = 'g' + d.gene_name.replace(/\W/g,'');
-                            if (this.state.selected_id == id){
-                                this.state.selected_id = null;
+                            if (this.layout.state.selected_id == id){
+                                this.layout.state.selected_id = null;
                                 d3.select("#" + id + "_bounding_box").attr("class", "lz-data_layer-gene lz-bounding_box-hovered");
                             } else {
-                                if (this.state.selected_id != null){
-                                    d3.select("#" + this.state.selected_id + "_bounding_box").attr("class", "lz-data_layer-gene lz-bounding_box");
-                                    if (this.layout.tooltip){ this.destroyTooltip(this.state.selected_id); }
+                                if (this.layout.state.selected_id != null){
+                                    d3.select("#" + this.layout.state.selected_id + "_bounding_box").attr("class", "lz-data_layer-gene lz-bounding_box");
+                                    if (this.layout.tooltip){ this.destroyTooltip(this.layout.state.selected_id); }
                                 }
-                                this.state.selected_id = id;
+                                this.layout.state.selected_id = id;
                                 d3.select("#" + id + "_bounding_box").attr("class", "lz-data_layer-gene lz-bounding_box-selected");
                             }
                             this.triggerOnUpdate();
                         }.bind(gene.parent));
                     // Apply existing selection from state
-                    if (gene.parent.state.selected_id != null){
-                        var selected_id = gene.parent.state.selected_id + "_clickarea";
-                        gene.parent.state.selected_id = null;
+                    if (gene.parent.layout.state.selected_id != null){
+                        var selected_id = gene.parent.layout.state.selected_id + "_clickarea";
+                        gene.parent.layout.state.selected_id = null;
                         var d = d3.select("#" + selected_id).datum();
                         d3.select("#" + selected_id).on("mouseover")(d);
                         d3.select("#" + selected_id).on("click")(d);

--- a/assets/js/app/Singletons.js
+++ b/assets/js/app/Singletons.js
@@ -468,6 +468,7 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, state){
                     this.state.selected_id = id;
                     d3.select("#" + id).attr("class", "lz-data_layer-scatter-selected");
                 }
+                this.triggerOnUpdate();
             }.bind(this));
             // Apply existing selection from state
             if (this.state.selected_id != null){
@@ -799,6 +800,7 @@ LocusZoom.DataLayers.add("genes", function(id, layout, state){
                                 this.state.selected_id = id;
                                 d3.select("#" + id + "_bounding_box").attr("class", "lz-data_layer-gene lz-bounding_box-selected");
                             }
+                            this.triggerOnUpdate();
                         }.bind(gene.parent));
                     // Apply existing selection from state
                     if (gene.parent.state.selected_id != null){

--- a/assets/js/app/Singletons.js
+++ b/assets/js/app/Singletons.js
@@ -472,13 +472,17 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, parent){
             if (this.state[this.state_id].selected != null){
                 var selected_id = this.state[this.state_id].selected;
                 if (d3.select("#" + selected_id).empty()){
-                    console.warn("Pre-defined state selection for " + this.state_id + " contains an ID that is not present on the plot: " + this.state[this.state_id].selected);
+                    console.warn("State selection for " + this.state_id + " contains an ID that is not or is no longer present on the plot: " + this.state[this.state_id].selected);
                     this.state[this.state_id].selected = null;
                 } else {
-                    this.state[this.state_id].selected = null;
-                    var d = d3.select("#" + selected_id).datum();
-                    d3.select("#" + selected_id).on("mouseover")(d);
-                    d3.select("#" + selected_id).on("click")(d);
+                    if (this.tooltips[this.state[this.state_id].selected]){
+                        this.positionTooltip(this.state[this.state_id].selected);
+                    } else {
+                        this.state[this.state_id].selected = null;
+                        var d = d3.select("#" + selected_id).datum();
+                        d3.select("#" + selected_id).on("mouseover")(d);
+                        d3.select("#" + selected_id).on("click")(d);
+                    }
                 }
             }
         }
@@ -812,13 +816,17 @@ LocusZoom.DataLayers.add("genes", function(id, layout, parent){
                     if (gene.parent.state[gene.parent.state_id].selected != null){
                         var selected_id = gene.parent.state[gene.parent.state_id].selected + "_clickarea";
                         if (d3.select("#" + selected_id).empty()){
-                            console.warn("Pre-defined state selection for " + gene.parent.state_id + " contains an ID that is not present on the plot: " + gene.parent.state[gene.parent.state_id].selected);
+                            console.warn("Pre-defined state selection for " + gene.parent.state_id + " contains an ID that is not or is no longer present on the plot: " + gene.parent.state[gene.parent.state_id].selected);
                             gene.parent.state[gene.parent.state_id].selected = null;
                         } else {
-                            gene.parent.state[gene.parent.state_id].selected = null;
-                            var d = d3.select("#" + selected_id).datum();
-                            d3.select("#" + selected_id).on("mouseover")(d);
-                            d3.select("#" + selected_id).on("click")(d);
+                            if (gene.parent.tooltips[gene.parent.state[gene.parent.state_id].selected]){
+                                gene.parent.positionTooltip(gene.parent.state[gene.parent.state_id].selected);
+                            } else {
+                                gene.parent.state[gene.parent.state_id].selected = null;
+                                var d = d3.select("#" + selected_id).datum();
+                                d3.select("#" + selected_id).on("mouseover")(d);
+                                d3.select("#" + selected_id).on("click")(d);
+                            }
                         }
                     }
                 }

--- a/assets/js/app/Singletons.js
+++ b/assets/js/app/Singletons.js
@@ -471,10 +471,15 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, parent){
             // Apply existing selection from state
             if (this.state[this.state_id].selected != null){
                 var selected_id = this.state[this.state_id].selected;
-                this.state[this.state_id].selected = null;
-                var d = d3.select("#" + selected_id).datum();
-                d3.select("#" + selected_id).on("mouseover")(d);
-                d3.select("#" + selected_id).on("click")(d);
+                if (d3.select("#" + selected_id).empty()){
+                    console.warn("Pre-defined state selection for " + this.state_id + " contains an ID that is not present on the plot: " + this.state[this.state_id].selected);
+                    this.state[this.state_id].selected = null;
+                } else {
+                    this.state[this.state_id].selected = null;
+                    var d = d3.select("#" + selected_id).datum();
+                    d3.select("#" + selected_id).on("mouseover")(d);
+                    d3.select("#" + selected_id).on("click")(d);
+                }
             }
         }
         
@@ -806,10 +811,15 @@ LocusZoom.DataLayers.add("genes", function(id, layout, parent){
                     // Apply existing selection from state
                     if (gene.parent.state[gene.parent.state_id].selected != null){
                         var selected_id = gene.parent.state[gene.parent.state_id].selected + "_clickarea";
-                        gene.parent.state[gene.parent.state_id].selected = null;
-                        var d = d3.select("#" + selected_id).datum();
-                        d3.select("#" + selected_id).on("mouseover")(d);
-                        d3.select("#" + selected_id).on("click")(d);
+                        if (d3.select("#" + selected_id).empty()){
+                            console.warn("Pre-defined state selection for " + gene.parent.state_id + " contains an ID that is not present on the plot: " + gene.parent.state[gene.parent.state_id].selected);
+                            gene.parent.state[gene.parent.state_id].selected = null;
+                        } else {
+                            gene.parent.state[gene.parent.state_id].selected = null;
+                            var d = d3.select("#" + selected_id).datum();
+                            d3.select("#" + selected_id).on("mouseover")(d);
+                            d3.select("#" + selected_id).on("click")(d);
+                        }
                     }
                 }
 

--- a/demo.html
+++ b/demo.html
@@ -50,6 +50,7 @@
     var layout = {
       resizable: "manual"
     };
+    layout = LocusZoom.mergeLayouts(layout, LocusZoom.StandardLayout);
 
     // Populate the div with a LocusZoom plot using the default layout
     var demo_instance = LocusZoom.populate("#lz-1", data_sources, layout);

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -2173,10 +2173,15 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, parent){
             // Apply existing selection from state
             if (this.state[this.state_id].selected != null){
                 var selected_id = this.state[this.state_id].selected;
-                this.state[this.state_id].selected = null;
-                var d = d3.select("#" + selected_id).datum();
-                d3.select("#" + selected_id).on("mouseover")(d);
-                d3.select("#" + selected_id).on("click")(d);
+                if (d3.select("#" + selected_id).empty()){
+                    console.warn("Pre-defined state selection for " + this.state_id + " contains an ID that is not present on the plot: " + this.state[this.state_id].selected);
+                    this.state[this.state_id].selected = null;
+                } else {
+                    this.state[this.state_id].selected = null;
+                    var d = d3.select("#" + selected_id).datum();
+                    d3.select("#" + selected_id).on("mouseover")(d);
+                    d3.select("#" + selected_id).on("click")(d);
+                }
             }
         }
         
@@ -2508,10 +2513,15 @@ LocusZoom.DataLayers.add("genes", function(id, layout, parent){
                     // Apply existing selection from state
                     if (gene.parent.state[gene.parent.state_id].selected != null){
                         var selected_id = gene.parent.state[gene.parent.state_id].selected + "_clickarea";
-                        gene.parent.state[gene.parent.state_id].selected = null;
-                        var d = d3.select("#" + selected_id).datum();
-                        d3.select("#" + selected_id).on("mouseover")(d);
-                        d3.select("#" + selected_id).on("click")(d);
+                        if (d3.select("#" + selected_id).empty()){
+                            console.warn("Pre-defined state selection for " + gene.parent.state_id + " contains an ID that is not present on the plot: " + gene.parent.state[gene.parent.state_id].selected);
+                            gene.parent.state[gene.parent.state_id].selected = null;
+                        } else {
+                            gene.parent.state[gene.parent.state_id].selected = null;
+                            var d = d3.select("#" + selected_id).datum();
+                            d3.select("#" + selected_id).on("mouseover")(d);
+                            d3.select("#" + selected_id).on("click")(d);
+                        }
                     }
                 }
 

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -30,6 +30,7 @@ LocusZoom.populate = function(selector, datasource, layout, state) {
     d3.select(selector).html("");
     // If state was passed as a fourth argument then merge it with layout (for backward compatibility)
     if (typeof state != "undefined"){
+        console.warn("Warning: state passed to LocusZoom.populate as fourth argument. This behavior is deprecated. Please include state as a parameter of layout");
         var stateful_layout = { state: state };
         var base_layout = layout || {};
         layout = LocusZoom.mergeLayouts(stateful_layout, base_layout);
@@ -73,7 +74,7 @@ LocusZoom.populate = function(selector, datasource, layout, state) {
 LocusZoom.populateAll = function(selector, datasource, layout, state) {
     var instances = [];
     d3.selectAll(selector).each(function(d,i) {
-        instances[i] = LocusZoom.populate(this, datasource, layout);
+        instances[i] = LocusZoom.populate(this, datasource, layout, state);
     });
     return instances;
 };
@@ -974,7 +975,7 @@ LocusZoom.Instance.prototype.initialize = function(){
                             this.raise();
                         }.bind(this));
                 } catch (e){
-                    console.warn("LocusZoom tried to render an error message but it's not a string:", message);
+                    console.error("LocusZoom tried to render an error message but it's not a string:", message);
                 }
             }
         },
@@ -1251,7 +1252,7 @@ LocusZoom.Panel.prototype.initialize = function(){
                             this.raise();
                         }.bind(this));
                 } catch (e){
-                    console.warn("LocusZoom tried to render an error message but it's not a string:", message);
+                    console.error("LocusZoom tried to render an error message but it's not a string:", message);
                 }
             }
         },

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -1558,7 +1558,7 @@ LocusZoom.DataLayer = function(id, layout, parent) {
             arrow: null,
             selector: d3.select(this.parent.parent.svg.node().parentNode).append("div")
                 .attr("class", "lz-data_layer-tooltip")
-                .attr("id", this.parent.getBaseId() + ".tooltip." + id)
+                .attr("id", this.getBaseId() + ".tooltip." + id)
         }
         if (this.layout.tooltip.html){
             this.tooltips[id].selector.html(LocusZoom.parseFields(d, this.layout.tooltip.html));
@@ -2174,13 +2174,17 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, parent){
             if (this.state[this.state_id].selected != null){
                 var selected_id = this.state[this.state_id].selected;
                 if (d3.select("#" + selected_id).empty()){
-                    console.warn("Pre-defined state selection for " + this.state_id + " contains an ID that is not present on the plot: " + this.state[this.state_id].selected);
+                    console.warn("State selection for " + this.state_id + " contains an ID that is not or is no longer present on the plot: " + this.state[this.state_id].selected);
                     this.state[this.state_id].selected = null;
                 } else {
-                    this.state[this.state_id].selected = null;
-                    var d = d3.select("#" + selected_id).datum();
-                    d3.select("#" + selected_id).on("mouseover")(d);
-                    d3.select("#" + selected_id).on("click")(d);
+                    if (this.tooltips[this.state[this.state_id].selected]){
+                        this.positionTooltip(this.state[this.state_id].selected);
+                    } else {
+                        this.state[this.state_id].selected = null;
+                        var d = d3.select("#" + selected_id).datum();
+                        d3.select("#" + selected_id).on("mouseover")(d);
+                        d3.select("#" + selected_id).on("click")(d);
+                    }
                 }
             }
         }
@@ -2514,13 +2518,17 @@ LocusZoom.DataLayers.add("genes", function(id, layout, parent){
                     if (gene.parent.state[gene.parent.state_id].selected != null){
                         var selected_id = gene.parent.state[gene.parent.state_id].selected + "_clickarea";
                         if (d3.select("#" + selected_id).empty()){
-                            console.warn("Pre-defined state selection for " + gene.parent.state_id + " contains an ID that is not present on the plot: " + gene.parent.state[gene.parent.state_id].selected);
+                            console.warn("Pre-defined state selection for " + gene.parent.state_id + " contains an ID that is not or is no longer present on the plot: " + gene.parent.state[gene.parent.state_id].selected);
                             gene.parent.state[gene.parent.state_id].selected = null;
                         } else {
-                            gene.parent.state[gene.parent.state_id].selected = null;
-                            var d = d3.select("#" + selected_id).datum();
-                            d3.select("#" + selected_id).on("mouseover")(d);
-                            d3.select("#" + selected_id).on("click")(d);
+                            if (gene.parent.tooltips[gene.parent.state[gene.parent.state_id].selected]){
+                                gene.parent.positionTooltip(gene.parent.state[gene.parent.state_id].selected);
+                            } else {
+                                gene.parent.state[gene.parent.state_id].selected = null;
+                                var d = d3.select("#" + selected_id).datum();
+                                d3.select("#" + selected_id).on("mouseover")(d);
+                                d3.select("#" + selected_id).on("click")(d);
+                            }
                         }
                     }
                 }

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -17,12 +17,12 @@
 /* eslint-disable no-console */
 
 var LocusZoom = {
-    version: "0.3.6"
+    version: "0.3.7"
 };
     
 // Populate a single element with a LocusZoom instance.
 // selector can be a string for a DOM Query or a d3 selector.
-LocusZoom.populate = function(selector, datasource, layout, state) {
+LocusZoom.populate = function(selector, datasource, layout) {
     if (typeof selector == "undefined"){
         throw ("LocusZoom.populate selector not defined");
     }
@@ -37,7 +37,7 @@ LocusZoom.populate = function(selector, datasource, layout, state) {
             this.attr("id", "#lz-" + iterator);
         }
         // Create the instance
-        instance = new LocusZoom.Instance(this.node().id, datasource, layout, state);
+        instance = new LocusZoom.Instance(this.node().id, datasource, layout);
         // Add an SVG to the div and set its dimensions
         instance.svg = d3.select("div#" + instance.id)
             .append("svg")
@@ -49,11 +49,7 @@ LocusZoom.populate = function(selector, datasource, layout, state) {
         instance.initialize();
         // Detect data-region and fill in state values if present
         if (typeof this.node().dataset !== "undefined" && typeof this.node().dataset.region !== "undefined"){
-            var region = LocusZoom.parsePositionQuery(this.node().dataset.region);
-            var attr;
-            for (attr in region){
-                instance.state[attr] = region[attr];
-            }
+            instance.layout.state = LocusZoom.mergeLayouts(LocusZoom.parsePositionQuery(this.node().dataset.region), instance.layout.state);
         }
         // If the instance has defined data sources then trigger its first mapping based on state values
         if (typeof datasource == "object" && Object.keys(datasource).length){
@@ -65,10 +61,10 @@ LocusZoom.populate = function(selector, datasource, layout, state) {
 
 // Populate arbitrarily many elements each with a LocusZoom instance
 // using a common datasource, layout, and/or state
-LocusZoom.populateAll = function(selector, datasource, layout, state) {
+LocusZoom.populateAll = function(selector, datasource, layout) {
     var instances = [];
     d3.selectAll(selector).each(function(d,i) {
-        instances[i] = LocusZoom.populate(this, datasource, layout, state);
+        instances[i] = LocusZoom.populate(this, datasource, layout);
     });
     return instances;
 };
@@ -292,17 +288,10 @@ LocusZoom.parseFields = function (data, html) {
     }
     return html;
 };
-    
-// Default State
-LocusZoom.DefaultState = {
-    chr: 0,
-    start: 0,
-    end: 0,
-    panels: {}
-};
 
 // Default Layout
 LocusZoom.DefaultLayout = {
+    state: {},
     width: 1,
     height: 1,
     min_width: 1,
@@ -314,6 +303,11 @@ LocusZoom.DefaultLayout = {
 
 // Standard Layout
 LocusZoom.StandardLayout = {
+    state: {
+        chr: 0,
+        start: 0,
+        end: 0
+    },
     width: 800,
     height: 450,
     min_width: 400,
@@ -708,11 +702,11 @@ LocusZoom.KnownDataSources = [
   LocusZoom.Instance Class
 
   An Instance is an independent LocusZoom object. Many such LocusZoom objects can exist simultaneously
-  on a single page, each having its own layout, data sources, and state.
+  on a single page, each having its own layout.
 
 */
 
-LocusZoom.Instance = function(id, datasource, layout, state) {
+LocusZoom.Instance = function(id, datasource, layout) {
 
     this.initialized = false;
 
@@ -728,20 +722,9 @@ LocusZoom.Instance = function(id, datasource, layout, state) {
     // If no layout was passed, use the Standard Layout
     // Otherwise merge whatever was passed with the Default Layout
     if (typeof layout == "undefined"){
-        this.layout = LocusZoom.mergeLayouts({}, LocusZoom.StandardLayout);
+        this.layout = LocusZoom.mergeLayouts(LocusZoom.StandardLayout, LocusZoom.DefaultLayout);
     } else {
         this.layout = LocusZoom.mergeLayouts(layout, LocusZoom.DefaultLayout);
-    }
-    
-    // The state property stores any parameters subject to change via user input
-    // At this step pre-parse layouts for panels and data layers and make sure they're all present in the state
-    this.state = LocusZoom.mergeLayouts(state || {}, LocusZoom.DefaultState);
-    var panel_id, data_layer_id;
-    for (panel_id in this.layout.panels){
-        this.state.panels[panel_id] = LocusZoom.mergeLayouts(this.state.panels[panel_id] || {}, LocusZoom.Panel.DefaultState);
-        for (data_layer_id in this.layout.panels[panel_id].data_layers){
-            this.state.panels[panel_id].data_layers[data_layer_id] = LocusZoom.mergeLayouts(this.state.panels[panel_id].data_layers[data_layer_id] || {}, LocusZoom.DataLayer.DefaultState);
-        }
     }
     
     // LocusZoom.Data.Requester
@@ -796,7 +779,7 @@ LocusZoom.Instance.prototype.initializeLayout = function(){
     // Add panels
     var panel_id;
     for (panel_id in this.layout.panels){
-        this.addPanel(panel_id, this.layout.panels[panel_id], this.state.panels[panel_id]);
+        this.addPanel(panel_id, this.layout.panels[panel_id]);
     }
 
 };
@@ -1033,9 +1016,9 @@ LocusZoom.Instance.prototype.mapTo = function(chr, start, end){
 
     // Apply new state values
     // TODO: preserve existing state until new state is completely loaded+rendered or aborted?
-    this.state.chr   = +chr;
-    this.state.start = +start;
-    this.state.end   = +end;
+    this.layout.state.chr   = +chr;
+    this.layout.state.start = +start;
+    this.layout.state.end   = +end;
 
     this.remap_promises = [];
     // Trigger reMap on each Panel Layer
@@ -1048,7 +1031,9 @@ LocusZoom.Instance.prototype.mapTo = function(chr, start, end){
             console.log(error);
             this.curtain.drop(error);
         }.bind(this))
-        .done(this.triggerOnUpdate);
+        .done(function(){
+            this.triggerOnUpdate()
+        }.bind(this));
 
     return this;
     
@@ -1056,7 +1041,7 @@ LocusZoom.Instance.prototype.mapTo = function(chr, start, end){
 
 // Refresh an instance's data from sources without changing position
 LocusZoom.Instance.prototype.refresh = function(){
-    this.mapTo(this.state.chr, this.state.start, this.state.end);
+    this.mapTo(this.layout.state.chr, this.layout.state.start, this.layout.state.end);
 };
 
 /* global d3,Q,LocusZoom */
@@ -1084,9 +1069,6 @@ LocusZoom.Panel = function(id, layout, state) {
 
     // The layout is a serializable object used to describe the composition of the Panel
     this.layout = LocusZoom.mergeLayouts(layout || {}, LocusZoom.Panel.DefaultLayout);
-
-    // The state property stores any parameters subject to change via user input
-    this.state = LocusZoom.mergeLayouts(state || {}, LocusZoom.Panel.DefaultState);
     
     this.data_layers = {};
     this.data_layer_ids_by_z_index = [];
@@ -1111,11 +1093,10 @@ LocusZoom.Panel = function(id, layout, state) {
     
 };
 
-LocusZoom.Panel.DefaultState = {
-    data_layers: {}   
-};
-
 LocusZoom.Panel.DefaultLayout = {
+    state: {
+        data_layers: {}   
+    },
     width:  0,
     height: 0,
     origin: { x: 0, y: 0 },
@@ -1134,7 +1115,7 @@ LocusZoom.Panel.DefaultLayout = {
         x:  {},
         y1: {},
         y2: {}
-    }            
+    }
 };
 
 LocusZoom.Panel.prototype.initializeLayout = function(){
@@ -1162,7 +1143,7 @@ LocusZoom.Panel.prototype.initializeLayout = function(){
     if (typeof this.layout.data_layers == "object"){
         var data_layer_id;
         for (data_layer_id in this.layout.data_layers){
-            this.addDataLayer(data_layer_id, this.layout.data_layers[data_layer_id], this.state.data_layers[data_layer_id]);
+            this.addDataLayer(data_layer_id, this.layout.data_layers[data_layer_id]);
         }
     }
 
@@ -1305,7 +1286,7 @@ LocusZoom.Panel.prototype.initialize = function(){
 
 
 // Create a new data layer by layout object
-LocusZoom.Panel.prototype.addDataLayer = function(id, layout, state){
+LocusZoom.Panel.prototype.addDataLayer = function(id, layout){
     if (typeof id !== "string"){
         throw "Invalid data layer id passed to LocusZoom.Panel.prototype.addDataLayer()";
     }
@@ -1320,7 +1301,7 @@ LocusZoom.Panel.prototype.addDataLayer = function(id, layout, state){
     }
 
     // Create the Data Layer and set its parent 
-    var data_layer = LocusZoom.DataLayers.get(layout.type, id, layout, state);
+    var data_layer = LocusZoom.DataLayers.get(layout.type, id, layout);
     data_layer.parent = this;
 
     // Store the Data Layer on the Panel
@@ -1332,7 +1313,7 @@ LocusZoom.Panel.prototype.addDataLayer = function(id, layout, state){
         this.xExtent = this.data_layers[data_layer.id].getAxisExtent("x");
     } else {
         this.xExtent = function(){
-            return d3.extent([this.parent.state.start, this.parent.state.end]);
+            return d3.extent([this.parent.layout.state.start, this.parent.layout.state.end]);
         };
     }
     // Generate the yExtent function
@@ -1435,7 +1416,7 @@ LocusZoom.Panel.prototype.render = function(){
             .attr("transform", "translate(" + this.layout.margin.left + "," + (this.layout.height - this.layout.margin.bottom) + ")")
             .call(this.x_axis);
         if (this.layout.axes.x.label_function){
-            this.layout.axes.x.label = LocusZoom.LabelFunctions.get(this.layout.axes.x.label_function, this.parent.state);
+            this.layout.axes.x.label = LocusZoom.LabelFunctions.get(this.layout.axes.x.label_function, this.parent.layout.state);
         }
         if (this.layout.axes.x.label != null){
             var x_label = this.layout.axes.x.label;
@@ -1454,7 +1435,7 @@ LocusZoom.Panel.prototype.render = function(){
             .attr("transform", "translate(" + this.layout.margin.left + "," + this.layout.margin.top + ")")
             .call(this.y1_axis);
         if (this.layout.axes.y1.label_function){
-            this.layout.axes.y1.label = LocusZoom.LabelFunctions.get(this.layout.axes.y1.label_function, this.parent.state);
+            this.layout.axes.y1.label = LocusZoom.LabelFunctions.get(this.layout.axes.y1.label_function, this.parent.layout.state);
         }
         if (this.layout.axes.y1.label != null){
             var y1_label = this.layout.axes.y1.label;
@@ -1475,7 +1456,7 @@ LocusZoom.Panel.prototype.render = function(){
             .attr("transform", "translate(" + (this.layout.width - this.layout.margin.right) + "," + this.layout.margin.top + ")")
             .call(this.y2_axis);
         if (this.layout.axes.y2.label_function){
-            this.layout.axes.y2.label = LocusZoom.LabelFunctions.get(this.layout.axes.y2.label_function, this.parent.state);
+            this.layout.axes.y2.label = LocusZoom.LabelFunctions.get(this.layout.axes.y2.label_function, this.parent.layout.state);
         }
         if (this.layout.axes.y2.label != null){
             var y2_label = this.layout.axes.y2.label;
@@ -1513,7 +1494,7 @@ LocusZoom.Panel.prototype.render = function(){
 
 */
 
-LocusZoom.DataLayer = function(id, layout, state) {
+LocusZoom.DataLayer = function(id, layout) {
 
     this.initialized = false;
 
@@ -1522,8 +1503,6 @@ LocusZoom.DataLayer = function(id, layout, state) {
     this.svg    = {};
 
     this.layout = LocusZoom.mergeLayouts(layout || {}, LocusZoom.DataLayer.DefaultLayout);
-
-    this.state = LocusZoom.mergeLayouts(state || {}, LocusZoom.DataLayer.DefaultState);
 
     this.data = [];
     this.metadata = {};
@@ -1625,9 +1604,6 @@ LocusZoom.DataLayer = function(id, layout, state) {
 
 };
 
-LocusZoom.DataLayer.DefaultState = {
-};
-
 LocusZoom.DataLayer.DefaultLayout = {
     type: "",
     fields: []
@@ -1688,7 +1664,7 @@ LocusZoom.DataLayer.prototype.draw = function(){
 LocusZoom.DataLayer.prototype.reMap = function(){
     this.destroyAllTooltips(); // hack - only non-visible tooltips should be destroyed
                                // and then recreated if returning to visibility
-    var promise = this.parent.parent.lzd.getData(this.parent.parent.state, this.layout.fields); //,"ld:best"
+    var promise = this.parent.parent.lzd.getData(this.parent.parent.layout.state, this.layout.fields); //,"ld:best"
     promise.then(function(new_data){
         this.data = new_data.body;
     }.bind(this));
@@ -1972,15 +1948,14 @@ LocusZoom.DataLayers = (function() {
     var obj = {};
     var datalayers = {};
 
-    obj.get = function(name, id, layout, state) {
+    obj.get = function(name, id, layout) {
         if (!name) {
             return null;
         } else if (datalayers[name]) {
             if (typeof id == "undefined" || typeof layout == "undefined"){
                 throw("id or layout argument missing for data layer [" + name + "]");
             } else {
-                state = LocusZoom.mergeLayouts(state || {}, LocusZoom.DataLayer.DefaultState);
-                return new datalayers[name](id, layout, state);
+                return new datalayers[name](id, layout);
             }
         } else {
             throw("data layer [" + name + "] not found");
@@ -2022,15 +1997,14 @@ LocusZoom.DataLayers = (function() {
   Implements a standard scatter plot
 */
 
-LocusZoom.DataLayers.add("scatter", function(id, layout, state){
+LocusZoom.DataLayers.add("scatter", function(id, layout){
 
     LocusZoom.DataLayer.apply(this, arguments);
 
-    this.DefaultState = {
-        selected_id: null
-    };
-
     this.DefaultLayout = {
+        state: {
+            selected_id: null
+        },
         point_size: 40,
         point_shape: "circle",
         color: "#888888",
@@ -2041,7 +2015,6 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, state){
     };
 
     this.layout = LocusZoom.mergeLayouts(layout, this.DefaultLayout);
-    this.state = LocusZoom.mergeLayouts(state, this.DefaultState);
 
     // Reimplement the positionTooltip() method to be scatter-specific
     this.positionTooltip = function(id){
@@ -2140,37 +2113,37 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, state){
         if (this.layout.selectable && (this.layout.fields.indexOf("id") != -1)){
             selection.on("mouseover", function(d){
                 var id = 's' + d.id.replace(/\W/g,'');
-                if (this.state.selected_id != id){
+                if (this.layout.state.selected_id != id){
                     d3.select("#" + id).attr("class", "lz-data_layer-scatter-hovered");
                     if (this.layout.tooltip){ this.createTooltip(d, id); }
                 }
             }.bind(this))
             .on("mouseout", function(d){
                 var id = 's' + d.id.replace(/\W/g,'');
-                if (this.state.selected_id != id){
+                if (this.layout.state.selected_id != id){
                     d3.select("#" + id).attr("class", "lz-data_layer-scatter");
                     if (this.layout.tooltip){ this.destroyTooltip(id); }
                 }
             }.bind(this))
             .on("click", function(d){
                 var id = 's' + d.id.replace(/\W/g,'');
-                if (this.state.selected_id == id){
-                    this.state.selected_id = null;
+                if (this.layout.state.selected_id == id){
+                    this.layout.state.selected_id = null;
                     d3.select("#" + id).attr("class", "lz-data_layer-scatter-hovered");
                 } else {
-                    if (this.state.selected_id != null){
-                        d3.select("#" + this.state.selected_id).attr("class", "lz-data_layer-scatter");
-                        if (this.layout.tooltip){ this.destroyTooltip(this.state.selected_id); }
+                    if (this.layout.state.selected_id != null){
+                        d3.select("#" + this.layout.state.selected_id).attr("class", "lz-data_layer-scatter");
+                        if (this.layout.tooltip){ this.destroyTooltip(this.layout.state.selected_id); }
                     }
-                    this.state.selected_id = id;
+                    this.layout.state.selected_id = id;
                     d3.select("#" + id).attr("class", "lz-data_layer-scatter-selected");
                 }
                 this.triggerOnUpdate();
             }.bind(this));
             // Apply existing selection from state
-            if (this.state.selected_id != null){
-                var selected_id = this.state.selected_id;
-                this.state.selected_id = null;
+            if (this.layout.state.selected_id != null){
+                var selected_id = this.layout.state.selected_id;
+                this.layout.state.selected_id = null;
                 var d = d3.select("#" + selected_id).datum();
                 d3.select("#" + selected_id).on("mouseover")(d);
                 d3.select("#" + selected_id).on("click")(d);
@@ -2187,15 +2160,14 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, state){
   Implements a data layer that will render gene tracks
 */
 
-LocusZoom.DataLayers.add("genes", function(id, layout, state){
+LocusZoom.DataLayers.add("genes", function(id, layout){
 
     LocusZoom.DataLayer.apply(this, arguments);
 
-    this.DefaultState = {
-        selected_id: null
-    };
-
     this.DefaultLayout = {
+        state: {
+            selected_id: null
+        },
         label_font_size: 12,
         label_exon_spacing: 4,
         exon_height: 16,
@@ -2205,7 +2177,6 @@ LocusZoom.DataLayers.add("genes", function(id, layout, state){
     };
 
     this.layout = LocusZoom.mergeLayouts(layout, this.DefaultLayout);
-    this.state = LocusZoom.mergeLayouts(state, this.DefaultState);
     
     // Helper function to sum layout values to derive total height for a single gene track
     this.getTrackHeight = function(){
@@ -2259,20 +2230,20 @@ LocusZoom.DataLayers.add("genes", function(id, layout, state){
             // Determine display range start and end, based on minimum allowable gene display width, bounded by what we can see
             // (range: values in terms of pixels on the screen)
             this.data[g].display_range = {
-                start: this.parent.x_scale(Math.max(d.start, this.parent.parent.state.start)),
-                end:   this.parent.x_scale(Math.min(d.end, this.parent.parent.state.end))
+                start: this.parent.x_scale(Math.max(d.start, this.parent.parent.layout.state.start)),
+                end:   this.parent.x_scale(Math.min(d.end, this.parent.parent.layout.state.end))
             };
             this.data[g].display_range.label_width = this.getLabelWidth(this.data[g].gene_name, this.layout.label_font_size);
             this.data[g].display_range.width = this.data[g].display_range.end - this.data[g].display_range.start;
             // Determine label text anchor (default to middle)
             this.data[g].display_range.text_anchor = "middle";
             if (this.data[g].display_range.width < this.data[g].display_range.label_width){
-                if (d.start < this.parent.parent.state.start){
+                if (d.start < this.parent.parent.layout.state.start){
                     this.data[g].display_range.end = this.data[g].display_range.start
                         + this.data[g].display_range.label_width
                         + this.metadata.horizontal_padding;
                     this.data[g].display_range.text_anchor = "start";
-                } else if (d.end > this.parent.parent.state.end){
+                } else if (d.end > this.parent.parent.layout.state.end){
                     this.data[g].display_range.start = this.data[g].display_range.end
                         - this.data[g].display_range.label_width
                         - this.metadata.horizontal_padding;
@@ -2280,12 +2251,12 @@ LocusZoom.DataLayers.add("genes", function(id, layout, state){
                 } else {
                     var centered_margin = ((this.data[g].display_range.label_width - this.data[g].display_range.width) / 2)
                         + this.metadata.horizontal_padding;
-                    if ((this.data[g].display_range.start - centered_margin) < this.parent.x_scale(this.parent.parent.state.start)){
-                        this.data[g].display_range.start = this.parent.x_scale(this.parent.parent.state.start);
+                    if ((this.data[g].display_range.start - centered_margin) < this.parent.x_scale(this.parent.parent.layout.state.start)){
+                        this.data[g].display_range.start = this.parent.x_scale(this.parent.parent.layout.state.start);
                         this.data[g].display_range.end = this.data[g].display_range.start + this.data[g].display_range.label_width;
                         this.data[g].display_range.text_anchor = "start";
-                    } else if ((this.data[g].display_range.end + centered_margin) > this.parent.x_scale(this.parent.parent.state.end)) {
-                        this.data[g].display_range.end = this.parent.x_scale(this.parent.parent.state.end);
+                    } else if ((this.data[g].display_range.end + centered_margin) > this.parent.x_scale(this.parent.parent.layout.state.end)) {
+                        this.data[g].display_range.end = this.parent.x_scale(this.parent.parent.layout.state.end);
                         this.data[g].display_range.start = this.data[g].display_range.end - this.data[g].display_range.label_width;
                         this.data[g].display_range.text_anchor = "end";
                     } else {
@@ -2476,37 +2447,37 @@ LocusZoom.DataLayers.add("genes", function(id, layout, state){
                     clickarea
                         .on("mouseover", function(d){
                             var id = 'g' + d.gene_name.replace(/\W/g,'');
-                            if (this.state.selected_id != id){
+                            if (this.layout.state.selected_id != id){
                                 d3.select("#" + id + "_bounding_box").attr("class", "lz-data_layer-gene lz-bounding_box-hovered");
                                 if (this.layout.tooltip){ this.createTooltip(d, id); }
                             }
                         }.bind(gene.parent))
                         .on("mouseout", function(d){
                             var id = 'g' + d.gene_name.replace(/\W/g,'');
-                            if (this.state.selected_id != id){
+                            if (this.layout.state.selected_id != id){
                                 d3.select("#" + id + "_bounding_box").attr("class", "lz-data_layer-gene lz-bounding_box");
                                 if (this.layout.tooltip){ this.destroyTooltip(id); }
                             }
                         }.bind(gene.parent))
                         .on("click", function(d){
                             var id = 'g' + d.gene_name.replace(/\W/g,'');
-                            if (this.state.selected_id == id){
-                                this.state.selected_id = null;
+                            if (this.layout.state.selected_id == id){
+                                this.layout.state.selected_id = null;
                                 d3.select("#" + id + "_bounding_box").attr("class", "lz-data_layer-gene lz-bounding_box-hovered");
                             } else {
-                                if (this.state.selected_id != null){
-                                    d3.select("#" + this.state.selected_id + "_bounding_box").attr("class", "lz-data_layer-gene lz-bounding_box");
-                                    if (this.layout.tooltip){ this.destroyTooltip(this.state.selected_id); }
+                                if (this.layout.state.selected_id != null){
+                                    d3.select("#" + this.layout.state.selected_id + "_bounding_box").attr("class", "lz-data_layer-gene lz-bounding_box");
+                                    if (this.layout.tooltip){ this.destroyTooltip(this.layout.state.selected_id); }
                                 }
-                                this.state.selected_id = id;
+                                this.layout.state.selected_id = id;
                                 d3.select("#" + id + "_bounding_box").attr("class", "lz-data_layer-gene lz-bounding_box-selected");
                             }
                             this.triggerOnUpdate();
                         }.bind(gene.parent));
                     // Apply existing selection from state
-                    if (gene.parent.state.selected_id != null){
-                        var selected_id = gene.parent.state.selected_id + "_clickarea";
-                        gene.parent.state.selected_id = null;
+                    if (gene.parent.layout.state.selected_id != null){
+                        var selected_id = gene.parent.layout.state.selected_id + "_clickarea";
+                        gene.parent.layout.state.selected_id = null;
                         var d = d3.select("#" + selected_id).datum();
                         d3.select("#" + selected_id).on("mouseover")(d);
                         d3.select("#" + selected_id).on("click")(d);

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -26,6 +26,8 @@ LocusZoom.populate = function(selector, datasource, layout, state) {
     if (typeof selector == "undefined"){
         throw ("LocusZoom.populate selector not defined");
     }
+    // Empty the selector of any existing content
+    d3.select(selector).html("");
     var instance;
     d3.select(selector).call(function(container){
         // Require each containing element have an ID. If one isn't present, create one.
@@ -297,6 +299,17 @@ LocusZoom.DefaultState = {
 
 // Default Layout
 LocusZoom.DefaultLayout = {
+    width: 1,
+    height: 1,
+    min_width: 1,
+    min_height: 1,
+    resizable: false,
+    aspect_ratio: 1,
+    panels: {}
+};
+
+// Standard Layout
+LocusZoom.StandardLayout = {
     width: 800,
     height: 450,
     min_width: 400,
@@ -368,6 +381,7 @@ LocusZoom.DefaultLayout = {
             proportional_height: 0.5,
             proportional_origin: { x: 0, y: 0.5 },
             margin: { top: 20, right: 20, bottom: 20, left: 50 },
+            axes: {},
             data_layers: {
                 genes: {
                     type: "genes",
@@ -707,7 +721,13 @@ LocusZoom.Instance = function(id, datasource, layout, state) {
     this.remap_promises = [];
 
     // The layout is a serializable object used to describe the composition of the instance
-    this.layout = LocusZoom.mergeLayouts(layout || {}, LocusZoom.DefaultLayout);
+    // If no layout was passed, use the Standard Layout
+    // Otherwise merge whatever was passed with the Default Layout
+    if (typeof layout == "undefined"){
+        this.layout = LocusZoom.mergeLayouts({}, LocusZoom.StandardLayout);
+    } else {
+        this.layout = LocusZoom.mergeLayouts(layout, LocusZoom.DefaultLayout);
+    }
     
     // The state property stores any parameters subject to change via user input
     this.state = LocusZoom.mergeLayouts(state || {}, LocusZoom.DefaultState);
@@ -1104,7 +1124,7 @@ LocusZoom.Panel.prototype.initializeLayout = function(){
 
     // Initialize panel axes
     ["x", "y1", "y2"].forEach(function(axis){
-        if (JSON.stringify(this.layout.axes[axis]) == JSON.stringify({})){
+        if (!Object.keys(this.layout.axes[axis]).length || this.layout.axes[axis].render === false){
             // The default layout sets the axis to an empty object, so set its render boolean here
             this.layout.axes[axis].render = false;
         } else {

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -22,7 +22,7 @@ var LocusZoom = {
     
 // Populate a single element with a LocusZoom instance.
 // selector can be a string for a DOM Query or a d3 selector.
-LocusZoom.populate = function(selector, datasource, layout) {
+LocusZoom.populate = function(selector, datasource, layout, state) {
     if (typeof selector == "undefined"){
         throw ("LocusZoom.populate selector not defined");
     }
@@ -70,7 +70,7 @@ LocusZoom.populate = function(selector, datasource, layout) {
 
 // Populate arbitrarily many elements each with a LocusZoom instance
 // using a common datasource, layout, and/or state
-LocusZoom.populateAll = function(selector, datasource, layout) {
+LocusZoom.populateAll = function(selector, datasource, layout, state) {
     var instances = [];
     d3.selectAll(selector).each(function(d,i) {
         instances[i] = LocusZoom.populate(this, datasource, layout);

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -2169,7 +2169,11 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, state){
             }.bind(this));
             // Apply existing selection from state
             if (this.state.selected_id != null){
-                d3.select("#" + this.state.selected_id).attr("class", "lz-data_layer-scatter-selected");
+                var selected_id = this.state.selected_id;
+                this.state.selected_id = null;
+                var d = d3.select("#" + selected_id).datum();
+                d3.select("#" + selected_id).on("mouseover")(d);
+                d3.select("#" + selected_id).on("click")(d);
             }
         }
         
@@ -2501,7 +2505,11 @@ LocusZoom.DataLayers.add("genes", function(id, layout, state){
                         }.bind(gene.parent));
                     // Apply existing selection from state
                     if (gene.parent.state.selected_id != null){
-                        d3.select("#" + gene.parent.state.selected_id + "_bounding_box").attr("class", "lz-data_layer-gene lz-bounding_box-selected");
+                        var selected_id = gene.parent.state.selected_id + "_clickarea";
+                        gene.parent.state.selected_id = null;
+                        var d = d3.select("#" + selected_id).datum();
+                        d3.select("#" + selected_id).on("mouseover")(d);
+                        d3.select("#" + selected_id).on("click")(d);
                     }
                 }
 

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -2067,6 +2067,8 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, state){
                 var x = this.parent.x_scale(d[this.layout.x_axis.field]);
                 var y_scale = "y"+this.layout.y_axis.axis+"_scale";
                 var y = this.parent[y_scale](d[this.layout.y_axis.field]);
+                if (isNaN(x)){ x = -1000; }
+                if (isNaN(y)){ y = -1000; }
                 return "translate(" + x + "," + y + ")";
             }.bind(this))
             .attr("d", d3.svg.symbol().size(this.layout.point_size).type(this.layout.point_shape))

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -29,7 +29,7 @@ LocusZoom.populate = function(selector, datasource, layout, state) {
     // Empty the selector of any existing content
     d3.select(selector).html("");
     var instance;
-    d3.select(selector).call(function(container){
+    d3.select(selector).call(function(){
         // Require each containing element have an ID. If one isn't present, create one.
         if (typeof this.node().id == "undefined"){
             var iterator = 0;
@@ -49,7 +49,11 @@ LocusZoom.populate = function(selector, datasource, layout, state) {
         instance.initialize();
         // Detect data-region and fill in state values if present
         if (typeof this.node().dataset !== "undefined" && typeof this.node().dataset.region !== "undefined"){
-            instance.state = LocusZoom.mergeLayouts(LocusZoom.parsePositionQuery(this.node().dataset.region), instance.state);
+            var region = LocusZoom.parsePositionQuery(this.node().dataset.region);
+            var attr;
+            for (attr in region){
+                instance.state[attr] = region[attr];
+            }
         }
         // If the instance has defined data sources then trigger its first mapping based on state values
         if (typeof datasource == "object" && Object.keys(datasource).length){
@@ -730,13 +734,29 @@ LocusZoom.Instance = function(id, datasource, layout, state) {
     }
     
     // The state property stores any parameters subject to change via user input
+    // At this step pre-parse layouts for panels and data layers and make sure they're all present in the state
     this.state = LocusZoom.mergeLayouts(state || {}, LocusZoom.DefaultState);
+    var panel_id, data_layer_id;
+    for (panel_id in this.layout.panels){
+        this.state.panels[panel_id] = LocusZoom.mergeLayouts(this.state.panels[panel_id] || {}, LocusZoom.Panel.DefaultState);
+        for (data_layer_id in this.layout.panels[panel_id].data_layers){
+            this.state.panels[panel_id].data_layers[data_layer_id] = LocusZoom.mergeLayouts(this.state.panels[panel_id].data_layers[data_layer_id] || {}, LocusZoom.DataLayer.DefaultState);
+        }
+    }
     
     // LocusZoom.Data.Requester
     this.lzd = new LocusZoom.Data.Requester(datasource);
 
     // Window.onresize listener (responsive layouts only)
     this.window_onresize = null;
+
+    // onUpdate - user defineable function that can be triggered whenever the layout or state are updated
+    this.onUpdate = null;
+    this.triggerOnUpdate = function(){
+        if (typeof this.onUpdate == "function"){
+            this.onUpdate();
+        }
+    };
 
     // Initialize the layout
     this.initializeLayout();
@@ -820,6 +840,7 @@ LocusZoom.Instance.prototype.setDimensions = function(width, height){
     if (this.initialized){
         this.ui.render();
     }
+    this.triggerOnUpdate();
     return this;
 };
 
@@ -838,9 +859,6 @@ LocusZoom.Instance.prototype.addPanel = function(id, layout, state){
     // Create the Panel and set its parent
     var panel = new LocusZoom.Panel(id, layout, state);
     panel.parent = this;
-
-    // Apply the Panel's state to the parent's state
-    panel.parent.state.panels[panel.id] = panel.state;
     
     // Store the Panel on the Instance
     this.panels[panel.id] = panel;
@@ -1030,7 +1048,7 @@ LocusZoom.Instance.prototype.mapTo = function(chr, start, end){
             console.log(error);
             this.curtain.drop(error);
         }.bind(this))
-        .done();
+        .done(this.triggerOnUpdate);
 
     return this;
     
@@ -1080,6 +1098,10 @@ LocusZoom.Panel = function(id, layout, state) {
 
     this.getBaseId = function(){
         return this.parent.id + "." + this.id;
+    };
+
+    this.triggerOnUpdate = function(){
+        this.parent.triggerOnUpdate();
     };
 
     // Initialize the layout
@@ -1186,8 +1208,6 @@ LocusZoom.Panel.prototype.setMargin = function(top, right, bottom, left){
     this.layout.cliparea.height = this.layout.height - (this.layout.margin.top + this.layout.margin.bottom);
     this.layout.cliparea.origin.x = this.layout.margin.left;
     this.layout.cliparea.origin.y = this.layout.margin.top;
-
-    //console.log(this.layout);
 
     if (this.initialized){ this.render(); }
     return this;
@@ -1302,9 +1322,6 @@ LocusZoom.Panel.prototype.addDataLayer = function(id, layout, state){
     // Create the Data Layer and set its parent 
     var data_layer = LocusZoom.DataLayers.get(layout.type, id, layout, state);
     data_layer.parent = this;
-
-    // Apply the Data Layer's state to the parent's state
-    data_layer.parent.state.data_layers[data_layer.id] = data_layer.state;
 
     // Store the Data Layer on the Panel
     this.data_layers[data_layer.id] = data_layer;
@@ -1513,6 +1530,10 @@ LocusZoom.DataLayer = function(id, layout, state) {
 
     this.getBaseId = function(){
         return this.parent.parent.id + "." + this.parent.id + "." + this.id;
+    };
+
+    this.triggerOnUpdate = function(){
+        this.parent.triggerOnUpdate();
     };
 
     // Tooltip methods
@@ -2144,6 +2165,7 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, state){
                     this.state.selected_id = id;
                     d3.select("#" + id).attr("class", "lz-data_layer-scatter-selected");
                 }
+                this.triggerOnUpdate();
             }.bind(this));
             // Apply existing selection from state
             if (this.state.selected_id != null){
@@ -2475,6 +2497,7 @@ LocusZoom.DataLayers.add("genes", function(id, layout, state){
                                 this.state.selected_id = id;
                                 d3.select("#" + id + "_bounding_box").attr("class", "lz-data_layer-gene lz-bounding_box-selected");
                             }
+                            this.triggerOnUpdate();
                         }.bind(gene.parent));
                     // Apply existing selection from state
                     if (gene.parent.state.selected_id != null){

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -1023,9 +1023,9 @@ LocusZoom.Instance.prototype.mapTo = function(chr, start, end){
 
     // Apply new state values
     // TODO: preserve existing state until new state is completely loaded+rendered or aborted?
-    this.layout.state.chr   = +chr;
-    this.layout.state.start = +start;
-    this.layout.state.end   = +end;
+    this.state.chr   = +chr;
+    this.state.start = +start;
+    this.state.end   = +end;
 
     this.remap_promises = [];
     // Trigger reMap on each Panel Layer
@@ -1048,7 +1048,7 @@ LocusZoom.Instance.prototype.mapTo = function(chr, start, end){
 
 // Refresh an instance's data from sources without changing position
 LocusZoom.Instance.prototype.refresh = function(){
-    this.mapTo(this.layout.state.chr, this.layout.state.start, this.layout.state.end);
+    this.mapTo(this.state.chr, this.state.start, this.state.end);
 };
 
 /* global d3,Q,LocusZoom */
@@ -1432,7 +1432,7 @@ LocusZoom.Panel.prototype.render = function(){
             .attr("transform", "translate(" + this.layout.margin.left + "," + (this.layout.height - this.layout.margin.bottom) + ")")
             .call(this.x_axis);
         if (this.layout.axes.x.label_function){
-            this.layout.axes.x.label = LocusZoom.LabelFunctions.get(this.layout.axes.x.label_function, this.parent.layout.state);
+            this.layout.axes.x.label = LocusZoom.LabelFunctions.get(this.layout.axes.x.label_function, this.state);
         }
         if (this.layout.axes.x.label != null){
             var x_label = this.layout.axes.x.label;
@@ -1451,7 +1451,7 @@ LocusZoom.Panel.prototype.render = function(){
             .attr("transform", "translate(" + this.layout.margin.left + "," + this.layout.margin.top + ")")
             .call(this.y1_axis);
         if (this.layout.axes.y1.label_function){
-            this.layout.axes.y1.label = LocusZoom.LabelFunctions.get(this.layout.axes.y1.label_function, this.parent.layout.state);
+            this.layout.axes.y1.label = LocusZoom.LabelFunctions.get(this.layout.axes.y1.label_function, this.state);
         }
         if (this.layout.axes.y1.label != null){
             var y1_label = this.layout.axes.y1.label;
@@ -1472,7 +1472,7 @@ LocusZoom.Panel.prototype.render = function(){
             .attr("transform", "translate(" + (this.layout.width - this.layout.margin.right) + "," + this.layout.margin.top + ")")
             .call(this.y2_axis);
         if (this.layout.axes.y2.label_function){
-            this.layout.axes.y2.label = LocusZoom.LabelFunctions.get(this.layout.axes.y2.label_function, this.parent.layout.state);
+            this.layout.axes.y2.label = LocusZoom.LabelFunctions.get(this.layout.axes.y2.label_function, this.state);
         }
         if (this.layout.axes.y2.label != null){
             var y2_label = this.layout.axes.y2.label;
@@ -2266,20 +2266,20 @@ LocusZoom.DataLayers.add("genes", function(id, layout, parent){
             // Determine display range start and end, based on minimum allowable gene display width, bounded by what we can see
             // (range: values in terms of pixels on the screen)
             this.data[g].display_range = {
-                start: this.parent.x_scale(Math.max(d.start, this.parent.parent.layout.state.start)),
-                end:   this.parent.x_scale(Math.min(d.end, this.parent.parent.layout.state.end))
+                start: this.parent.x_scale(Math.max(d.start, this.state.start)),
+                end:   this.parent.x_scale(Math.min(d.end, this.state.end))
             };
             this.data[g].display_range.label_width = this.getLabelWidth(this.data[g].gene_name, this.layout.label_font_size);
             this.data[g].display_range.width = this.data[g].display_range.end - this.data[g].display_range.start;
             // Determine label text anchor (default to middle)
             this.data[g].display_range.text_anchor = "middle";
             if (this.data[g].display_range.width < this.data[g].display_range.label_width){
-                if (d.start < this.parent.parent.layout.state.start){
+                if (d.start < this.state.start){
                     this.data[g].display_range.end = this.data[g].display_range.start
                         + this.data[g].display_range.label_width
                         + this.metadata.horizontal_padding;
                     this.data[g].display_range.text_anchor = "start";
-                } else if (d.end > this.parent.parent.layout.state.end){
+                } else if (d.end > this.state.end){
                     this.data[g].display_range.start = this.data[g].display_range.end
                         - this.data[g].display_range.label_width
                         - this.metadata.horizontal_padding;
@@ -2287,12 +2287,12 @@ LocusZoom.DataLayers.add("genes", function(id, layout, parent){
                 } else {
                     var centered_margin = ((this.data[g].display_range.label_width - this.data[g].display_range.width) / 2)
                         + this.metadata.horizontal_padding;
-                    if ((this.data[g].display_range.start - centered_margin) < this.parent.x_scale(this.parent.parent.layout.state.start)){
-                        this.data[g].display_range.start = this.parent.x_scale(this.parent.parent.layout.state.start);
+                    if ((this.data[g].display_range.start - centered_margin) < this.parent.x_scale(this.state.start)){
+                        this.data[g].display_range.start = this.parent.x_scale(this.state.start);
                         this.data[g].display_range.end = this.data[g].display_range.start + this.data[g].display_range.label_width;
                         this.data[g].display_range.text_anchor = "start";
-                    } else if ((this.data[g].display_range.end + centered_margin) > this.parent.x_scale(this.parent.parent.layout.state.end)) {
-                        this.data[g].display_range.end = this.parent.x_scale(this.parent.parent.layout.state.end);
+                    } else if ((this.data[g].display_range.end + centered_margin) > this.parent.x_scale(this.state.end)) {
+                        this.data[g].display_range.end = this.parent.x_scale(this.state.end);
                         this.data[g].display_range.start = this.data[g].display_range.end - this.data[g].display_range.label_width;
                         this.data[g].display_range.text_anchor = "end";
                     } else {

--- a/plot_builder.html
+++ b/plot_builder.html
@@ -31,25 +31,25 @@
   <div style="max-width: 100%; clear: both; margin: 0;">
 
     <div class="row">
-      <div class="four columns">
-        <h2>LocusZoom Plot Builder</h2>
-      </div>
-      <div class="eight columns">
-        <div class="u-pull-right">
-          <a class="button" href="https://github.com/statgen/locuszoom/wiki/API-Reference" target="_blank">API Reference</a>
-          <button onclick="resetPlot();">Reset Plot</button>
-          <button class="button-primary" onClick="updatePlot();">Apply Layout &amp; State</button>
-        </div>
-      </div>
+      <h2>LocusZoom Plot Builder</h2>
     </div>
     
     <div class="row">
       
       <div class="six columns">
-        <h5>Layout <small id="layout_message" style="color: #AD2528; margin-left: 15px;"></small></h5>
-        <textarea id="layout" style="height: 260px;"></textarea>
-        <h5>State <small id="state_message" style="color: #AD2528; margin-left: 15px;"></small></h5>
-        <textarea id="state" style="height: 120px;"></textarea>
+        <textarea id="layout" style="height: 460px;"></textarea>
+        <div class="row">
+          <div class="four columns">
+            <h5>Layout <small id="layout_message" style="color: #AD2528; margin-left: 15px;"></small></h5>
+          </div>
+          <div class="eight columns">
+            <div class="u-pull-right">
+              <a class="button" href="https://github.com/statgen/locuszoom/wiki/API-Reference" target="_blank">API Reference</a>
+              <button onclick="resetPlot();">Reset Plot</button>
+              <button class="button-primary" onClick="updatePlot();">Apply Layout</button>
+            </div>
+          </div>
+        </div>
       </div>
 
       <div class="six columns">
@@ -74,13 +74,11 @@
     function resetPlot(){
       plot = LocusZoom.populate("#plot", data_sources);
       applyOnUpdate();
-      plot.onUpdate();
     }
 
     function applyOnUpdate(){
       plot.onUpdate = function(){
         $("#layout").val(JSON.stringify(plot.layout, null, "  "));
-        $("#state").val(JSON.stringify(plot.state, null, "  "));
       };
     }
     
@@ -89,22 +87,14 @@
       var state = null;
       $("#layout").removeClass("error");
       $("#layout_message").html("");
-      $("#state").removeClass("error");
-      $("#state_message").html("");
       try {
         layout = JSON.parse($("#layout").val());
       } catch (e) {
         $("#layout").addClass("error");
         $("#layout_message").html("Invalid JSON");
+        return;
       }
-      try {
-        state = JSON.parse($("#state").val());
-      } catch (e) {
-        $("#state").addClass("error");
-        $("#state_message").html("Invalid JSON");
-      }
-      if (layout == null || state == null){ return; }
-      plot = LocusZoom.populate("#plot", data_sources, layout, state);
+      plot = LocusZoom.populate("#plot", data_sources, layout);
       applyOnUpdate();
     }
 

--- a/plot_builder.html
+++ b/plot_builder.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <title>LocusZoom Plot Builder</title>
+
+  <script src="https://code.jquery.com/jquery-2.1.4.min.js" type="text/javascript"></script>
+  <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/skeleton/2.0.4/skeleton.css"/>
+
+  <!-- Necessary includes for LocusZoom -->
+  <script src="locuszoom.vendor.min.js" type="text/javascript"></script>
+  <script src="locuszoom.app.js" type="text/javascript"></script>
+  <link rel="stylesheet" type="text/css" href="locuszoom.css"/>
+
+</head>
+
+<body style="background-color: #E8E8E8; margin-left: 20px; margin-right: 20px;">
+
+  <div style="max-width: 100%; clear: both; margin: 0;">
+
+    <div class="row">
+      <div class="four columns">
+        <h2>LocusZoom Plot Builder</h2>
+      </div>
+      <div class="eight columns">
+        <div class="u-pull-right">
+          <a class="button" href="https://github.com/statgen/locuszoom/wiki/API-Reference" target="_blank">API Reference</a>
+          <button>Reset Plot</button>
+          <button class="button-primary">Apply Layout &amp; State</button>
+        </div>
+      </div>
+    </div>
+    
+    <div class="row">
+      
+      <div class="six columns">
+        <h5>Layout</h5>
+        <textarea id="plot_builder_layout" style="width: 100%; max-width: 100%; min-height: 40px; height: 260px;"></textarea>
+        <h5>State</h5>
+        <textarea id="plot_builder_state" style="width: 100%; max-width: 100%; min-height: 40px; height: 120px;"></textarea>
+      </div>
+
+      <div class="six columns">
+        <div id="lz-1" class="lz-container-responsive" data-region="10:114550452-115067678"></div>
+      </div>
+
+    </div>
+
+  </div>
+
+  <script type="text/javascript">
+
+    // Define LocusZoom Data Sources object
+    var apiBase = "http://portaldev.sph.umich.edu/api/v1/";
+    var data_sources = new LocusZoom.DataSources();
+    data_sources.addSource("base", ["AssociationLZ", {url:apiBase + "single/", params: {analysis: 3}}]);
+    data_sources.addSource("ld", ["LDLZ" ,apiBase + "pair/LD/"]);
+    data_sources.addSource("gene", ["GeneLZ", { url: apiBase + "annotation/genes/", params: {source: 2} }]);
+
+    // Populate the div with a LocusZoom plot
+    var plot = LocusZoom.populate("#lz-1", data_sources);
+    $("#plot_builder_layout").text(JSON.stringify(plot.layout, null, "  "));
+    $("#plot_builder_state").text(JSON.stringify(plot.state, null, "  "));
+
+  </script>
+
+</body>
+</html>

--- a/plot_builder.html
+++ b/plot_builder.html
@@ -69,10 +69,19 @@
     data_sources.addSource("ld", ["LDLZ" ,apiBase + "pair/LD/"]);
     data_sources.addSource("gene", ["GeneLZ", { url: apiBase + "annotation/genes/", params: {source: 2} }]);
 
+    var plot;
+
     function resetPlot(){
-      var plot = LocusZoom.populate("#plot", data_sources);
-      $("#layout").val(JSON.stringify(plot.layout, null, "  "));
-      $("#state").val(JSON.stringify(plot.state, null, "  "));
+      plot = LocusZoom.populate("#plot", data_sources);
+      applyOnUpdate();
+      plot.onUpdate();
+    }
+
+    function applyOnUpdate(){
+      plot.onUpdate = function(){
+        $("#layout").val(JSON.stringify(plot.layout, null, "  "));
+        $("#state").val(JSON.stringify(plot.state, null, "  "));
+      };
     }
     
     function updatePlot(){
@@ -96,11 +105,10 @@
       }
       if (layout == null || state == null){ return; }
       plot = LocusZoom.populate("#plot", data_sources, layout, state);
-      $("#layout").val(JSON.stringify(plot.layout, null, "  "));
-      $("#state").val(JSON.stringify(plot.state, null, "  "));
+      applyOnUpdate();
     }
 
-    resetPlot();
+    resetPlot();    
 
   </script>
 

--- a/plot_builder.html
+++ b/plot_builder.html
@@ -7,6 +7,17 @@
 
   <script src="https://code.jquery.com/jquery-2.1.4.min.js" type="text/javascript"></script>
   <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/skeleton/2.0.4/skeleton.css"/>
+  <style>
+    textarea {
+      width: 100%;
+      max-width: 100%;
+      min-height: 40px;
+      background-color: white;
+    }
+    textarea.error {
+      background-color: #F7DADA;
+    }
+  </style>
 
   <!-- Necessary includes for LocusZoom -->
   <script src="locuszoom.vendor.min.js" type="text/javascript"></script>
@@ -27,7 +38,7 @@
         <div class="u-pull-right">
           <a class="button" href="https://github.com/statgen/locuszoom/wiki/API-Reference" target="_blank">API Reference</a>
           <button>Reset Plot</button>
-          <button class="button-primary">Apply Layout &amp; State</button>
+          <button class="button-primary" onClick="updatePlot();">Apply Layout &amp; State</button>
         </div>
       </div>
     </div>
@@ -35,10 +46,10 @@
     <div class="row">
       
       <div class="six columns">
-        <h5>Layout</h5>
-        <textarea id="plot_builder_layout" style="width: 100%; max-width: 100%; min-height: 40px; height: 260px;"></textarea>
-        <h5>State</h5>
-        <textarea id="plot_builder_state" style="width: 100%; max-width: 100%; min-height: 40px; height: 120px;"></textarea>
+        <h5>Layout <small id="layout_message" style="color: #AD2528; margin-left: 15px;"></small></h5>
+        <textarea id="layout" style="height: 260px;"></textarea>
+        <h5>State <small id="state_message" style="color: #AD2528; margin-left: 15px;"></small></h5>
+        <textarea id="state" style="height: 120px;"></textarea>
       </div>
 
       <div class="six columns">
@@ -60,8 +71,33 @@
 
     // Populate the div with a LocusZoom plot
     var plot = LocusZoom.populate("#lz-1", data_sources);
-    $("#plot_builder_layout").text(JSON.stringify(plot.layout, null, "  "));
-    $("#plot_builder_state").text(JSON.stringify(plot.state, null, "  "));
+    $("#layout").val(JSON.stringify(plot.layout, null, "  "));
+    $("#state").val(JSON.stringify(plot.state, null, "  "));
+
+    function updatePlot(){
+      var layout = null;
+      var state = null;
+      $("#layout").removeClass("error");
+      $("#layout_message").html("");
+      $("#state").removeClass("error");
+      $("#state_message").html("");
+      try {
+        layout = JSON.parse($("#layout").val());
+      } catch (e) {
+        $("#layout").addClass("error");
+        $("#layout_message").html("Invalid JSON");
+      }
+      try {
+        state = JSON.parse($("#state").val());
+      } catch (e) {
+        $("#state").addClass("error");
+        $("#state_message").html("Invalid JSON");
+      }
+      if (layout == null || state == null){ return; }
+      
+      console.log(layout);
+      console.log(state);
+    }
 
   </script>
 

--- a/plot_builder.html
+++ b/plot_builder.html
@@ -37,7 +37,7 @@
       <div class="eight columns">
         <div class="u-pull-right">
           <a class="button" href="https://github.com/statgen/locuszoom/wiki/API-Reference" target="_blank">API Reference</a>
-          <button>Reset Plot</button>
+          <button onclick="resetPlot();">Reset Plot</button>
           <button class="button-primary" onClick="updatePlot();">Apply Layout &amp; State</button>
         </div>
       </div>
@@ -53,7 +53,7 @@
       </div>
 
       <div class="six columns">
-        <div id="lz-1" class="lz-container-responsive" data-region="10:114550452-115067678"></div>
+        <div id="plot" class="lz-container-responsive" data-region="10:114550452-115067678"></div>
       </div>
 
     </div>
@@ -69,11 +69,12 @@
     data_sources.addSource("ld", ["LDLZ" ,apiBase + "pair/LD/"]);
     data_sources.addSource("gene", ["GeneLZ", { url: apiBase + "annotation/genes/", params: {source: 2} }]);
 
-    // Populate the div with a LocusZoom plot
-    var plot = LocusZoom.populate("#lz-1", data_sources);
-    $("#layout").val(JSON.stringify(plot.layout, null, "  "));
-    $("#state").val(JSON.stringify(plot.state, null, "  "));
-
+    function resetPlot(){
+      var plot = LocusZoom.populate("#plot", data_sources);
+      $("#layout").val(JSON.stringify(plot.layout, null, "  "));
+      $("#state").val(JSON.stringify(plot.state, null, "  "));
+    }
+    
     function updatePlot(){
       var layout = null;
       var state = null;
@@ -94,10 +95,12 @@
         $("#state_message").html("Invalid JSON");
       }
       if (layout == null || state == null){ return; }
-      
-      console.log(layout);
-      console.log(state);
+      plot = LocusZoom.populate("#plot", data_sources, layout, state);
+      $("#layout").val(JSON.stringify(plot.layout, null, "  "));
+      $("#state").val(JSON.stringify(plot.state, null, "  "));
     }
+
+    resetPlot();
 
   </script>
 

--- a/test/Instance.js
+++ b/test/Instance.js
@@ -45,17 +45,17 @@ describe('LocusZoom.Instance', function(){
         it('should have an id', function(){
             this.instance.should.have.property('id').which.is.a.String;
         });
-        it('should have a layout which is (superficially) a copy of DefaultLayout', function(){
-            assert.equal(this.instance.layout.width, LocusZoom.DefaultLayout.width);
-            assert.equal(this.instance.layout.height, LocusZoom.DefaultLayout.height);
-            assert.equal(this.instance.layout.min_width, LocusZoom.DefaultLayout.min_width);
-            assert.equal(this.instance.layout.min_height, LocusZoom.DefaultLayout.min_height);
+        it('should have a layout which is (superficially) a copy of StandardLayout', function(){
+            assert.equal(this.instance.layout.width, LocusZoom.StandardLayout.width);
+            assert.equal(this.instance.layout.height, LocusZoom.StandardLayout.height);
+            assert.equal(this.instance.layout.min_width, LocusZoom.StandardLayout.min_width);
+            assert.equal(this.instance.layout.min_height, LocusZoom.StandardLayout.min_height);
         });
     });
     describe("Configuration API", function() {
         beforeEach(function() {
             d3.select("body").append("div").attr("id", "instance_id");
-            var layout = { resizable: "manual" };
+            var layout = LocusZoom.mergeLayouts({ resizable: "manual" }, LocusZoom.StandardLayout);
             this.instance = LocusZoom.populate("#instance_id", {}, layout);
         });
         it('should allow setting dimensions, bounded by layout minimums', function(){
@@ -69,12 +69,12 @@ describe('LocusZoom.Instance', function(){
             this.instance.layout.aspect_ratio.should.be.exactly(1320/681);
             this.instance.setDimensions("q", 0);
             this.instance.layout.width.should.be.exactly(1320);
-            this.instance.layout.height.should.be.exactly(LocusZoom.DefaultLayout.min_height);
-            this.instance.layout.aspect_ratio.should.be.exactly(1320/LocusZoom.DefaultLayout.min_height);
+            this.instance.layout.height.should.be.exactly(LocusZoom.StandardLayout.min_height);
+            this.instance.layout.aspect_ratio.should.be.exactly(1320/LocusZoom.StandardLayout.min_height);
             this.instance.setDimensions(0, 0);
-            this.instance.layout.width.should.be.exactly(LocusZoom.DefaultLayout.min_width);
-            this.instance.layout.height.should.be.exactly(LocusZoom.DefaultLayout.min_height);
-            this.instance.layout.aspect_ratio.should.be.exactly(LocusZoom.DefaultLayout.min_width/LocusZoom.DefaultLayout.min_height);
+            this.instance.layout.width.should.be.exactly(LocusZoom.StandardLayout.min_width);
+            this.instance.layout.height.should.be.exactly(LocusZoom.StandardLayout.min_height);
+            this.instance.layout.aspect_ratio.should.be.exactly(LocusZoom.StandardLayout.min_width/LocusZoom.StandardLayout.min_height);
         });
         it('should allow for adding arbitrarily many panels', function(){
             this.instance.addPanel.should.be.a.Function;
@@ -86,7 +86,7 @@ describe('LocusZoom.Instance', function(){
             this.instance.panels[panel.id].should.have.property("parent").which.is.exactly(this.instance);
         });
         it('should enforce minimum dimensions based on its panels', function(){
-            this.instance.setDimensions(0, 0);
+            this.instance.setDimensions(1, 1);
             var calculated_min_width = 0;
             var calculated_min_height = 0;
             var panel;
@@ -100,7 +100,8 @@ describe('LocusZoom.Instance', function(){
             this.instance.layout.height.should.not.be.lessThan(this.instance.layout.min_height);
         });
         it('should allow for responsively setting dimensions using a predefined aspect ratio', function(){
-            this.instance = LocusZoom.populate("#instance_id", {}, { aspect_ratio: 2 });
+            var layout = LocusZoom.mergeLayouts({ aspect_ratio: 2 }, LocusZoom.StandardLayout);
+            this.instance = LocusZoom.populate("#instance_id", {}, layout);
             this.instance.layout.aspect_ratio.should.be.exactly(2);
             assert.equal(this.instance.layout.width/this.instance.layout.height, 2);
             this.instance.setDimensions(2000);
@@ -111,14 +112,14 @@ describe('LocusZoom.Instance', function(){
             assert.equal(this.instance.layout.width/this.instance.layout.height, 2);
         });
         it('should allow for responsively positioning panels using a proportional dimensions', function(){
-            var responsive_layout = {
+            var responsive_layout = LocusZoom.mergeLayouts({
                 resizable: "responsive",
                 aspect_ratio: 2,
                 panels: {
                     positions: { proportional_width: 1, proportional_height: 0.6 },
                     genes:     { proportional_width: 1, proportional_height: 0.4 }
                 }
-            };
+            }, LocusZoom.StandardLayout);
             this.instance = LocusZoom.populate("#instance_id", {}, responsive_layout);
             assert.equal(this.instance.layout.panels.positions.height/this.instance.layout.height, 0.6);
             assert.equal(this.instance.layout.panels.genes.height/this.instance.layout.height, 0.4);

--- a/test/LocusZoom.js
+++ b/test/LocusZoom.js
@@ -38,6 +38,14 @@ describe('LocusZoom Core', function(){
 
     describe("LocusZoom Core Singleton", function() {
 
+        beforeEach(function(){
+            d3.select("body").append("div").attr("id", "instance_id");
+        });
+
+        afterEach(function(){
+            d3.select("body").selectAll("*").remove();
+        });
+
         it('should have a version number', function(){
             LocusZoom.should.have.property('version').which.is.a.String;
         });
@@ -77,7 +85,6 @@ describe('LocusZoom Core', function(){
         });
 
         it('should have a method for populating a single element with a LocusZoom instance', function(){
-            d3.select("body").append("div").attr("id", "instance_id");
             LocusZoom.populate.should.be.a.Function;
             var instance = LocusZoom.populate("#instance_id", {});
             instance.should.be.an.Object;
@@ -102,6 +109,27 @@ describe('LocusZoom Core', function(){
                 instances[i].svg.should.be.an.Object;
                 assert.equal(instances[i].svg.html(), svg_selector.html());
             });
+        });
+
+        it('should allow for populating an element with a predefined layout and state as separate arguments (DEPRECATED)', function(){
+            var layout = { width: 200 };
+            var state = { chr: 10 };
+            var instance = LocusZoom.populate("#instance_id", {}, layout, state);
+            instance.layout.width.should.be.exactly(200);
+            instance.layout.state.chr.should.be.exactly(10);
+            assert.deepEqual(instance.state, instance.layout.state);
+        });
+
+        it('should allow for populating an instance with a predefined layout', function(){
+            LocusZoom.populate.should.be.a.Function;
+            var instance = LocusZoom.populate("#instance_id", {});
+            instance.should.be.an.Object;
+            instance.id.should.be.exactly("instance_id");
+            var svg_selector = d3.select('div#instance_id svg');
+            svg_selector.should.be.an.Object;
+            svg_selector.size().should.be.exactly(1);
+            instance.svg.should.be.an.Object;
+            assert.equal(instance.svg.html(), svg_selector.html());
         });
 
         describe("Position Queries", function() {

--- a/test/Panel.js
+++ b/test/Panel.js
@@ -37,8 +37,10 @@ describe('LocusZoom.Panel', function(){
     });
 
     describe("Constructor", function() {
-        beforeEach(function() {
-            this.panel = new LocusZoom.Panel();
+        beforeEach(function(){
+            d3.select("body").append("div").attr("id", "instance_id");
+            this.instance = LocusZoom.populate("#instance_id");
+            this.panel = this.instance.panels.positions;
         });
         it("returns an object", function() {
             this.panel.should.be.an.Object;

--- a/test/Singletons.js
+++ b/test/Singletons.js
@@ -218,7 +218,7 @@ describe('LocusZoom Singletons', function(){
         });
         it('should throw an exception if asked to get a function that has not been defined', function(){
             assert.throws(function(){
-                LocusZoom.ScaleFunctions.get("nonexistent", this.instance.layout.state);
+                LocusZoom.ScaleFunctions.get("nonexistent", this.instance.state);
             });
         });
         it('should throw an exception when adding a new scale function with an already in use name', function(){
@@ -334,7 +334,7 @@ describe('LocusZoom Singletons', function(){
         });
         it('should throw an exception if asked to get a function that has not been defined', function(){
             assert.throws(function(){
-                LocusZoom.DataLayers.get("nonexistent", this.instance.layout.state);
+                LocusZoom.DataLayers.get("nonexistent", this.instance.state);
             });
         });
         it('should throw an exception when trying to add a new data layer that is not a function', function(){

--- a/test/Singletons.js
+++ b/test/Singletons.js
@@ -48,8 +48,8 @@ describe('LocusZoom Singletons', function(){
         it("should have a general method to get a function or execute it for a result", function(){
             LocusZoom.LabelFunctions.should.have.property("get").which.is.a.Function;
             LocusZoom.LabelFunctions.get("chromosome").should.be.a.Function;
-            var returned_label = LocusZoom.LabelFunctions.get("chromosome", this.instance.state);
-            var expected_label = "Chromosome 0 (Mb)";
+            var returned_label = LocusZoom.LabelFunctions.get("chromosome", { chr: 17, start: 40 });
+            var expected_label = "Chromosome 17 (Mb)";
             assert.equal(returned_label, expected_label);
         });
         it("should have a method to add a label function", function(){
@@ -59,8 +59,8 @@ describe('LocusZoom Singletons', function(){
             var returned_list = LocusZoom.LabelFunctions.list();
             var expected_list = ["chromosome", "foo"];
             assert.deepEqual(returned_list, expected_list);
-            var returned_label = LocusZoom.LabelFunctions.get("foo", this.instance.state);
-            var expected_label = "start: 0";
+            var returned_label = LocusZoom.LabelFunctions.get("foo", { start: 20 });
+            var expected_label = "start: 20";
             assert.equal(returned_label, expected_label);
         });
         it("should have a method to change or delete existing label functions", function(){
@@ -70,8 +70,8 @@ describe('LocusZoom Singletons', function(){
             var returned_list = LocusZoom.LabelFunctions.list();
             var expected_list = ["chromosome", "foo"];
             assert.deepEqual(returned_list, expected_list);
-            var returned_label = LocusZoom.LabelFunctions.get("foo", this.instance.state);
-            var expected_label = "end: 0";
+            var returned_label = LocusZoom.LabelFunctions.get("foo", { start: 20, end: 50 });
+            var expected_label = "end: 50";
             assert.equal(returned_label, expected_label);
             LocusZoom.LabelFunctions.set("foo");
             var returned_list = LocusZoom.LabelFunctions.list();
@@ -80,7 +80,7 @@ describe('LocusZoom Singletons', function(){
         });
         it("should throw an exception if asked to get a function that has not been defined", function(){
             assert.throws(function(){
-                LocusZoom.LabelFunctions.get("nonexistent", this.instance.state);
+                LocusZoom.LabelFunctions.get("nonexistent", {});
             });
         });
         it('should throw an exception when adding a new label function with an already in use name', function(){
@@ -218,7 +218,7 @@ describe('LocusZoom Singletons', function(){
         });
         it('should throw an exception if asked to get a function that has not been defined', function(){
             assert.throws(function(){
-                LocusZoom.ScaleFunctions.get("nonexistent", this.instance.state);
+                LocusZoom.ScaleFunctions.get("nonexistent", this.instance.layout.state);
             });
         });
         it('should throw an exception when adding a new scale function with an already in use name', function(){
@@ -334,7 +334,7 @@ describe('LocusZoom Singletons', function(){
         });
         it('should throw an exception if asked to get a function that has not been defined', function(){
             assert.throws(function(){
-                LocusZoom.DataLayers.get("nonexistent", this.instance.state);
+                LocusZoom.DataLayers.get("nonexistent", this.instance.layout.state);
             });
         });
         it('should throw an exception when trying to add a new data layer that is not a function', function(){


### PR DESCRIPTION
# What

This branch was built to address the idea put forth in #46 - a tool to be able to see an editable layout and plot side by side as an interactive Layout/Plot builder.

In building this tool a few latent bugs in initialization, layout parsing, and state I/O quickly surfaced. This led to an idea that's been brought up before coming to pass - **merging the layout and state**.

## Unified Layout

Wherever there once was a layout and/or a state, now there's just a layout. State is still there. It's just *inside* layout, and it's still called `state`.

From this the following changes fall out:

* Initialization functions like `LocusZoom.populate()` **still take `state` as a fourth argument for backward compatibility**. Now, however, `populate()`'s logic merges any state passed in with state defined in the passed in layout and state detected from the `data-region` parameter on the container into a single `state` object in the layout.  

* The nested structure of panels and data layers is no longer repeated in both layout and state.  

* A new state syntax has been developed for the states of panels and datalayers to allow for tracking their state in a deterministic way without building a deeply nested JSON object (the thinking here is to make it easy for implementers to pre-load state).

## Plot Builder

A new demo appears in this branch - `plot_builder.html`. This is a simple tool that shows a plot next to a textarea filled with the current layout with simple UI and hooks to keep them in sync with one another as either is changed.

### onUpdate()

To make the tool function the plot builder needed a means to know when the layout has been updated (e.g. the plot resizing, any data query, selecting elements in the plot, etc.) so this branch adds support for a user-defined `onUpdate()` event handler that can be added to a plot. It is automatically triggered whenever a plot's layout is effectively changed.

## Status

This branch is now **Development Complete**.

The attention paid to backward compatibility should mean that existing LocusZoom implementations are not disrupted, unless those implementations are directly passing state objects to pre-select points on data layers. That syntax has been simplified in this branch, so that change will need to be communicated.