### PR TITLE
Static Data and the Line Data Layer

### DIFF
--- a/assets/css/locuszoom.scss
+++ b/assets/css/locuszoom.scss
@@ -103,6 +103,12 @@ svg.#{$namespace}-locuszoom {
     stroke-width: 4;
   }
 
+  path.#{$namespace}-data_layer-line {
+    stroke: #{$default_black};
+    stroke-width: 1;
+    cursor: pointer;
+  }
+
   g.#{$namespace}-data_layer-gene {
     cursor: pointer;
   }

--- a/assets/css/locuszoom.scss
+++ b/assets/css/locuszoom.scss
@@ -109,6 +109,12 @@ svg.#{$namespace}-locuszoom {
     cursor: pointer;
   }
 
+  path.#{$namespace}-data_layer-line-hitarea {
+    stroke: transparent;
+    stroke-width: 12px;
+    cursor: pointer;
+  }
+
   g.#{$namespace}-data_layer-gene {
     cursor: pointer;
   }

--- a/assets/css/locuszoom.scss
+++ b/assets/css/locuszoom.scss
@@ -110,6 +110,7 @@ svg.#{$namespace}-locuszoom {
   }
 
   path.#{$namespace}-data_layer-line-hitarea {
+    fill: transparent;
     stroke: transparent;
     stroke-width: 12px;
     cursor: pointer;
@@ -165,40 +166,45 @@ div.#{$namespace}-data_layer-tooltip {
 }
 
 div.#{$namespace}-data_layer-tooltip-arrow_up {
-  width: 0; 
-  height: 0; 
+  width: 0;
+  height: 0;
+  pointer-events: none;
   border-left: #{$tooltip_arrow_width}px solid transparent;
   border-right: #{$tooltip_arrow_width}px solid transparent;
   border-bottom: #{$tooltip_arrow_width}px solid #{$default_black};
 }
 
 div.#{$namespace}-data_layer-tooltip-arrow_down {
-  width: 0; 
-  height: 0; 
+  width: 0;
+  height: 0;
+  pointer-events: none;
   border-left: #{$tooltip_arrow_width}px solid transparent;
   border-right: #{$tooltip_arrow_width}px solid transparent;
   border-top: #{$tooltip_arrow_width}px solid #{$default_black};
 }
 
 div.#{$namespace}-data_layer-tooltip-arrow_right {
-  width: 0; 
-  height: 0; 
+  width: 0;
+  height: 0;
+  pointer-events: none;
   border-top: #{$tooltip_arrow_width}px solid transparent;
   border-bottom: #{$tooltip_arrow_width}px solid transparent;
   border-left: #{$tooltip_arrow_width}px solid #{$default_black};
 }
 
 div.#{$namespace}-data_layer-tooltip-arrow_left {
-  width: 0; 
-  height: 0; 
+  width: 0;
+  height: 0;
+  pointer-events: none;
   border-top: #{$tooltip_arrow_width}px solid transparent;
   border-bottom: #{$tooltip_arrow_width}px solid transparent;
   border-right: #{$tooltip_arrow_width}px solid #{$default_black}; 
 }
 
 div.#{$namespace}-data_layer-tooltip-arrow_top_left {
-  width: 0; 
+  width: 0;
   height: 0;
+  pointer-events: none;
   border-top: #{$tooltip_arrow_width}px solid #{$default_black};
   border-left: #{$tooltip_arrow_width}px solid #{$default_black};
   border-bottom: #{$tooltip_arrow_width}px solid transparent;
@@ -206,8 +212,9 @@ div.#{$namespace}-data_layer-tooltip-arrow_top_left {
 }
 
 div.#{$namespace}-data_layer-tooltip-arrow_top_right {
-  width: 0; 
+  width: 0;
   height: 0;
+  pointer-events: none;
   border-top: #{$tooltip_arrow_width}px solid #{$default_black};
   border-left: #{$tooltip_arrow_width}px solid transparent;
   border-bottom: #{$tooltip_arrow_width}px solid transparent;
@@ -215,8 +222,9 @@ div.#{$namespace}-data_layer-tooltip-arrow_top_right {
 }
 
 div.#{$namespace}-data_layer-tooltip-arrow_bottom_left {
-  width: 0; 
+  width: 0;
   height: 0;
+  pointer-events: none;
   border-top: #{$tooltip_arrow_width}px solid transparent;
   border-left: #{$tooltip_arrow_width}px solid #{$default_black};
   border-bottom: #{$tooltip_arrow_width}px solid #{$default_black};
@@ -224,8 +232,9 @@ div.#{$namespace}-data_layer-tooltip-arrow_bottom_left {
 }
 
 div.#{$namespace}-data_layer-tooltip-arrow_bottom_right {
-  width: 0; 
+  width: 0;
   height: 0;
+  pointer-events: none;
   border-top: #{$tooltip_arrow_width}px solid transparent;
   border-left: #{$tooltip_arrow_width}px solid transparent;
   border-bottom: #{$tooltip_arrow_width}px solid #{$default_black};

--- a/assets/js/app/DataLayer.js
+++ b/assets/js/app/DataLayer.js
@@ -55,6 +55,10 @@ LocusZoom.DataLayer = function(id, layout, parent) {
         if (typeof id != "string"){
             throw ("Unable to create tooltip: id is not a string");
         }
+        if (this.tooltips[id]){
+            this.positionTooltip(id);
+            return;
+        }
         this.tooltips[id] = {
             data: d,
             arrow: null,

--- a/assets/js/app/DataLayer.js
+++ b/assets/js/app/DataLayer.js
@@ -213,6 +213,7 @@ LocusZoom.DataLayer.prototype.reMap = function(){
     // Fetch new data for data layers without static data
     if (this.layout.static_data){
         this.data = this.layout.static_data;
+        return Q.when(true);
     } else {
         var promise = this.parent.parent.lzd.getData(this.state, this.layout.fields); //,"ld:best"
         promise.then(function(new_data){

--- a/assets/js/app/DataLayer.js
+++ b/assets/js/app/DataLayer.js
@@ -244,17 +244,12 @@ LocusZoom.DataLayer.prototype.reMap = function(){
     this.destroyAllTooltips(); // hack - only non-visible tooltips should be destroyed
                                // and then recreated if returning to visibility
 
-    // Fetch new data for data layers without static data
-    if (this.layout.static_data){
-        this.data = this.layout.static_data;
+    // Fetch new data
+    var promise = this.parent.parent.lzd.getData(this.state, this.layout.fields); //,"ld:best"
+    promise.then(function(new_data){
+        this.data = new_data.body;
         this.initialized = true;
-        return Q.when(true);
-    } else {
-        var promise = this.parent.parent.lzd.getData(this.state, this.layout.fields); //,"ld:best"
-        promise.then(function(new_data){
-            this.data = new_data.body;
-            this.initialized = true;
-        }.bind(this));
-        return promise;
-    }
+    }.bind(this));
+    return promise;
+
 };

--- a/assets/js/app/Instance.js
+++ b/assets/js/app/Instance.js
@@ -325,9 +325,6 @@ LocusZoom.Instance.prototype.initialize = function(){
         this.mouse_guide.horizontal.attr("y", coords[1]);
     }.bind(this));
     
-    // Flip the "initialized" bit
-    this.initialized = true;
-
     return this;
 
 };
@@ -357,6 +354,7 @@ LocusZoom.Instance.prototype.mapTo = function(chr, start, end){
             this.curtain.drop(error);
         }.bind(this))
         .done(function(){
+            this.initialized = true;
             this.triggerOnUpdate();
         }.bind(this));
 
@@ -391,6 +389,7 @@ LocusZoom.Instance.prototype.applyState = function(new_state){
             this.curtain.drop(error);
         }.bind(this))
         .done(function(){
+            this.initialized = true;
             this.triggerOnUpdate();
         }.bind(this));
 

--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -323,8 +323,8 @@ LocusZoom.StandardLayout = {
                     fields: ["x", "y"],
                     style: {
                         "stroke": "#D3D3D3",
-                        "stroke-width": "3px",
-                        "stroke-dasharray": "10px 10px"
+                        "stroke-width": "3px"
+                        /* "stroke-dasharray": "10px 10px" */
                     },
                     x_axis: {
                         field: "x",
@@ -333,6 +333,9 @@ LocusZoom.StandardLayout = {
                     y_axis: {
                         axis: 1,
                         field: "y"
+                    },
+                    tooltip: {
+                        html: "significance"
                     },
                     static_data: [
                         { "x": 0, "y": 5 },

--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -331,6 +331,27 @@ LocusZoom.StandardLayout = {
                 }
             },
             data_layers: {
+                significance: {
+                    type: "line",
+                    fields: ["x", "y"],
+                    style: {
+                        "stroke": "#D3D3D3",
+                        "stroke-width": "3px",
+                        "stroke-dasharray": "10px 10px"
+                    },
+                    x_axis: {
+                        field: "x",
+                        decoupled: true
+                    },
+                    y_axis: {
+                        axis: 1,
+                        field: "y"
+                    },
+                    static_data: [
+                        { "x": 0, "y": 5 },
+                        { "x": 3000000000, "y": 5 }
+                    ]
+                },
                 positions: {
                     type: "scatter",
                     point_shape: "circle",
@@ -362,24 +383,6 @@ LocusZoom.StandardLayout = {
                             { html: "Ref. Allele: <strong>{{refAllele}}</strong>" }
                         ]
                     }
-                },
-                significance: {
-                    type: "scatter",
-                    point_shape: "cross",
-                    point_size: 40,
-                    color: "red",
-                    fields: ["x", "y"],
-                    x_axis: {
-                        field: "x"
-                    },
-                    y_axis: {
-                        axis: 1,
-                        field: "y"
-                    },
-                    static_data: [
-                        { "x": 114550452, "y": 5, id: "foo" },
-                        { "x": 115067678, "y": 5, id: "bar" }
-                    ]
                 }
             }
         },

--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -323,8 +323,8 @@ LocusZoom.StandardLayout = {
                     fields: ["x", "y"],
                     style: {
                         "stroke": "#D3D3D3",
-                        "stroke-width": "3px"
-                        /* "stroke-dasharray": "10px 10px" */
+                        "stroke-width": "3px",
+                        "stroke-dasharray": "10px 10px"
                     },
                     x_axis: {
                         field: "x",
@@ -335,11 +335,11 @@ LocusZoom.StandardLayout = {
                         field: "y"
                     },
                     tooltip: {
-                        html: "significance"
+                        html: "Significance Threshold: 3 × 10^-5"
                     },
                     static_data: [
-                        { "x": 0, "y": 5 },
-                        { "x": 3000000000, "y": 5 }
+                        { "x": 0, "y": 4.522 },
+                        { "x": 2881033286, "y": 4.522 }
                     ]
                 },
                 positions: {

--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -362,6 +362,24 @@ LocusZoom.StandardLayout = {
                             { html: "Ref. Allele: <strong>{{refAllele}}</strong>" }
                         ]
                     }
+                },
+                significance: {
+                    type: "scatter",
+                    point_shape: "cross",
+                    point_size: 40,
+                    color: "red",
+                    fields: ["x", "y"],
+                    x_axis: {
+                        field: "x"
+                    },
+                    y_axis: {
+                        axis: 1,
+                        field: "y"
+                    },
+                    static_data: [
+                        { "x": 114550452, "y": 5, id: "foo" },
+                        { "x": 115067678, "y": 5, id: "bar" }
+                    ]
                 }
             }
         },

--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -327,27 +327,23 @@ LocusZoom.StandardLayout = {
             data_layers: {
                 significance: {
                     type: "line",
-                    fields: ["x", "y"],
+                    fields: ["sig:x", "sig:y"],
                     style: {
                         "stroke": "#D3D3D3",
                         "stroke-width": "3px",
                         "stroke-dasharray": "10px 10px"
                     },
                     x_axis: {
-                        field: "x",
+                        field: "sig:x",
                         decoupled: true
                     },
                     y_axis: {
                         axis: 1,
-                        field: "y"
+                        field: "sig:y"
                     },
                     tooltip: {
                         html: "Significance Threshold: 3 × 10^-5"
-                    },
-                    static_data: [
-                        { "x": 0, "y": 4.522 },
-                        { "x": 2881033286, "y": 4.522 }
-                    ]
+                    }
                 },
                 positions: {
                     type: "scatter",

--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -323,7 +323,6 @@ LocusZoom.StandardLayout = {
                     label_function: "chromosome",
                     label_offset: 32,
                     tick_format: "region",
-
                 },
                 y1: {
                     label: "-log10 p-value",

--- a/assets/js/app/Panel.js
+++ b/assets/js/app/Panel.js
@@ -317,14 +317,14 @@ LocusZoom.Panel.prototype.generateExtents = function(){
 
         // If defined and not decoupled, merge the x extent of the data layer with the panel's x extent
         // If not defined but state has start and end values then default to that range
-        if (data_layer.layout.x_axis && !data_layer.layout.x_axis.decoupled){
+        if (data_layer.layout.x_axis && !data_layer.layout.x_axis.decoupled && typeof data_layer.layout.x_axis.field == "string"){
             this.x_extent = d3.extent((this.x_extent || []).concat(data_layer.getAxisExtent("x")));
         } else if (!isNaN(this.state.start) && !isNaN(this.state.end)) {
             this.x_extent = [this.state.start, this.state.end];
         }
 
         // If defined and not decoupled, merge the y extent of the data layer with the panel's appropriate y extent
-        if (data_layer.layout.y_axis && !data_layer.layout.y_axis.decoupled){
+        if (data_layer.layout.y_axis && !data_layer.layout.y_axis.decoupled && typeof data_layer.layout.y_axis.field == "string"){
             var y_axis = "y" + data_layer.layout.y_axis.axis;
             this[y_axis+"_extent"] = d3.extent((this[y_axis+"_extent"] || []).concat(data_layer.getAxisExtent("y")));
         }

--- a/assets/js/app/Panel.js
+++ b/assets/js/app/Panel.js
@@ -243,9 +243,6 @@ LocusZoom.Panel.prototype.initialize = function(){
         this.data_layers[id].initialize();
     }
 
-    // Flip the "initialized" bit
-    this.initialized = true;
-
     return this;
     
 };
@@ -294,6 +291,7 @@ LocusZoom.Panel.prototype.reMap = function(){
     // When all finished trigger a render
     return Q.all(this.data_promises)
         .then(function(){
+            this.initialized = true;
             this.render();
         }.bind(this))
         .catch(function(error){
@@ -316,15 +314,12 @@ LocusZoom.Panel.prototype.generateExtents = function(){
         var data_layer = this.data_layers[id];
 
         // If defined and not decoupled, merge the x extent of the data layer with the panel's x extent
-        // If not defined but state has start and end values then default to that range
-        if (data_layer.layout.x_axis && !data_layer.layout.x_axis.decoupled && typeof data_layer.layout.x_axis.field == "string"){
+        if (data_layer.layout.x_axis && !data_layer.layout.x_axis.decoupled){
             this.x_extent = d3.extent((this.x_extent || []).concat(data_layer.getAxisExtent("x")));
-        } else if (!isNaN(this.state.start) && !isNaN(this.state.end)) {
-            this.x_extent = [this.state.start, this.state.end];
         }
 
         // If defined and not decoupled, merge the y extent of the data layer with the panel's appropriate y extent
-        if (data_layer.layout.y_axis && !data_layer.layout.y_axis.decoupled && typeof data_layer.layout.y_axis.field == "string"){
+        if (data_layer.layout.y_axis && !data_layer.layout.y_axis.decoupled){
             var y_axis = "y" + data_layer.layout.y_axis.axis;
             this[y_axis+"_extent"] = d3.extent((this[y_axis+"_extent"] || []).concat(data_layer.getAxisExtent("y")));
         }

--- a/assets/js/app/Panel.js
+++ b/assets/js/app/Panel.js
@@ -318,16 +318,16 @@ LocusZoom.Panel.prototype.generateExtents = function(){
 
         var data_layer = this.data_layers[id];
 
-        // If defined, merge the x extent of the data layer with the panel's x extent
+        // If defined and not decoupled, merge the x extent of the data layer with the panel's x extent
         // If not defined but state has start and end values then default to that range
-        if (data_layer.layout.x_axis){
+        if (data_layer.layout.x_axis && !data_layer.layout.x_axis.decoupled){
             this.x_extent = d3.extent((this.x_extent || []).concat(data_layer.getAxisExtent("x")));
         } else if (!isNaN(this.state.start) && !isNaN(this.state.end)) {
             this.x_extent = [this.state.start, this.state.end];
         }
 
-        // If defined, merge the y extent of the data layer with the panel's appropriate y extent
-        if (data_layer.layout.y_axis){
+        // If defined and not decoupled, merge the y extent of the data layer with the panel's appropriate y extent
+        if (data_layer.layout.y_axis && !data_layer.layout.y_axis.decoupled){
             var y_axis = "y" + data_layer.layout.y_axis.axis;
             this[y_axis+"_extent"] = d3.extent((this[y_axis+"_extent"] || []).concat(data_layer.getAxisExtent("y")));
         }

--- a/assets/js/app/Singletons.js
+++ b/assets/js/app/Singletons.js
@@ -536,6 +536,8 @@ LocusZoom.DataLayers.add("line", function(id, layout, parent){
     // Var for storing the generated line function itself
     this.line = null;
 
+    this.tooltip_timeout = null;
+
     // Apply the arguments to set LocusZoom.DataLayer as the prototype
     LocusZoom.DataLayer.apply(this, arguments);
 
@@ -576,7 +578,10 @@ LocusZoom.DataLayers.add("line", function(id, layout, parent){
         var offset_right = Math.max((tooltip_box.width / 2) - display.x, 0);
         var offset_left = Math.max((tooltip_box.width / 2) + display.x - data_layer_width, 0);
         var left = page_origin.x + display.x - (tooltip_box.width / 2) - offset_left + offset_right;
-        var arrow_left = (tooltip_box.width / 2) - (arrow_width / 2) + offset_left - offset_right;
+        var min_arrow_left = arrow_width / 2;
+        var max_arrow_left = tooltip_box.width - (2.5 * arrow_width);
+        var arrow_left = (tooltip_box.width / 2) - arrow_width + offset_left - offset_right;
+        arrow_left = Math.min(Math.max(arrow_left, min_arrow_left), max_arrow_left);
 
         // Position vertically above the line unless there's insufficient space
         var top, arrow_type, arrow_top;
@@ -616,9 +621,9 @@ LocusZoom.DataLayers.add("line", function(id, layout, parent){
         // Join data to the line selection
         var selection = this.svg.group
             .selectAll("path.lz-data_layer-line")
-            .data([this.data]); //, function(d){ return d.x + "," + d.y; }
+            .data([this.data]);
 
-        // Create elements, apply class and ID
+        // Create path element, apply class
         selection.enter()
             .append("path")
             .attr("class", "lz-data_layer-line");
@@ -645,18 +650,36 @@ LocusZoom.DataLayers.add("line", function(id, layout, parent){
 
         // Apply tooltip, etc
         if (this.layout.tooltip){
-            selection.on("mouseover", function(d){
-                data_layer.mouse_event = this;
-                data_layer.createTooltip(d, data_layer.state_id);
-            })
-            .on("mousemove", function(){
-                data_layer.mouse_event = this;
-                data_layer.positionTooltip(data_layer.state_id);
-            })
-            .on("mouseout", function(){
-                data_layer.mouse_event = null;
-                data_layer.destroyTooltip(data_layer.state_id);
-            });
+            // Generate an overlaying transparent "hit area" line for more intuitive mouse events
+            var hitarea = this.svg.group
+                .selectAll("path.lz-data_layer-line-hitarea")
+                .data([this.data]);
+            hitarea.enter()
+                .append("path")
+                .attr("class", "lz-data_layer-line-hitarea");
+            var hitarea_line = d3.svg.line()
+                .x(function(d) { return panel[x_scale](d[x_field]); })
+                .y(function(d) { return panel[y_scale](d[y_field]); })
+                .interpolate(this.layout.interpolate);
+            hitarea
+                .attr("d", hitarea_line)
+                .on("mouseover", function(d){
+                    clearTimeout(data_layer.tooltip_timeout);
+                    data_layer.mouse_event = this;
+                    data_layer.createTooltip(d, data_layer.state_id);
+                })
+                .on("mousemove", function(){
+                    clearTimeout(data_layer.tooltip_timeout);
+                    data_layer.mouse_event = this;
+                    data_layer.positionTooltip(data_layer.state_id);
+                })
+                .on("mouseout", function(){
+                    data_layer.tooltip_timeout = setTimeout(function(){
+                        data_layer.mouse_event = null;
+                        data_layer.destroyTooltip(data_layer.state_id);
+                    }, 300);
+                });
+            hitarea.exit().remove();
         }
 
         // Remove old elements as needed

--- a/assets/js/app/Singletons.js
+++ b/assets/js/app/Singletons.js
@@ -605,8 +605,10 @@ LocusZoom.DataLayers.add("line", function(id, layout, parent){
 
     // Define a default layout for this DataLayer type and merge it with the passed argument
     this.DefaultLayout = {
-        style: {},
-        interpolate: "basis",
+        style: {
+            fill: "transparent"
+        },
+        interpolate: "linear",
         x_axis: { field: "x" },
         y_axis: { field: "y", axis: 1 },
         selectable: false
@@ -640,17 +642,17 @@ LocusZoom.DataLayers.add("line", function(id, layout, parent){
         var data_layer_height = this.parent.layout.height - (this.parent.layout.margin.top + this.parent.layout.margin.bottom);
         var data_layer_width = this.parent.layout.width - (this.parent.layout.margin.left + this.parent.layout.margin.right);
 
-        // Determine x/y coordinates for dispaly and data
+        // Determine x/y coordinates for display and data
         var x_field = this.layout.x_axis.field;
         var y_field = this.layout.y_axis.field;
         var x_scale = "x_scale";
         var y_scale = "y" + this.layout.y_axis.axis + "_scale";
         var display = { x: d3.mouse(this.mouse_event)[0], y: null };
         var data = { x: this.parent[x_scale].invert(display.x), y: null };
-        var bisect = d3.bisector(function(datum) { return datum.x; }).right;
-        var index = bisect(this.data, data.x);
-        var startDatum = this.data[index - 1];
-        var endDatum = this.data[index];
+        var bisect = d3.bisector(function(datum) { return datum[x_field]; }).left;
+        var index = bisect(this.data, data.x) - 1;
+        var startDatum = this.data[index];
+        var endDatum = this.data[index + 1];
         var interpolate = d3.interpolateNumber(startDatum[y_field], endDatum[y_field]);
         var range = endDatum[x_field] - startDatum[x_field];
         data.y = interpolate((data.x % range) / range);

--- a/assets/js/app/Singletons.js
+++ b/assets/js/app/Singletons.js
@@ -509,7 +509,76 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, parent){
     };
        
     return this;
+
 });
+
+
+/*********************
+  Line Data Layer
+  Implements a standard line plot
+*/
+
+LocusZoom.DataLayers.add("line", function(id, layout, parent){
+
+    // Define a default layout for this DataLayer type and merge it with the passed argument
+    this.DefaultLayout = {
+        style: {},
+        interpolate: "basis",
+        x_axis: { field: "x" },
+        y_axis: { field: "y", axis: 1 },
+        selectable: false
+    };
+    layout = LocusZoom.mergeLayouts(layout, this.DefaultLayout);
+
+    // Apply the arguments to set LocusZoom.DataLayer as the prototype
+    LocusZoom.DataLayer.apply(this, arguments);
+
+    // Implement the main render function
+    this.render = function(){
+
+        var selection = this.svg.group
+            .selectAll("path.lz-data_layer-line")
+            .data([this.data]); //, function(d){ return d.x + "," + d.y; }
+
+        // Create elements, apply class and ID
+        selection.enter()
+            .append("path")
+            .attr("class", "lz-data_layer-line");
+
+        // Generate the line
+        var panel = this.parent;
+        var x_field = this.layout.x_axis.field;
+        var y_field = this.layout.y_axis.field;
+        var x_scale = "x_scale";
+        var y_scale = "y" + this.layout.y_axis.axis + "_scale";
+        var line = d3.svg.line()
+            .x(function(d) { return panel[x_scale](d[x_field]); })
+            .y(function(d) { return panel[y_scale](d[y_field]); })
+            .interpolate(this.layout.interpolate);
+
+        // Apply line and style
+        if (this.layout.transition){
+            selection
+                .transition()
+                .duration(this.layout.transition.duration || 0)
+                .ease(this.layout.transition.ease || "cubic-in-out")
+                .attr("d", line)
+                .style(this.layout.style);
+        } else {
+            selection
+                .attr("d", line)
+                .style(this.layout.style);
+        }
+
+        // Remove old elements as needed
+        selection.exit().remove();
+        
+    };
+       
+    return this;
+
+});
+
 
 /*********************
   Genes Data Layer
@@ -940,4 +1009,5 @@ LocusZoom.DataLayers.add("genes", function(id, layout, parent){
     };
        
     return this;
+
 });

--- a/demo.html
+++ b/demo.html
@@ -39,11 +39,12 @@
 
     // Define LocusZoom Data Sources object
     var apiBase = "http://portaldev.sph.umich.edu/api_internal_dev/v1/";
-    var data_sources = new LocusZoom.DataSources();
-    data_sources.add("base", ["AssociationLZ", {url: apiBase + "single/", params: {analysis: 3}}]);
-    data_sources.add("ld", ["LDLZ" ,apiBase + "pair/LD/"]);
-    data_sources.add("gene", ["GeneLZ", { url: apiBase + "annotation/genes/", params: {source: 2} }]);
-    data_sources.add("recomb", ["RecombLZ", { url: apiBase + "recomb/results/", params: {source: 15} }]);
+    var data_sources = new LocusZoom.DataSources()
+      .add("base", ["AssociationLZ", {url: apiBase + "single/", params: {analysis: 3}}])
+      .add("ld", ["LDLZ" ,apiBase + "pair/LD/"])
+      .add("gene", ["GeneLZ", { url: apiBase + "annotation/genes/", params: {source: 2} }])
+      .add("sig", ["StaticJSON", [{ "x": 0, "y": 4.522 }, { "x": 2881033286, "y": 4.522 }] ])
+      .add("recomb", ["RecombLZ", { url: apiBase + "recomb/results/", params: {source: 15} }]);
 
     // Define custom LocusZoom layout object to allow manual resizing.
     // This will be merged with the default layout (LocusZoom.DefaultLayout)

--- a/demo_responsive.html
+++ b/demo_responsive.html
@@ -32,10 +32,11 @@
 
     // Define LocusZoom Data Sources object
     var apiBase = "http://portaldev.sph.umich.edu/api/v1/";
-    var data_sources = new LocusZoom.DataSources();
-    data_sources.add("base", ["AssociationLZ", {url:apiBase + "single/", params: {analysis: 3}}]);
-    data_sources.add("ld", ["LDLZ" ,apiBase + "pair/LD/"]);
-    data_sources.add("gene", ["GeneLZ", { url: apiBase + "annotation/genes/", params: {source: 2} }]);
+    var data_sources = new LocusZoom.DataSources()
+      .add("base", ["AssociationLZ", {url:apiBase + "single/", params: {analysis: 3}}])
+      .add("ld", ["LDLZ" ,apiBase + "pair/LD/"])
+      .add("gene", ["GeneLZ", { url: apiBase + "annotation/genes/", params: {source: 2} }])
+      .add("sig", ["StaticJSON", [{ "x": 0, "y": 4.522 }, { "x": 2881033286, "y": 4.522 }] ]);
 
     // Populate the div with a LocusZoom plot
     var demo_instance = LocusZoom.populate("#lz-1", data_sources);

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -337,8 +337,8 @@ LocusZoom.StandardLayout = {
                     fields: ["x", "y"],
                     style: {
                         "stroke": "#D3D3D3",
-                        "stroke-width": "3px",
-                        "stroke-dasharray": "10px 10px"
+                        "stroke-width": "3px"
+                        /* "stroke-dasharray": "10px 10px" */
                     },
                     x_axis: {
                         field: "x",
@@ -347,6 +347,9 @@ LocusZoom.StandardLayout = {
                     y_axis: {
                         axis: 1,
                         field: "y"
+                    },
+                    tooltip: {
+                        html: "significance"
                     },
                     static_data: [
                         { "x": 0, "y": 5 },
@@ -1428,14 +1431,14 @@ LocusZoom.Panel.prototype.generateExtents = function(){
 
         // If defined and not decoupled, merge the x extent of the data layer with the panel's x extent
         // If not defined but state has start and end values then default to that range
-        if (data_layer.layout.x_axis && !data_layer.layout.x_axis.decoupled){
+        if (data_layer.layout.x_axis && !data_layer.layout.x_axis.decoupled && typeof data_layer.layout.x_axis.field == "string"){
             this.x_extent = d3.extent((this.x_extent || []).concat(data_layer.getAxisExtent("x")));
         } else if (!isNaN(this.state.start) && !isNaN(this.state.end)) {
             this.x_extent = [this.state.start, this.state.end];
         }
 
         // If defined and not decoupled, merge the y extent of the data layer with the panel's appropriate y extent
-        if (data_layer.layout.y_axis && !data_layer.layout.y_axis.decoupled){
+        if (data_layer.layout.y_axis && !data_layer.layout.y_axis.decoupled && typeof data_layer.layout.y_axis.field == "string"){
             var y_axis = "y" + data_layer.layout.y_axis.axis;
             this[y_axis+"_extent"] = d3.extent((this[y_axis+"_extent"] || []).concat(data_layer.getAxisExtent("y")));
         }
@@ -2387,12 +2390,90 @@ LocusZoom.DataLayers.add("line", function(id, layout, parent){
     };
     layout = LocusZoom.mergeLayouts(layout, this.DefaultLayout);
 
+    // Var for storing mouse events for use in tool tip positioning
+    this.mouse_event = null;
+
+    // Var for storing the generated line function itself
+    this.line = null;
+
     // Apply the arguments to set LocusZoom.DataLayer as the prototype
     LocusZoom.DataLayer.apply(this, arguments);
+
+    // Reimplement the positionTooltip() method to be line-specific
+    this.positionTooltip = function(id){
+        if (typeof id != "string"){
+            throw ("Unable to position tooltip: id is not a string");
+        }
+        if (!this.tooltips[id]){
+            throw ("Unable to position tooltip: id does not point to a valid tooltip");
+        }
+        var tooltip = this.tooltips[id];
+        var arrow_width = 7; // as defined in the default stylesheet
+        var stroke_width = 1; // as defined in the default stylesheet
+        var page_origin = this.getPageOrigin();
+        var tooltip_box = tooltip.selector.node().getBoundingClientRect();
+        var data_layer_height = this.parent.layout.height - (this.parent.layout.margin.top + this.parent.layout.margin.bottom);
+        var data_layer_width = this.parent.layout.width - (this.parent.layout.margin.left + this.parent.layout.margin.right);
+
+        // Determine x/y coordinates for dispaly and data
+        var x_field = this.layout.x_axis.field;
+        var y_field = this.layout.y_axis.field;
+        var x_scale = "x_scale";
+        var y_scale = "y" + this.layout.y_axis.axis + "_scale";
+        var display = { x: d3.mouse(this.mouse_event)[0], y: null };
+        var data = { x: this.parent[x_scale].invert(display.x), y: null };
+        var bisect = d3.bisector(function(datum) { return datum.x; }).right;
+        var index = bisect(this.data, data.x);
+        var startDatum = this.data[index - 1];
+        var endDatum = this.data[index];
+        var interpolate = d3.interpolateNumber(startDatum[y_field], endDatum[y_field]);
+        var range = endDatum[x_field] - startDatum[x_field];
+        data.y = interpolate((data.x % range) / range);
+        display.y = this.parent[y_scale](data.y);
+
+        // Position horizontally: attempt to center on the mouse's x coordinate
+        // pad to either side if bumping up against the edge of the data layer
+        var offset_right = Math.max((tooltip_box.width / 2) - display.x, 0);
+        var offset_left = Math.max((tooltip_box.width / 2) + display.x - data_layer_width, 0);
+        var left = page_origin.x + display.x - (tooltip_box.width / 2) - offset_left + offset_right;
+        var arrow_left = (tooltip_box.width / 2) - (arrow_width / 2) + offset_left - offset_right;
+
+        // Position vertically above the line unless there's insufficient space
+        var top, arrow_type, arrow_top;
+        if (tooltip_box.height + stroke_width + arrow_width < data_layer_height - display.y){
+            top = page_origin.y + display.y + stroke_width + arrow_width;
+            arrow_type = "up";
+            arrow_top = 0 - stroke_width - arrow_width;
+        } else {
+            top = page_origin.y + display.y - (tooltip_box.height + stroke_width + arrow_width);
+            arrow_type = "down";
+            arrow_top = tooltip_box.height - stroke_width;
+        }
+
+        // Apply positions to the main div
+        tooltip.selector.style("left", left + "px").style("top", top + "px");
+        // Create / update position on arrow connecting tooltip to data
+        if (!tooltip.arrow){
+            tooltip.arrow = tooltip.selector.append("div").style("position", "absolute");
+        }
+        tooltip.arrow
+            .attr("class", "lz-data_layer-tooltip-arrow_" + arrow_type)
+            .style("left", arrow_left + "px")
+            .style("top", arrow_top + "px");
+    };
 
     // Implement the main render function
     this.render = function(){
 
+        // Several vars needed to be in scope
+        var data_layer = this;
+        var panel = this.parent;
+        var x_field = this.layout.x_axis.field;
+        var y_field = this.layout.y_axis.field;
+        var x_scale = "x_scale";
+        var y_scale = "y" + this.layout.y_axis.axis + "_scale";
+
+        // Join data to the line selection
         var selection = this.svg.group
             .selectAll("path.lz-data_layer-line")
             .data([this.data]); //, function(d){ return d.x + "," + d.y; }
@@ -2403,12 +2484,7 @@ LocusZoom.DataLayers.add("line", function(id, layout, parent){
             .attr("class", "lz-data_layer-line");
 
         // Generate the line
-        var panel = this.parent;
-        var x_field = this.layout.x_axis.field;
-        var y_field = this.layout.y_axis.field;
-        var x_scale = "x_scale";
-        var y_scale = "y" + this.layout.y_axis.axis + "_scale";
-        var line = d3.svg.line()
+        this.line = d3.svg.line()
             .x(function(d) { return panel[x_scale](d[x_field]); })
             .y(function(d) { return panel[y_scale](d[y_field]); })
             .interpolate(this.layout.interpolate);
@@ -2419,12 +2495,28 @@ LocusZoom.DataLayers.add("line", function(id, layout, parent){
                 .transition()
                 .duration(this.layout.transition.duration || 0)
                 .ease(this.layout.transition.ease || "cubic-in-out")
-                .attr("d", line)
+                .attr("d", this.line)
                 .style(this.layout.style);
         } else {
             selection
-                .attr("d", line)
+                .attr("d", this.line)
                 .style(this.layout.style);
+        }
+
+        // Apply tooltip, etc
+        if (this.layout.tooltip){
+            selection.on("mouseover", function(d){
+                data_layer.mouse_event = this;
+                data_layer.createTooltip(d, data_layer.state_id);
+            })
+            .on("mousemove", function(){
+                data_layer.mouse_event = this;
+                data_layer.positionTooltip(data_layer.state_id);
+            })
+            .on("mouseout", function(){
+                data_layer.mouse_event = null;
+                data_layer.destroyTooltip(data_layer.state_id);
+            });
         }
 
         // Remove old elements as needed

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -1039,9 +1039,6 @@ LocusZoom.Instance.prototype.initialize = function(){
         this.mouse_guide.horizontal.attr("y", coords[1]);
     }.bind(this));
     
-    // Flip the "initialized" bit
-    this.initialized = true;
-
     return this;
 
 };
@@ -1071,6 +1068,7 @@ LocusZoom.Instance.prototype.mapTo = function(chr, start, end){
             this.curtain.drop(error);
         }.bind(this))
         .done(function(){
+            this.initialized = true;
             this.triggerOnUpdate();
         }.bind(this));
 
@@ -1105,6 +1103,7 @@ LocusZoom.Instance.prototype.applyState = function(new_state){
             this.curtain.drop(error);
         }.bind(this))
         .done(function(){
+            this.initialized = true;
             this.triggerOnUpdate();
         }.bind(this));
 
@@ -1357,9 +1356,6 @@ LocusZoom.Panel.prototype.initialize = function(){
         this.data_layers[id].initialize();
     }
 
-    // Flip the "initialized" bit
-    this.initialized = true;
-
     return this;
     
 };
@@ -1408,6 +1404,7 @@ LocusZoom.Panel.prototype.reMap = function(){
     // When all finished trigger a render
     return Q.all(this.data_promises)
         .then(function(){
+            this.initialized = true;
             this.render();
         }.bind(this))
         .catch(function(error){
@@ -1430,15 +1427,12 @@ LocusZoom.Panel.prototype.generateExtents = function(){
         var data_layer = this.data_layers[id];
 
         // If defined and not decoupled, merge the x extent of the data layer with the panel's x extent
-        // If not defined but state has start and end values then default to that range
-        if (data_layer.layout.x_axis && !data_layer.layout.x_axis.decoupled && typeof data_layer.layout.x_axis.field == "string"){
+        if (data_layer.layout.x_axis && !data_layer.layout.x_axis.decoupled){
             this.x_extent = d3.extent((this.x_extent || []).concat(data_layer.getAxisExtent("x")));
-        } else if (!isNaN(this.state.start) && !isNaN(this.state.end)) {
-            this.x_extent = [this.state.start, this.state.end];
         }
 
         // If defined and not decoupled, merge the y extent of the data layer with the panel's appropriate y extent
-        if (data_layer.layout.y_axis && !data_layer.layout.y_axis.decoupled && typeof data_layer.layout.y_axis.field == "string"){
+        if (data_layer.layout.y_axis && !data_layer.layout.y_axis.decoupled){
             var y_axis = "y" + data_layer.layout.y_axis.axis;
             this[y_axis+"_extent"] = d3.extent((this[y_axis+"_extent"] || []).concat(data_layer.getAxisExtent("y")));
         }
@@ -1794,28 +1788,47 @@ LocusZoom.DataLayer.prototype.getAxisExtent = function(dimension){
 
     var axis = dimension + "_axis";
 
-    var extent = d3.extent(this.data, function(d) {
-        return +d[this.layout[axis].field];
-    }.bind(this));
-
-    // Apply upper/lower buffers, if applicable
-    var original_extent_span = extent[1] - extent[0];
-    if (!isNaN(this.layout[axis].lower_buffer)){ extent.push(extent[0] - (original_extent_span * this.layout[axis].lower_buffer)); }
-    if (!isNaN(this.layout[axis].upper_buffer)){ extent.push(extent[1] + (original_extent_span * this.layout[axis].upper_buffer)); }
-
-    // Apply minimum extent
-    if (typeof this.layout[axis].min_extent == "object" && !isNaN(this.layout[axis].min_extent[0]) && !isNaN(this.layout[axis].min_extent[1])){
-        extent.push(this.layout[axis].min_extent[0], this.layout[axis].min_extent[1]);
+    // If a floor AND a ceiling are explicitly defined then jsut return that extent and be done
+    if (!isNaN(this.layout[axis].floor) && !isNaN(this.layout[axis].ceiling)){
+        return [+this.layout[axis].floor, +this.layout[axis].ceiling];
     }
 
-    // Generate a new base extent
-    extent = d3.extent(extent);
+    // If a field is defined for the axis and the data layer has data then generate the extent from the data set
+    if (this.layout[axis].field && this.data && this.data.length){
 
-    // Apply floor/ceiling, if applicable
-    if (!isNaN(this.layout[axis].floor)){ extent[0] = this.layout[axis].floor; }
-    if (!isNaN(this.layout[axis].ceiling)){ extent[1] = this.layout[axis].ceiling; }
+        var extent = d3.extent(this.data, function(d) {
+            return +d[this.layout[axis].field];
+        }.bind(this));
 
-    return extent;
+        // Apply upper/lower buffers, if applicable
+        var original_extent_span = extent[1] - extent[0];
+        if (!isNaN(this.layout[axis].lower_buffer)){ extent.push(extent[0] - (original_extent_span * this.layout[axis].lower_buffer)); }
+        if (!isNaN(this.layout[axis].upper_buffer)){ extent.push(extent[1] + (original_extent_span * this.layout[axis].upper_buffer)); }
+
+        // Apply minimum extent
+        if (typeof this.layout[axis].min_extent == "object" && !isNaN(this.layout[axis].min_extent[0]) && !isNaN(this.layout[axis].min_extent[1])){
+            extent.push(this.layout[axis].min_extent[0], this.layout[axis].min_extent[1]);
+        }
+
+        // Generate a new base extent
+        extent = d3.extent(extent);
+        
+        // Apply floor/ceiling, if applicable
+        if (!isNaN(this.layout[axis].floor)){ extent[0] = this.layout[axis].floor; }
+        if (!isNaN(this.layout[axis].ceiling)){ extent[1] = this.layout[axis].ceiling; }
+
+        return extent;
+
+    }
+
+    // If this is for the x axis and no extent could be generated yet but state has a defined start and end
+    // then default to using the state-defined region as the extent
+    if (dimension == "x" && !isNaN(this.state.start) && !isNaN(this.state.end)) {
+        return [this.state.start, this.state.end];
+    }
+
+    // No conditions met for generating a valid extent, return an empty array
+    return [];
 
 };
 
@@ -1835,9 +1848,6 @@ LocusZoom.DataLayer.prototype.initialize = function(){
     this.svg.group = this.svg.container.append("g")
         .attr("id", this.getBaseId() + ".data_layer")
         .attr("clip-path", "url(#" + this.getBaseId() + ".clip)");
-
-    // Flip the "initialized" bit
-    this.initialized = true;
 
     return this;
 
@@ -1861,11 +1871,13 @@ LocusZoom.DataLayer.prototype.reMap = function(){
     // Fetch new data for data layers without static data
     if (this.layout.static_data){
         this.data = this.layout.static_data;
+        this.initialized = true;
         return Q.when(true);
     } else {
         var promise = this.parent.parent.lzd.getData(this.state, this.layout.fields); //,"ld:best"
         promise.then(function(new_data){
             this.data = new_data.body;
+            this.initialized = true;
         }.bind(this));
         return promise;
     }

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -1844,6 +1844,7 @@ LocusZoom.DataLayer.prototype.reMap = function(){
     // Fetch new data for data layers without static data
     if (this.layout.static_data){
         this.data = this.layout.static_data;
+        return Q.when(true);
     } else {
         var promise = this.parent.parent.lzd.getData(this.state, this.layout.fields); //,"ld:best"
         promise.then(function(new_data){

--- a/locuszoom.css
+++ b/locuszoom.css
@@ -68,6 +68,10 @@ svg.lz-locuszoom {
     stroke: rgba(24, 24, 24, 1);
     stroke-width: 1;
     cursor: pointer; }
+  svg.lz-locuszoom path.lz-data_layer-line-hitarea {
+    stroke: transparent;
+    stroke-width: 12px;
+    cursor: pointer; }
   svg.lz-locuszoom g.lz-data_layer-gene {
     cursor: pointer; }
   svg.lz-locuszoom text.lz-data_layer-gene.lz-label {

--- a/locuszoom.css
+++ b/locuszoom.css
@@ -69,6 +69,7 @@ svg.lz-locuszoom {
     stroke-width: 1;
     cursor: pointer; }
   svg.lz-locuszoom path.lz-data_layer-line-hitarea {
+    fill: transparent;
     stroke: transparent;
     stroke-width: 12px;
     cursor: pointer; }
@@ -108,6 +109,7 @@ div.lz-data_layer-tooltip {
 div.lz-data_layer-tooltip-arrow_up {
   width: 0;
   height: 0;
+  pointer-events: none;
   border-left: 7px solid transparent;
   border-right: 7px solid transparent;
   border-bottom: 7px solid rgba(24, 24, 24, 1); }
@@ -115,6 +117,7 @@ div.lz-data_layer-tooltip-arrow_up {
 div.lz-data_layer-tooltip-arrow_down {
   width: 0;
   height: 0;
+  pointer-events: none;
   border-left: 7px solid transparent;
   border-right: 7px solid transparent;
   border-top: 7px solid rgba(24, 24, 24, 1); }
@@ -122,6 +125,7 @@ div.lz-data_layer-tooltip-arrow_down {
 div.lz-data_layer-tooltip-arrow_right {
   width: 0;
   height: 0;
+  pointer-events: none;
   border-top: 7px solid transparent;
   border-bottom: 7px solid transparent;
   border-left: 7px solid rgba(24, 24, 24, 1); }
@@ -129,6 +133,7 @@ div.lz-data_layer-tooltip-arrow_right {
 div.lz-data_layer-tooltip-arrow_left {
   width: 0;
   height: 0;
+  pointer-events: none;
   border-top: 7px solid transparent;
   border-bottom: 7px solid transparent;
   border-right: 7px solid rgba(24, 24, 24, 1); }
@@ -136,6 +141,7 @@ div.lz-data_layer-tooltip-arrow_left {
 div.lz-data_layer-tooltip-arrow_top_left {
   width: 0;
   height: 0;
+  pointer-events: none;
   border-top: 7px solid rgba(24, 24, 24, 1);
   border-left: 7px solid rgba(24, 24, 24, 1);
   border-bottom: 7px solid transparent;
@@ -144,6 +150,7 @@ div.lz-data_layer-tooltip-arrow_top_left {
 div.lz-data_layer-tooltip-arrow_top_right {
   width: 0;
   height: 0;
+  pointer-events: none;
   border-top: 7px solid rgba(24, 24, 24, 1);
   border-left: 7px solid transparent;
   border-bottom: 7px solid transparent;
@@ -152,6 +159,7 @@ div.lz-data_layer-tooltip-arrow_top_right {
 div.lz-data_layer-tooltip-arrow_bottom_left {
   width: 0;
   height: 0;
+  pointer-events: none;
   border-top: 7px solid transparent;
   border-left: 7px solid rgba(24, 24, 24, 1);
   border-bottom: 7px solid rgba(24, 24, 24, 1);
@@ -160,6 +168,7 @@ div.lz-data_layer-tooltip-arrow_bottom_left {
 div.lz-data_layer-tooltip-arrow_bottom_right {
   width: 0;
   height: 0;
+  pointer-events: none;
   border-top: 7px solid transparent;
   border-left: 7px solid transparent;
   border-bottom: 7px solid rgba(24, 24, 24, 1);

--- a/locuszoom.css
+++ b/locuszoom.css
@@ -64,6 +64,10 @@ svg.lz-locuszoom {
   svg.lz-locuszoom path.lz-data_layer-scatter-selected {
     stroke: rgba(24, 24, 24, 1);
     stroke-width: 4; }
+  svg.lz-locuszoom path.lz-data_layer-line {
+    stroke: rgba(24, 24, 24, 1);
+    stroke-width: 1;
+    cursor: pointer; }
   svg.lz-locuszoom g.lz-data_layer-gene {
     cursor: pointer; }
   svg.lz-locuszoom text.lz-data_layer-gene.lz-label {

--- a/plot_builder.html
+++ b/plot_builder.html
@@ -88,10 +88,12 @@
 
     // Define LocusZoom Data Sources object
     var apiBase = "http://portaldev.sph.umich.edu/api/v1/";
-    var data_sources = new LocusZoom.DataSources();
-    data_sources.add("base", ["AssociationLZ", {url:apiBase + "single/", params: {analysis: 3}}]);
-    data_sources.add("ld", ["LDLZ" ,apiBase + "pair/LD/"]);
-    data_sources.add("gene", ["GeneLZ", { url: apiBase + "annotation/genes/", params: {source: 2} }]);
+    var data_sources = new LocusZoom.DataSources()
+      .add("base", ["AssociationLZ", {url:apiBase + "single/", params: {analysis: 3}}])
+      .add("ld", ["LDLZ" ,apiBase + "pair/LD/"])
+      .add("gene", ["GeneLZ", { url: apiBase + "annotation/genes/", params: {source: 2} }])
+      .add("sig", ["StaticJSON", [{ "x": 0, "y": 4.522 }, { "x": 2881033286, "y": 4.522 }] ]);
+
 
     var plot;
 

--- a/test/DataLayer.js
+++ b/test/DataLayer.js
@@ -67,16 +67,30 @@ describe('LocusZoom.DataLayer', function(){
         });
     });
 
+    describe("Static data pass-through", function() {
+        it("allows for defining persistent static data", function() {
+            this.layout = {
+                static_data: [
+                    { x: 1 }, { x: 2 }, { x: 3 }
+                ]
+            };
+            this.datalayer = new LocusZoom.DataLayer("test", this.layout);
+            this.datalayer.reMap();
+            assert.deepEqual(this.datalayer.data, this.layout.static_data);
+        });
+    });
+
     describe("Extent generation", function() {
         it("has a method to generate an extent function for any axis", function() {
             this.datalayer = new LocusZoom.DataLayer("test", {});
             this.datalayer.getAxisExtent.should.be.a.Function;
         });
         it("throws an error on invalid axis identifiers", function() {
-            assert.throws(function(){ this.datalayer.getAxisExtent(); }.bind(this));
-            assert.throws(function(){ this.datalayer.getAxisExtent("foo"); }.bind(this));
-            assert.throws(function(){ this.datalayer.getAxisExtent(1); }.bind(this));
-            assert.throws(function(){ this.datalayer.getAxisExtent("y1"); }.bind(this));
+            var data_layer = new LocusZoom.DataLayer();
+            assert.throws(function(){ datalayer.getAxisExtent(); });
+            assert.throws(function(){ datalayer.getAxisExtent("foo"); });
+            assert.throws(function(){ datalayer.getAxisExtent(1); });
+            assert.throws(function(){ datalayer.getAxisExtent("y1"); });
         });
         it("generates an accurate extent array for arbitrary data sets", function() {
             this.layout = {

--- a/test/DataLayer.js
+++ b/test/DataLayer.js
@@ -67,19 +67,6 @@ describe('LocusZoom.DataLayer', function(){
         });
     });
 
-    describe("Static data pass-through", function() {
-        it("allows for defining persistent static data", function() {
-            this.layout = {
-                static_data: [
-                    { x: 1 }, { x: 2 }, { x: 3 }
-                ]
-            };
-            this.datalayer = new LocusZoom.DataLayer("test", this.layout);
-            this.datalayer.reMap();
-            assert.deepEqual(this.datalayer.data, this.layout.static_data);
-        });
-    });
-
     describe("Extent generation", function() {
         it("has a method to generate an extent function for any axis", function() {
             this.datalayer = new LocusZoom.DataLayer("test", {});

--- a/test/DataLayer.js
+++ b/test/DataLayer.js
@@ -78,6 +78,142 @@ describe('LocusZoom.DataLayer', function(){
             assert.throws(function(){ this.datalayer.getAxisExtent(1); }.bind(this));
             assert.throws(function(){ this.datalayer.getAxisExtent("y1"); }.bind(this));
         });
+        it("generates an accurate extent array for arbitrary data sets", function() {
+            this.layout = {
+                x_axis: { field: "x" }
+            }
+            this.datalayer = new LocusZoom.DataLayer("test", this.layout);
+            this.datalayer.data = [
+                { x: 1 }, { x: 2 }, { x: 3 }, { x: 4 }
+            ];
+            assert.deepEqual(this.datalayer.getAxisExtent("x"), [1, 4]);
+            this.datalayer.data = [
+                { x: 200 }, { x: -73 }, { x: 0 }, { x: 38 }
+            ];
+            assert.deepEqual(this.datalayer.getAxisExtent("x"), [-73, 200]);
+            this.datalayer.data = [
+                { x: 6 }
+            ];
+            assert.deepEqual(this.datalayer.getAxisExtent("x"), [6, 6]);
+            this.datalayer.data = [
+                { x: "apple" }, { x: "pear" }, { x: "orange" }
+            ];
+            assert.deepEqual(this.datalayer.getAxisExtent("x"), [undefined, undefined]);
+        });
+        it("applies upper and lower buffers to extents as defined in the layout", function() {
+            this.layout = {
+                x_axis: {
+                    field: "x",
+                    lower_buffer: 0.05
+                }
+            }
+            this.datalayer = new LocusZoom.DataLayer("test", this.layout);
+            this.datalayer.data = [
+                { x: 1 }, { x: 2 }, { x: 3 }, { x: 4 }
+            ];
+            assert.deepEqual(this.datalayer.getAxisExtent("x"), [0.85, 4]);
+            this.layout = {
+                x_axis: {
+                    field: "x",
+                    upper_buffer: 0.2
+                }
+            }
+            this.datalayer = new LocusZoom.DataLayer("test", this.layout);
+            this.datalayer.data = [
+                { x: 62 }, { x: 7 }, { x: -18 }, { x: 106 }
+            ];
+            assert.deepEqual(this.datalayer.getAxisExtent("x"), [-18, 130.8]);
+            this.layout = {
+                x_axis: {
+                    field: "x",
+                    lower_buffer: 0.35,
+                    upper_buffer: 0.6
+                }
+            }
+            this.datalayer = new LocusZoom.DataLayer("test", this.layout);
+            this.datalayer.data = [
+                { x: 95 }, { x: 0 }, { x: -4 }, { x: 256 }
+            ];
+            assert.deepEqual(this.datalayer.getAxisExtent("x"), [-95, 412]);
+        });
+        it("applies a minimum extent as defined in the layout", function() {
+            this.layout = {
+                x_axis: {
+                    field: "x",
+                    min_extent: [ 0, 3 ]
+                }
+            }
+            this.datalayer = new LocusZoom.DataLayer("test", this.layout);
+            this.datalayer.data = [
+                { x: 1 }, { x: 2 }, { x: 3 }, { x: 4 }
+            ];
+            assert.deepEqual(this.datalayer.getAxisExtent("x"), [0, 4]);
+            this.layout = {
+                x_axis: {
+                    field: "x",
+                    upper_buffer: 0.1,
+                    lower_buffer: 0.2,
+                    min_extent: [ 0, 10 ]
+                }
+            }
+            this.datalayer = new LocusZoom.DataLayer("test", this.layout);
+            this.datalayer.data = [
+                { x: 3 }, { x: 4 }, { x: 5 }, { x: 6 }
+            ];
+            assert.deepEqual(this.datalayer.getAxisExtent("x"), [0, 10]);
+            this.datalayer.data = [
+                { x: 0.6 }, { x: 4 }, { x: 5 }, { x: 9 }
+            ];
+            assert.deepEqual(this.datalayer.getAxisExtent("x"), [-1.08, 10]);
+            this.datalayer.data = [
+                { x: 0.4 }, { x: 4 }, { x: 5 }, { x: 9.8 }
+            ];
+            assert.deepEqual(this.datalayer.getAxisExtent("x"), [-1.48, 10.74]);
+        });
+        it("applies hard floor and ceiling as defined in the layout", function() {
+            this.layout = {
+                x_axis: {
+                    field: "x",
+                    min_extent: [6, 10],
+                    lower_buffer: 0.5,
+                    floor: 0
+                }
+            }
+            this.datalayer = new LocusZoom.DataLayer("test", this.layout);
+            this.datalayer.data = [
+                { x: 8 }, { x: 9 }, { x: 8 }, { x: 8.5 }
+            ];
+            assert.deepEqual(this.datalayer.getAxisExtent("x"), [0, 10]);
+            this.layout = {
+                x_axis: {
+                    field: "x",
+                    min_extent: [0, 10],
+                    upper_buffer: 0.8,
+                    ceiling: 5
+                }
+            }
+            this.datalayer = new LocusZoom.DataLayer("test", this.layout);
+            this.datalayer.data = [
+                { x: 3 }, { x: 4 }, { x: 5 }, { x: 6 }
+            ];
+            assert.deepEqual(this.datalayer.getAxisExtent("x"), [0, 5]);
+            this.layout = {
+                x_axis: {
+                    field: "x",
+                    min_extent: [0, 10],
+                    lower_buffer: 0.8,
+                    upper_buffer: 0.8,
+                    floor: 4,
+                    ceiling: 6
+                }
+            }
+            this.datalayer = new LocusZoom.DataLayer("test", this.layout);
+            this.datalayer.data = [
+                { x: 2 }, { x: 4 }, { x: 5 }, { x: 17 }
+            ];
+            assert.deepEqual(this.datalayer.getAxisExtent("x"), [4, 6]);
+        });
+
     });
 
 });

--- a/test/Instance.js
+++ b/test/Instance.js
@@ -162,13 +162,6 @@ describe('LocusZoom.Instance', function(){
                 this.instance = LocusZoom.populate("#instance_id", {}, responsive_layout);
             });
         });
-        it('should track whether it\'s initialized', function(){
-            this.instance.initialize.should.be.a.Function;
-            assert.equal(this.instance.initialized, true);
-            d3.select("body").append("div").attr("id", "another_instance_id");
-            var another_instance = LocusZoom.populate("#another_instance_id");
-            assert.equal(another_instance.initialized, true);
-        });
         it('should allow for mapping to new coordinates', function(){
             /*
               // BUSTED - Need to mock data sources to make these tests work again!

--- a/test/Singletons.js
+++ b/test/Singletons.js
@@ -281,10 +281,10 @@ describe('LocusZoom Singletons', function(){
         it('LocusZoom should have a DataLayers singleton', function(){
             LocusZoom.should.have.property('DataLayers').which.is.an.Object;
         });
-       it('should have a method to list available data layers', function(){
+        it('should have a method to list available data layers', function(){
             LocusZoom.DataLayers.should.have.property('list').which.is.a.Function;
             var returned_list = LocusZoom.DataLayers.list();
-            var expected_list = ["scatter", "genes"];
+            var expected_list = ["scatter", "line", "genes"];
             assert.deepEqual(returned_list, expected_list);
         });
         it('should have a general method to get a data layer by name', function(){
@@ -301,7 +301,7 @@ describe('LocusZoom Singletons', function(){
             };
             LocusZoom.DataLayers.add("foo", foo);
             var returned_list = LocusZoom.DataLayers.list();
-            var expected_list = ["scatter", "genes", "foo"];
+            var expected_list = ["scatter", "line", "genes", "foo"];
             assert.deepEqual(returned_list, expected_list);
             var returned_value = LocusZoom.DataLayers.get("foo", "bar", {});
             var expected_value = new foo("bar", {});
@@ -320,7 +320,7 @@ describe('LocusZoom Singletons', function(){
             };
             LocusZoom.DataLayers.set("foo", foo_new);
             var returned_list = LocusZoom.DataLayers.list();
-            var expected_list = ["scatter", "genes", "foo"];
+            var expected_list = ["scatter", "line", "genes", "foo"];
             assert.deepEqual(returned_list, expected_list);
             var returned_value = LocusZoom.DataLayers.get("foo", "baz", {});
             var expected_value = new foo_new("baz", {});
@@ -329,7 +329,7 @@ describe('LocusZoom Singletons', function(){
             assert.equal(returned_value.render(), expected_value.render());
             LocusZoom.DataLayers.set("foo");
             var returned_list = LocusZoom.DataLayers.list();
-            var expected_list = ["scatter", "genes"];
+            var expected_list = ["scatter", "line", "genes"];
             assert.deepEqual(returned_list, expected_list);
         });
         it('should throw an exception if asked to get a function that has not been defined', function(){


### PR DESCRIPTION
This branch implements the minimum viable product to render a line of genome-wide significance on positions panel. It does so by implementing a basic data layer of type `line`, as well makes use of the `StaticJSON` data source introduced in #53.

## Line Data Layer

The `line` data layer uses d3's `line()` method to render a standard line. Layout parameters supported include `style`, and `transition`, as well as the line-specific parameter of `interpolate` which is passed directly through to d3's `interpolate` function.

Selectability is not currently implemented for the line data layer, as it's not clear what that behavior should be.

Tool tips have been implemented on this branch with a custom positioning function. What's more, to improve the "tightness" of the UI's feel, line data layers with defined tool tip content will actually render the path twice. The first pass will take styles from the layout and be visible; the second pass will render an identical invisible line on top with a predefined stroke width of `12px`. This second line acts as the "hit area" for mouse events. All mouse events related to tool tips use this line instead of the rendered line but both lines are joined to the same data underneath, resulting in the ability to have thin or dotted/dashed lines that have wide, continuous mouse hit areas.

## To Do

Open question which of these are in scope for this branch or could be added later.

- [x] Tool tips
  - [x] Basic mouse event binding
  - [x] Line-data-layer-specific tool tip positioning methods
- [x] Tests
  - [x] Data layer axis minimum extent logic