### PR TITLE
Modify GeneSource to allow for positional transcript annotation

### DIFF
--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -662,8 +662,71 @@ LocusZoom.Data.GeneSource.prototype.getURL = function(state, chain, fields) {
         " and start le " + state.end +
         " and end ge " + state.start;
 };
+LocusZoom.Data.GeneSource.prototype.findTranscriptPositions = function(data, transName) {
+    var transData;
+    for(var g=0; g < data.length && !transData; g++) {
+        for (var t=0; t < data[g].transcripts.length; t++) {
+            if (data[g].transcripts[t].transcript_id==transName) {
+                transData = {
+                    start: data[g].transcripts[t].start,
+                    end: data[g].transcripts[t].end,
+                    exonStarts: [],
+                    exonEnds: []
+                };
+                data[g].transcripts[t].exons.forEach(function(ex) {
+                    transData.exonStarts.push(ex.start);
+                    transData.exonEnds.push(ex.end);
+                });
+                break;
+            }
+        }
+    }
+    return transData;
+};
+LocusZoom.Data.GeneSource.prototype.annotateOverlap = function(data, positions, outname) {
+    var between = function(x, a, b) {return x>=a && x<=b;};
+    //assuming exon positions are sorted and non-overlaping
+    var exid = 0;
+    for(var i=0; i < data.length; i++) {
+        var pos = data[i].position;
+        if (positions && between(pos, positions.start, positions.end)) {
+            //jump to "next" exon
+            while(exid < positions.exonEnds.length && pos > positions.exonEnds[exid]) {exid++;}
+            if( between(pos, positions.exonStarts[exid], positions.exonEnds[exid])) {
+                data[i][outname] = 2;
+            } else {
+                data[i][outname] = 1;
+            }
+        } else {
+            //trans not found or not in transcript
+            data[i][outname] = 0;
+        }
+    }
+};
 LocusZoom.Data.GeneSource.prototype.parseResponse = function(resp, chain, fields, outnames) {
-    return {header: chain.header, body: resp.data};
+    if (fields.length==1 & fields[0]=="gene") { 
+        //raw dump of gene info for genes panel 
+        return {header: chain.header, body: resp.data};
+    } else {
+        //should match "type(parameter)" where parameters are optional
+        var fregex = /([^()]+)(?:\(([^()]+)\))?/;
+        for (var f=0; f < fields.length; f++) {
+            var field = fields[f];
+            var outname = outnames[f];
+            var matches =  fregex.exec(field);
+            if ( matches[1] == "transanno" ) {
+                var transName = matches[2];
+                if (!transName) {throw("missing required transcript for transanno: " + field);}
+                if (!chain.body.length) {return chain;}
+                var transData = this.findTranscriptPositions(resp.data, transName);
+                //merge info into chain
+                this.annotateOverlap(chain.body, transData, outname);
+            } else {
+                throw("unrecognized gene field: " + field);
+            }
+        }
+        return chain;
+    }
 };
 LocusZoom.Data.GeneSource.SOURCE_NAME = "GeneLZ";
 


### PR DESCRIPTION
This is an extension of the gene data source to allow for annotation of positions indicating weather or not a position is in the exon of a transcript or not.

Now you can request a field from the gene data source like `gene:transanno(ENST00000277945.7)` and that will return 1 for each position that is in that transcript but not in an exon, 2 for each position in an exon of that transcript, and 0 otherwise.

The basic logic for the merging can be tested with

```
var gs = new LocusZoom.Data.GeneSource("http://foo.bar")
var mockResp = {data:[{gene:1, transcripts:[]},{gene:2, transcripts:[{transcript_id:"ENST1", start: 2, end:15, exons:[{start:2, end:3}, {start:7, end:12}]}]}]};
var mockChain = {body:[{position:1},{position:5}, {position:10}, {position:30}]};
gs.parseResponse(mockResp, mockChain, ["transanno(ENST1)"],["anno"])
```

With the demo page data_sources object ...

```
var req = new LocusZoom.Data.Requester(data_sources);
req.getData({chr:10, start:114550452, end:115067678},["position","pvalue","gene:transanno(ENST00000277945.7)"]).then(function(x) {console.log(x)}).done()
```

you should see that the 211st element has a value indicating inclusion in the gene
