### PR TITLE
Scatter labels

### DIFF
--- a/assets/css/locuszoom.scss
+++ b/assets/css/locuszoom.scss
@@ -103,6 +103,16 @@ svg.#{$namespace}-locuszoom {
     stroke-width: 4;
   }
 
+  text.#{$namespace}-data_layer-scatter-label {
+    fill: #{$default_black};
+    alignment-baseline: middle;
+  }
+
+  line.#{$namespace}-data_layer-scatter-label {
+    stroke: #{$default_black};
+    stroke-width: 1px;
+  }
+
   g.#{$namespace}-data_layer-gene {
     cursor: pointer;
   }

--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -351,6 +351,8 @@ LocusZoom.StandardLayout = {
                     },
                     label: {
                         text: "{{id}}",
+                        spacing: 4,
+                        lines: true,
                         filters: [
                             {
                                 field: "pvalue|neglog10",

--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -367,7 +367,7 @@ LocusZoom.StandardLayout = {
                             }
                         ],
                         style: {
-                            "font_size": "12px",
+                            "font-size": "12px",
                             "fill": "#333333"
                         }
                     }

--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -352,7 +352,13 @@ LocusZoom.StandardLayout = {
                     label: {
                         text: "{{id}}",
                         spacing: 4,
-                        lines: true,
+                        lines: {
+                            style: {
+                                "stroke-width": "1px",
+                                "stroke": "#333333",
+                                "stroke-dasharray": "1px 1px"
+                            }
+                        },
                         filters: [
                             {
                                 field: "pvalue|neglog10",
@@ -361,8 +367,8 @@ LocusZoom.StandardLayout = {
                             }
                         ],
                         style: {
-                            "font_size": "10px",
-                            "fill": "#666666"
+                            "font_size": "12px",
+                            "fill": "#333333"
                         }
                     }
                 }

--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -410,6 +410,7 @@ LocusZoom.StandardLayout = {
                             { html: "Ref. Allele: <strong>{{refAllele}}</strong>" }
                         ]
                     },
+                    /*
                     label: {
                         text: "{{id}}",
                         spacing: 4,
@@ -432,6 +433,7 @@ LocusZoom.StandardLayout = {
                             "fill": "#333333"
                         }
                     }
+                    */
                 }
             }
         },

--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -350,7 +350,7 @@ LocusZoom.StandardLayout = {
                         ]
                     },
                     label: {
-                        text: "ID: {{id}}",
+                        text: "{{id}}",
                         filters: [
                             {
                                 field: "pvalue|neglog10",

--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -348,6 +348,20 @@ LocusZoom.StandardLayout = {
                             { html: "P Value: <strong>{{pvalue|scinotation}}</strong>" },
                             { html: "Ref. Allele: <strong>{{refAllele}}</strong>" }
                         ]
+                    },
+                    label: {
+                        text: "ID: {{id}}",
+                        filters: [
+                            {
+                                field: "pvalue|neglog10",
+                                operator: ">=",
+                                value: 50
+                            }
+                        ],
+                        style: {
+                            "font_size": "10px",
+                            "fill": "#666666"
+                        }
                     }
                 }
             }

--- a/assets/js/app/Singletons.js
+++ b/assets/js/app/Singletons.js
@@ -414,12 +414,12 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, parent){
 
         // Generate new values (or functions for them) for position, color, and shape
         var transform = function(d) {
-            var x = data_layer.parent[x_scale](d[data_layer.layout.x_axis.field]);
-            var y = data_layer.parent[y_scale](d[data_layer.layout.y_axis.field]);
+            var x = this.parent[x_scale](d[this.layout.x_axis.field]);
+            var y = this.parent[y_scale](d[this.layout.y_axis.field]);
             if (isNaN(x)){ x = -1000; }
             if (isNaN(y)){ y = -1000; }
             return "translate(" + x + "," + y + ")";
-        };
+        }.bind(this);
         var fill;
         if (this.layout.color){
             switch (typeof this.layout.color){
@@ -427,12 +427,12 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, parent){
                 fill = this.layout.color;
                 break;
             case "object":
-                if (data_layer.layout.color.scale_function && data_layer.layout.color.field) {
+                if (this.layout.color.scale_function && this.layout.color.field) {
                     fill = function(d){
-                        return LocusZoom.ScaleFunctions.get(data_layer.layout.color.scale_function,
-                                                            data_layer.layout.color.parameters || {},
-                                                            d[data_layer.layout.color.field]);
-                    };
+                        return LocusZoom.ScaleFunctions.get(this.layout.color.scale_function,
+                                                            this.layout.color.parameters || {},
+                                                            d[this.layout.color.field]);
+                    }.bind(this);
                 }
                 break;
             }
@@ -543,42 +543,123 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, parent){
                     return match;
                 }
             });
-            var label_groups = this.svg.group
+            this.label_groups = this.svg.group
                 .selectAll("g.lz-data_layer-scatter-label")
                 .data(filtered_data, function(d){ return d.id + "_label"; });
-            label_groups.enter()
+            this.label_groups.enter()
                 .append("g")
                 .attr("class", "lz-data_layer-scatter-label");
-            label_groups
-                .each(function(datum){
-                    // Render label text
-                    var label_text = d3.select(this).selectAll("text.lz-data_layer-scatter-label")
-                        .data([datum], function(d){ return d.id + "_label_text"; });
-                    label_text.enter().append("text")
-                        .attr("class", "lz-data_layer-scatter-label");
-                    label_text
-                        .text(LocusZoom.parseFields(datum, data_layer.layout.label.text || ""))
-                        .style(data_layer.layout.label.style || {})
-                        .attr({
-                            "x": function(d){
-                                var x = data_layer.parent[x_scale](d[data_layer.layout.x_axis.field]);
-                                if (isNaN(x)){ x = -1000; }
-                                return x;
-                            },
-                            "y": function(d){
-                                var y = data_layer.parent[y_scale](d[data_layer.layout.y_axis.field]);
-                                if (isNaN(y)){ y = -1000; }
-                                return y;
-                            },
-                            "text-anchor": function(d){
-                                return "start";
-                            }
-                        });
-                    label_text.exit().remove();
+
+            // Render label text
+            this.label_texts = this.label_groups.append("text")
+                .attr("class", "lz-data_layer-scatter-label");
+            this.label_texts
+                .text(function(d){
+                    return LocusZoom.parseFields(d, data_layer.layout.label.text || "");
+                })
+                .style(data_layer.layout.label.style || {})
+                .attr({
+                    "x": function(d){
+                        var x = data_layer.parent[x_scale](d[data_layer.layout.x_axis.field])
+                              + Math.sqrt(data_layer.layout.point_size);
+                        if (isNaN(x)){ x = -1000; }
+                        return x;
+                    },
+                    "y": function(d){
+                        var y = data_layer.parent[y_scale](d[data_layer.layout.y_axis.field])
+                              + Math.sqrt(data_layer.layout.point_size);
+                        if (isNaN(y)){ y = -1000; }
+                        return y;
+                    },
+                    "text-anchor": function(d){
+                        return "start";
+                    }
+                });            
+            // Render label lines
+            this.label_lines = this.label_groups.append("line")
+                .attr("class", "lz-data_layer-scatter-label");
+            this.label_lines
+                .attr({
+                    "x1": function(d){
+                        var x = data_layer.parent[x_scale](d[data_layer.layout.x_axis.field]);
+                        if (isNaN(x)){ x = -1000; }
+                        return x;
+                    },
+                    "y1": function(d){
+                        var y = data_layer.parent[y_scale](d[data_layer.layout.y_axis.field]);
+                        if (isNaN(y)){ y = -1000; }
+                        return y;
+                    },
+                    "x2": function(d){
+                        var x = data_layer.parent[x_scale](d[data_layer.layout.x_axis.field])
+                              + Math.sqrt(data_layer.layout.point_size);
+                        if (isNaN(x)){ x = -1000; }
+                        return x;
+                    },
+                    "y2": function(d){
+                        var y = data_layer.parent[y_scale](d[data_layer.layout.y_axis.field])
+                              + Math.sqrt(data_layer.layout.point_size);
+                        if (isNaN(y)){ y = -1000; }
+                        return y;
+                    },
                 });
-            label_groups.exit().remove();
+            this.label_groups.exit().remove();
         }
+
+        this.separate_labels();
         
+    };
+
+    // Function to space labels apart immediately after initial render
+    // Adapted from thudfactor's fiddle here: https://jsfiddle.net/thudfactor/HdwTH/
+    this.separate_labels = function(){
+        var data_layer = this;
+        var alpha = 0.5;
+        var padding = 2;
+        var again = false;
+        data_layer.label_texts.each(function (d, i) {
+            a = this;
+            da = d3.select(a);
+            y1 = da.attr("y");
+            data_layer.label_texts.each(function (d, j) {
+                b = this;
+                // a & b are the same element and don't collide.
+                if (a == b) return;
+                db = d3.select(b);
+                // a & b are on opposite sides of the chart and
+                // don't collide
+                if (da.attr("text-anchor") != db.attr("text-anchor")) return;
+                // Determine if the  bounding rects for the two text elements collide
+                abound = da.node().getBoundingClientRect();
+                bbound = db.node().getBoundingClientRect();
+                var collision = abound.left < bbound.left + bbound.width + (2*padding) &&
+                    abound.left + abound.width + (2*padding) > bbound.left &&
+                    abound.top < bbound.top + bbound.height + (2*padding) &&
+                    abound.height + abound.top + (2*padding) > bbound.top;
+                if (!collision) return;
+                
+                // If the labels collide, we'll push each
+                // of the two labels up and down a little bit.
+                again = true;
+                y2 = db.attr("y");
+                sign = abound.top < bbound.top ? 1 : -1;
+                adjust = sign * alpha;
+                da.attr("y",+y1 - adjust);
+                db.attr("y",+y2 + adjust);
+            });
+        });
+        // Adjust our line leaders here
+        // so that they follow the labels. 
+        if (again) {
+            labelElements = data_layer.label_texts[0];
+            data_layer.label_lines.attr("y2",function(d,i) {
+                labelForLine = d3.select(labelElements[i]);
+                return labelForLine.attr("y");
+            });
+            setTimeout(function(){
+                this.separate_labels()
+            }.bind(this), 20);
+        }
     };
        
     return this;

--- a/assets/js/app/Singletons.js
+++ b/assets/js/app/Singletons.js
@@ -458,6 +458,11 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, parent){
                     abound.height + abound.top + (2*spacing) > bbound.top;
                 if (collision){
                     flip(da, dal);
+                    // Double check that this flip didn't push the label past min_x. If it did, immediately flip back.
+                    dax = +da.attr("x");
+                    if (dax - abound.width - spacing < min_x){
+                        flip(da, dal);
+                    }
                 }
                 return;
             });
@@ -558,29 +563,33 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, parent){
                 if (!data_layer.layout.label.filters){
                     return true;
                 } else {
-                    // Start by assuming a match, run through all filters to test if not a match
+                    // Start by assuming a match, run through all filters to test if not a match on any one
                     var match = true;
                     data_layer.layout.label.filters.forEach(function(filter){
-                        switch (filter.operator){
-                        case "<":
-                            if (!(d[filter.field] < filter.value)){ match = false; }
-                            break;
-                        case "<=":
-                            if (!(d[filter.field] <= filter.value)){ match = false; }
-                            break;
-                        case ">":
-                            if (!(d[filter.field] > filter.value)){ match = false; }
-                            break;
-                        case ">=":
-                            if (!(d[filter.field] >= filter.value)){ match = false; }
-                            break;
-                        case "=":
-                            if (!(d[filter.field] == filter.value)){ match = false; }
-                            break;
-                        default:
-                            // If we got here the operator is not valid, so the filter should fail
+                        if (isNaN(d[filter.field])){
                             match = false;
-                            break;
+                        } else {
+                            switch (filter.operator){
+                            case "<":
+                                if (!(d[filter.field] < filter.value)){ match = false; }
+                                break;
+                            case "<=":
+                                if (!(d[filter.field] <= filter.value)){ match = false; }
+                                break;
+                            case ">":
+                                if (!(d[filter.field] > filter.value)){ match = false; }
+                                break;
+                            case ">=":
+                                if (!(d[filter.field] >= filter.value)){ match = false; }
+                                break;
+                            case "=":
+                                if (!(d[filter.field] == filter.value)){ match = false; }
+                                break;
+                            default:
+                                // If we got here the operator is not valid, so the filter should fail
+                                match = false;
+                                break;
+                            }
                         }
                     });
                     return match;

--- a/assets/js/app/Singletons.js
+++ b/assets/js/app/Singletons.js
@@ -402,6 +402,104 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, parent){
         var x_scale = "x_scale";
         var y_scale = "y"+this.layout.y_axis.axis+"_scale";
 
+        // Generate labels first (if defined)
+        if (this.layout.label){
+            var filtered_data = this.data.filter(function(d){
+                if (!data_layer.layout.label.filters){
+                    return true;
+                } else {
+                    // Start by assuming a match, run through all filters to test if not a match
+                    var match = true;
+                    data_layer.layout.label.filters.forEach(function(filter){
+                        switch (filter.operator){
+                        case "<":
+                            if (!(d[filter.field] < filter.value)){ match = false; }
+                            break;
+                        case "<=":
+                            if (!(d[filter.field] <= filter.value)){ match = false; }
+                            break;
+                        case ">":
+                            if (!(d[filter.field] > filter.value)){ match = false; }
+                            break;
+                        case ">=":
+                            if (!(d[filter.field] >= filter.value)){ match = false; }
+                            break;
+                        case "=":
+                            if (!(d[filter.field] == filter.value)){ match = false; }
+                            break;
+                        default:
+                            // If we got here the operator is not valid, so the filter should fail
+                            match = false;
+                            break;
+                        }
+                    });
+                    return match;
+                }
+            });
+            this.label_groups = this.svg.group
+                .selectAll("g.lz-data_layer-scatter-label")
+                .data(filtered_data, function(d){ return d.id + "_label"; });
+            this.label_groups.enter()
+                .append("g")
+                .attr("class", "lz-data_layer-scatter-label");
+
+            // Render label text
+            this.label_texts = this.label_groups.append("text")
+                .attr("class", "lz-data_layer-scatter-label");
+            this.label_texts
+                .text(function(d){
+                    return LocusZoom.parseFields(d, data_layer.layout.label.text || "");
+                })
+                .style(data_layer.layout.label.style || {})
+                .attr({
+                    "x": function(d){
+                        var x = data_layer.parent[x_scale](d[data_layer.layout.x_axis.field])
+                            + (1.5 * Math.sqrt(data_layer.layout.point_size)) + 2;
+                        if (isNaN(x)){ x = -1000; }
+                        return x;
+                    },
+                    "y": function(d){
+                        var y = data_layer.parent[y_scale](d[data_layer.layout.y_axis.field])
+                              + Math.sqrt(data_layer.layout.point_size);
+                        if (isNaN(y)){ y = -1000; }
+                        return y;
+                    },
+                    "text-anchor": function(d){
+                        return "start";
+                    }
+                });            
+            // Render label lines
+            this.label_lines = this.label_groups.append("line")
+                .attr("class", "lz-data_layer-scatter-label");
+            this.label_lines
+                .attr({
+                    "x1": function(d){
+                        var x = data_layer.parent[x_scale](d[data_layer.layout.x_axis.field]);
+                        if (isNaN(x)){ x = -1000; }
+                        return x;
+                    },
+                    "y1": function(d){
+                        var y = data_layer.parent[y_scale](d[data_layer.layout.y_axis.field]);
+                        if (isNaN(y)){ y = -1000; }
+                        return y;
+                    },
+                    "x2": function(d){
+                        var x = data_layer.parent[x_scale](d[data_layer.layout.x_axis.field])
+                              + (1.5 * Math.sqrt(data_layer.layout.point_size));
+                        if (isNaN(x)){ x = -1000; }
+                        return x;
+                    },
+                    "y2": function(d){
+                        var y = data_layer.parent[y_scale](d[data_layer.layout.y_axis.field])
+                              + Math.sqrt(data_layer.layout.point_size);
+                        if (isNaN(y)){ y = -1000; }
+                        return y;
+                    },
+                });
+            this.label_groups.exit().remove();
+        }
+
+        // Generate main scatter data elements
         var selection = this.svg.group
             .selectAll("path.lz-data_layer-scatter")
             .data(this.data, function(d){ return d.id; });
@@ -509,109 +607,16 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, parent){
         // Remove old elements as needed
         selection.exit().remove();
 
-        // Generate labels (if defined)
+        // Apply method to keep labels from overlapping each other
         if (this.layout.label){
-            var filtered_data = this.data.filter(function(d){
-                if (!data_layer.layout.label.filters){
-                    return true;
-                } else {
-                    // Start by assuming a match, run through all filters to test if not a match
-                    var match = true;
-                    data_layer.layout.label.filters.forEach(function(filter){
-                        switch (filter.operator){
-                        case "<":
-                            if (!(d[filter.field] < filter.value)){ match = false; }
-                            break;
-                        case "<=":
-                            if (!(d[filter.field] <= filter.value)){ match = false; }
-                            break;
-                        case ">":
-                            if (!(d[filter.field] > filter.value)){ match = false; }
-                            break;
-                        case ">=":
-                            if (!(d[filter.field] >= filter.value)){ match = false; }
-                            break;
-                        case "=":
-                            if (!(d[filter.field] == filter.value)){ match = false; }
-                            break;
-                        default:
-                            // If we got here the operator is not valid, so the filter should fail
-                            match = false;
-                            break;
-                        }
-                    });
-                    return match;
-                }
-            });
-            this.label_groups = this.svg.group
-                .selectAll("g.lz-data_layer-scatter-label")
-                .data(filtered_data, function(d){ return d.id + "_label"; });
-            this.label_groups.enter()
-                .append("g")
-                .attr("class", "lz-data_layer-scatter-label");
-
-            // Render label text
-            this.label_texts = this.label_groups.append("text")
-                .attr("class", "lz-data_layer-scatter-label");
-            this.label_texts
-                .text(function(d){
-                    return LocusZoom.parseFields(d, data_layer.layout.label.text || "");
-                })
-                .style(data_layer.layout.label.style || {})
-                .attr({
-                    "x": function(d){
-                        var x = data_layer.parent[x_scale](d[data_layer.layout.x_axis.field])
-                              + Math.sqrt(data_layer.layout.point_size);
-                        if (isNaN(x)){ x = -1000; }
-                        return x;
-                    },
-                    "y": function(d){
-                        var y = data_layer.parent[y_scale](d[data_layer.layout.y_axis.field])
-                              + Math.sqrt(data_layer.layout.point_size);
-                        if (isNaN(y)){ y = -1000; }
-                        return y;
-                    },
-                    "text-anchor": function(d){
-                        return "start";
-                    }
-                });            
-            // Render label lines
-            this.label_lines = this.label_groups.append("line")
-                .attr("class", "lz-data_layer-scatter-label");
-            this.label_lines
-                .attr({
-                    "x1": function(d){
-                        var x = data_layer.parent[x_scale](d[data_layer.layout.x_axis.field]);
-                        if (isNaN(x)){ x = -1000; }
-                        return x;
-                    },
-                    "y1": function(d){
-                        var y = data_layer.parent[y_scale](d[data_layer.layout.y_axis.field]);
-                        if (isNaN(y)){ y = -1000; }
-                        return y;
-                    },
-                    "x2": function(d){
-                        var x = data_layer.parent[x_scale](d[data_layer.layout.x_axis.field])
-                              + Math.sqrt(data_layer.layout.point_size);
-                        if (isNaN(x)){ x = -1000; }
-                        return x;
-                    },
-                    "y2": function(d){
-                        var y = data_layer.parent[y_scale](d[data_layer.layout.y_axis.field])
-                              + Math.sqrt(data_layer.layout.point_size);
-                        if (isNaN(y)){ y = -1000; }
-                        return y;
-                    },
-                });
-            this.label_groups.exit().remove();
+            this.separate_labels();
         }
-
-        this.separate_labels();
         
     };
 
     // Function to space labels apart immediately after initial render
     // Adapted from thudfactor's fiddle here: https://jsfiddle.net/thudfactor/HdwTH/
+    // TODO: Make labels also aware of data elements
     this.separate_labels = function(){
         var data_layer = this;
         var alpha = 0.5;
@@ -644,8 +649,31 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, parent){
                 y2 = db.attr("y");
                 sign = abound.top < bbound.top ? 1 : -1;
                 adjust = sign * alpha;
-                da.attr("y",+y1 - adjust);
-                db.attr("y",+y2 + adjust);
+                new_a_y = +y1 - adjust;
+                new_b_y = +y2 + adjust;
+                // Keep new values from extending outside the data layer
+                var min_y = 2 * padding;
+                var max_y = data_layer.parent.layout.height - data_layer.parent.layout.margin.top - data_layer.parent.layout.margin.bottom - (2 * padding);
+                if (new_a_y - (abound.height/2) < min_y){
+                    delta = +y1 - new_a_y;
+                    new_a_y = +y1;
+                    new_b_y += delta;
+                } else if (new_b_y - (bbound.height/2) < min_y){
+                    delta = +y2 - new_b_y;
+                    new_b_y = +y2;
+                    new_a_y += delta;
+                }
+                if (new_a_y + (abound.height/2) > max_y){
+                    delta = new_a_y - +y1;
+                    new_a_y = +y1;
+                    new_b_y -= delta;
+                } else if (new_b_y + (bbound.height/2) > max_y){
+                    delta = new_b_y - +y2;
+                    new_b_y = +y2;
+                    new_a_y -= delta;
+                }
+                da.attr("y",new_a_y);
+                db.attr("y",new_b_y);
             });
         });
         // Adjust our line leaders here
@@ -656,9 +684,7 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, parent){
                 labelForLine = d3.select(labelElements[i]);
                 return labelForLine.attr("y");
             });
-            setTimeout(function(){
-                this.separate_labels()
-            }.bind(this), 20);
+            this.separate_labels();
         }
     };
        

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -366,7 +366,13 @@ LocusZoom.StandardLayout = {
                     label: {
                         text: "{{id}}",
                         spacing: 4,
-                        lines: true,
+                        lines: {
+                            style: {
+                                "stroke-width": "1px",
+                                "stroke": "#333333",
+                                "stroke-dasharray": "1px 1px"
+                            }
+                        },
                         filters: [
                             {
                                 field: "pvalue|neglog10",
@@ -375,8 +381,8 @@ LocusZoom.StandardLayout = {
                             }
                         ],
                         style: {
-                            "font_size": "10px",
-                            "fill": "#666666"
+                            "font_size": "12px",
+                            "fill": "#333333"
                         }
                     }
                 }
@@ -2232,26 +2238,65 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, parent){
     };
 
     // Function to flip labels from being anchored at the start of the text to the end
-    // Both to keep labels from running outside the data layer and
-    // also as a first pass on recursive separation
+    // Both to keep labels from running outside the data layer and  also as a first
+    // pass on recursive separation
     this.flip_labels = function(){
         var data_layer = this;
         var spacing = this.layout.label.spacing;
+        var handle_lines = Boolean(data_layer.layout.label.lines);
         var min_x = 2 * spacing;
         var max_x = data_layer.parent.layout.width - data_layer.parent.layout.margin.left - data_layer.parent.layout.margin.right - (2 * spacing);
+        var flip = function(dn, dnl){
+            var dnx = +dn.attr("x");
+            var text_swing = (2 * spacing) + (2 * Math.sqrt(data_layer.layout.point_size));
+            if (handle_lines){
+                var dnlx2 = +dnl.attr("x2");
+                var line_swing = spacing + (2 * Math.sqrt(data_layer.layout.point_size));
+            }
+            if (dn.style("text-anchor") == "start"){
+                dn.style("text-anchor", "end");
+                dn.attr("x", dnx - text_swing);
+                if (handle_lines){ dnl.attr("x2", dnlx2 - line_swing); }
+            } else {
+                dn.style("text-anchor", "start");
+                dn.attr("x", dnx + text_swing);
+                if (handle_lines){ dnl.attr("x2", dnlx2 + line_swing); }
+            }
+        };
+        // Flip any going over the right edge from the right side to the left side
+        // (all labels start on the right side)
         data_layer.label_texts.each(function (d, i) {
             a = this;
             da = d3.select(a);
             dax = +da.attr("x");
             abound = da.node().getBoundingClientRect();
             if (dax + abound.width + spacing > max_x){
-                da.style("text-anchor", "end");
-                da.attr("x", dax - (2 * spacing) - (2 * Math.sqrt(data_layer.layout.point_size)));
-                var dl = d3.select(data_layer.label_lines[0][i]);
-                var dlx2 = +dl.attr("x2");
-                dlx2 -= spacing + (2 * Math.sqrt(data_layer.layout.point_size));
-                dl.attr("x2", dlx2);
+                dal = handle_lines ? d3.select(data_layer.label_lines[0][i]) : null;
+                flip(da, dal);
             }
+        });
+        // Second pass to flip any others that haven't flipped yet if they collide with another label
+        data_layer.label_texts.each(function (d, i) {
+            a = this;
+            da = d3.select(a);
+            if (da.style("text-anchor") == "end") return;
+            dax = +da.attr("x");
+            abound = da.node().getBoundingClientRect();
+            dal = handle_lines ? d3.select(data_layer.label_lines[0][i]) : null;
+            data_layer.label_texts.each(function (d, j) {
+                b = this;
+                db = d3.select(b);
+                dbx = +db.attr("x");
+                bbound = db.node().getBoundingClientRect();
+                var collision = abound.left < bbound.left + bbound.width + (2*spacing) &&
+                    abound.left + abound.width + (2*spacing) > bbound.left &&
+                    abound.top < bbound.top + bbound.height + (2*spacing) &&
+                    abound.height + abound.top + (2*spacing) > bbound.top;
+                if (collision){
+                    flip(da, dal);
+                }
+                return;
+            });
         });
     };
 
@@ -2326,10 +2371,12 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, parent){
                     return label_line.attr("y");
                 });
             }
-            // Recurse
-            setTimeout(function(){
-                this.separate_labels();
-            }.bind(this), 1);
+            // After ~150 iterations we're probably beyond diminising returns, so stop recursing
+            if (this.seperate_iterations < 150){
+                setTimeout(function(){
+                    this.separate_labels();
+                }.bind(this), 1);
+            }
         }
     };
 
@@ -2342,8 +2389,7 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, parent){
 
         // Generate labels first (if defined)
         if (this.layout.label){
-            var min_x = this.parent.layout.margin.left + this.layout.label.spacing;
-            var max_x = this.parent.layout.width - this.parent.layout.margin.left - this.parent.layout.margin.right - this.layout.label.spacing;
+            // Apply filters to generate a filtered data set
             var filtered_data = this.data.filter(function(d){
                 if (!data_layer.layout.label.filters){
                     return true;
@@ -2376,14 +2422,15 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, parent){
                     return match;
                 }
             });
+            // Render label groups
             this.label_groups = this.svg.group
                 .selectAll("g.lz-data_layer-scatter-label")
                 .data(filtered_data, function(d){ return d.id + "_label"; });
             this.label_groups.enter()
                 .append("g")
                 .attr("class", "lz-data_layer-scatter-label");
-
-            // Render label text
+            // Render label texts
+            if (this.label_texts){ this.label_texts.remove(); }
             this.label_texts = this.label_groups.append("text")
                 .attr("class", "lz-data_layer-scatter-label");
             this.label_texts
@@ -2409,9 +2456,11 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, parent){
                 });
             // Render label lines
             if (data_layer.layout.label.lines){
+                if (this.label_lines){ this.label_lines.remove(); }
                 this.label_lines = this.label_groups.append("line")
                     .attr("class", "lz-data_layer-scatter-label");
                 this.label_lines
+                    .style(data_layer.layout.label.lines.style || {})
                     .attr({
                         "x1": function(d){
                             var x = data_layer.parent[x_scale](d[data_layer.layout.x_axis.field]);
@@ -2436,6 +2485,7 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, parent){
                         },
                     });
             }
+            // Remove labels when they're no longer in the filtered data set
             this.label_groups.exit().remove();
         }
             

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -381,7 +381,7 @@ LocusZoom.StandardLayout = {
                             }
                         ],
                         style: {
-                            "font_size": "12px",
+                            "font-size": "12px",
                             "fill": "#333333"
                         }
                     }
@@ -2294,6 +2294,11 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, parent){
                     abound.height + abound.top + (2*spacing) > bbound.top;
                 if (collision){
                     flip(da, dal);
+                    // Double check that this flip didn't push the label past min_x. If it did, immediately flip back.
+                    dax = +da.attr("x");
+                    if (dax - abound.width - spacing < min_x){
+                        flip(da, dal);
+                    }
                 }
                 return;
             });
@@ -2394,29 +2399,33 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, parent){
                 if (!data_layer.layout.label.filters){
                     return true;
                 } else {
-                    // Start by assuming a match, run through all filters to test if not a match
+                    // Start by assuming a match, run through all filters to test if not a match on any one
                     var match = true;
                     data_layer.layout.label.filters.forEach(function(filter){
-                        switch (filter.operator){
-                        case "<":
-                            if (!(d[filter.field] < filter.value)){ match = false; }
-                            break;
-                        case "<=":
-                            if (!(d[filter.field] <= filter.value)){ match = false; }
-                            break;
-                        case ">":
-                            if (!(d[filter.field] > filter.value)){ match = false; }
-                            break;
-                        case ">=":
-                            if (!(d[filter.field] >= filter.value)){ match = false; }
-                            break;
-                        case "=":
-                            if (!(d[filter.field] == filter.value)){ match = false; }
-                            break;
-                        default:
-                            // If we got here the operator is not valid, so the filter should fail
+                        if (isNaN(d[filter.field])){
                             match = false;
-                            break;
+                        } else {
+                            switch (filter.operator){
+                            case "<":
+                                if (!(d[filter.field] < filter.value)){ match = false; }
+                                break;
+                            case "<=":
+                                if (!(d[filter.field] <= filter.value)){ match = false; }
+                                break;
+                            case ">":
+                                if (!(d[filter.field] > filter.value)){ match = false; }
+                                break;
+                            case ">=":
+                                if (!(d[filter.field] >= filter.value)){ match = false; }
+                                break;
+                            case "=":
+                                if (!(d[filter.field] == filter.value)){ match = false; }
+                                break;
+                            default:
+                                // If we got here the operator is not valid, so the filter should fail
+                                match = false;
+                                break;
+                            }
                         }
                     });
                     return match;

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -424,6 +424,7 @@ LocusZoom.StandardLayout = {
                             { html: "Ref. Allele: <strong>{{refAllele}}</strong>" }
                         ]
                     },
+                    /*
                     label: {
                         text: "{{id}}",
                         spacing: 4,
@@ -446,6 +447,7 @@ LocusZoom.StandardLayout = {
                             "fill": "#333333"
                         }
                     }
+                    */
                 }
             }
         },

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -362,6 +362,20 @@ LocusZoom.StandardLayout = {
                             { html: "P Value: <strong>{{pvalue|scinotation}}</strong>" },
                             { html: "Ref. Allele: <strong>{{refAllele}}</strong>" }
                         ]
+                    },
+                    label: {
+                        text: "ID: {{id}}",
+                        filters: [
+                            {
+                                field: "pvalue|neglog10",
+                                operator: ">=",
+                                value: 50
+                            }
+                        ],
+                        style: {
+                            "font_size": "10px",
+                            "fill": "#666666"
+                        }
                     }
                 }
             }
@@ -2212,6 +2226,10 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, parent){
     // Implement the main render function
     this.render = function(){
 
+        var data_layer = this;
+        var x_scale = "x_scale";
+        var y_scale = "y"+this.layout.y_axis.axis+"_scale";
+
         var selection = this.svg.group
             .selectAll("path.lz-data_layer-scatter")
             .data(this.data, function(d){ return d.id; });
@@ -2224,13 +2242,12 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, parent){
 
         // Generate new values (or functions for them) for position, color, and shape
         var transform = function(d) {
-            var x = this.parent.x_scale(d[this.layout.x_axis.field]);
-            var y_scale = "y"+this.layout.y_axis.axis+"_scale";
-            var y = this.parent[y_scale](d[this.layout.y_axis.field]);
+            var x = data_layer.parent[x_scale](d[data_layer.layout.x_axis.field]);
+            var y = data_layer.parent[y_scale](d[data_layer.layout.y_axis.field]);
             if (isNaN(x)){ x = -1000; }
             if (isNaN(y)){ y = -1000; }
             return "translate(" + x + "," + y + ")";
-        }.bind(this);
+        };
         var fill;
         if (this.layout.color){
             switch (typeof this.layout.color){
@@ -2238,12 +2255,12 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, parent){
                 fill = this.layout.color;
                 break;
             case "object":
-                if (this.layout.color.scale_function && this.layout.color.field) {
+                if (data_layer.layout.color.scale_function && data_layer.layout.color.field) {
                     fill = function(d){
-                        return LocusZoom.ScaleFunctions.get(this.layout.color.scale_function,
-                                                            this.layout.color.parameters || {},
-                                                            d[this.layout.color.field]);
-                    }.bind(this);
+                        return LocusZoom.ScaleFunctions.get(data_layer.layout.color.scale_function,
+                                                            data_layer.layout.color.parameters || {},
+                                                            d[data_layer.layout.color.field]);
+                    };
                 }
                 break;
             }
@@ -2319,6 +2336,76 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, parent){
 
         // Remove old elements as needed
         selection.exit().remove();
+
+        // Generate labels (if defined)
+        if (this.layout.label){
+            var filtered_data = this.data.filter(function(d){
+                if (!data_layer.layout.label.filters){
+                    return true;
+                } else {
+                    // Start by assuming a match, run through all filters to test if not a match
+                    var match = true;
+                    data_layer.layout.label.filters.forEach(function(filter){
+                        switch (filter.operator){
+                        case "<":
+                            if (!(d[filter.field] < filter.value)){ match = false; }
+                            break;
+                        case "<=":
+                            if (!(d[filter.field] <= filter.value)){ match = false; }
+                            break;
+                        case ">":
+                            if (!(d[filter.field] > filter.value)){ match = false; }
+                            break;
+                        case ">=":
+                            if (!(d[filter.field] >= filter.value)){ match = false; }
+                            break;
+                        case "=":
+                            if (!(d[filter.field] == filter.value)){ match = false; }
+                            break;
+                        default:
+                            // If we got here the operator is not valid, so the filter should fail
+                            match = false;
+                            break;
+                        }
+                    });
+                    return match;
+                }
+            });
+            var label_groups = this.svg.group
+                .selectAll("g.lz-data_layer-scatter-label")
+                .data(filtered_data, function(d){ return d.id + "_label"; });
+            label_groups.enter()
+                .append("g")
+                .attr("class", "lz-data_layer-scatter-label");
+            label_groups
+                .each(function(datum){
+                    // Render label text
+                    var label_text = d3.select(this).selectAll("text.lz-data_layer-scatter-label")
+                        .data([datum], function(d){ return d.id + "_label_text"; });
+                    label_text.enter().append("text")
+                        .attr("class", "lz-data_layer-scatter-label");
+                    label_text
+                        .text(LocusZoom.parseFields(datum, data_layer.layout.label.text || ""))
+                        .style(data_layer.layout.label.style || {})
+                        .attr({
+                            "x": function(d){
+                                var x = data_layer.parent[x_scale](d[data_layer.layout.x_axis.field]);
+                                if (isNaN(x)){ x = -1000; }
+                                return x;
+                            },
+                            "y": function(d){
+                                var y = data_layer.parent[y_scale](d[data_layer.layout.y_axis.field]);
+                                if (isNaN(y)){ y = -1000; }
+                                return y;
+                            },
+                            "text-anchor": function(d){
+                                return "start";
+                            }
+                        });
+                    label_text.exit().remove();
+                });
+            label_groups.exit().remove();
+        }
         
     };
        

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -365,6 +365,8 @@ LocusZoom.StandardLayout = {
                     },
                     label: {
                         text: "{{id}}",
+                        spacing: 4,
+                        lines: true,
                         filters: [
                             {
                                 field: "pvalue|neglog10",
@@ -2166,6 +2168,12 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, parent){
     };
     layout = LocusZoom.mergeLayouts(layout, this.DefaultLayout);
 
+    // Extra default for layout spacing
+    // Not in default layout since that would make the label attribute always present
+    if (layout.label && isNaN(layout.label.spacing)){
+        layout.label.spacing = 4;
+    }
+
     // Apply the arguments to set LocusZoom.DataLayer as the prototype
     LocusZoom.DataLayer.apply(this, arguments);
 
@@ -2223,6 +2231,108 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, parent){
             .style("top", arrow_top + "px");
     };
 
+    // Function to flip labels from being anchored at the start of the text to the end
+    // Both to keep labels from running outside the data layer and
+    // also as a first pass on recursive separation
+    this.flip_labels = function(){
+        var data_layer = this;
+        var spacing = this.layout.label.spacing;
+        var min_x = 2 * spacing;
+        var max_x = data_layer.parent.layout.width - data_layer.parent.layout.margin.left - data_layer.parent.layout.margin.right - (2 * spacing);
+        data_layer.label_texts.each(function (d, i) {
+            a = this;
+            da = d3.select(a);
+            dax = +da.attr("x");
+            abound = da.node().getBoundingClientRect();
+            if (dax + abound.width + spacing > max_x){
+                da.style("text-anchor", "end");
+                da.attr("x", dax - (2 * spacing) - (2 * Math.sqrt(data_layer.layout.point_size)));
+                var dl = d3.select(data_layer.label_lines[0][i]);
+                var dlx2 = +dl.attr("x2");
+                dlx2 -= spacing + (2 * Math.sqrt(data_layer.layout.point_size));
+                dl.attr("x2", dlx2);
+            }
+        });
+    };
+
+    // Recursive function to space labels apart immediately after initial render
+    // Adapted from thudfactor's fiddle here: https://jsfiddle.net/thudfactor/HdwTH/
+    // TODO: Make labels also aware of data elements
+    this.separate_labels = function(){
+        this.seperate_iterations++;
+        var data_layer = this;
+        var alpha = 0.5;
+        var spacing = this.layout.label.spacing;
+        var again = false;
+        data_layer.label_texts.each(function (d, i) {
+            a = this;
+            da = d3.select(a);
+            y1 = da.attr("y");
+            data_layer.label_texts.each(function (d, j) {
+                b = this;
+                // a & b are the same element and don't collide.
+                if (a == b) return;
+                db = d3.select(b);
+                // a & b are on opposite sides of the chart and
+                // don't collide
+                if (da.attr("text-anchor") != db.attr("text-anchor")) return;
+                // Determine if the  bounding rects for the two text elements collide
+                abound = da.node().getBoundingClientRect();
+                bbound = db.node().getBoundingClientRect();
+                var collision = abound.left < bbound.left + bbound.width + (2*spacing) &&
+                    abound.left + abound.width + (2*spacing) > bbound.left &&
+                    abound.top < bbound.top + bbound.height + (2*spacing) &&
+                    abound.height + abound.top + (2*spacing) > bbound.top;
+                if (!collision) return;
+                again = true;                
+                // If the labels collide, we'll push each
+                // of the two labels up and down a little bit.
+                y2 = db.attr("y");
+                sign = abound.top < bbound.top ? 1 : -1;
+                adjust = sign * alpha;
+                new_a_y = +y1 - adjust;
+                new_b_y = +y2 + adjust;
+                // Keep new values from extending outside the data layer
+                var min_y = 2 * spacing;
+                var max_y = data_layer.parent.layout.height - data_layer.parent.layout.margin.top - data_layer.parent.layout.margin.bottom - (2 * spacing);
+                if (new_a_y - (abound.height/2) < min_y){
+                    delta = +y1 - new_a_y;
+                    new_a_y = +y1;
+                    new_b_y += delta;
+                } else if (new_b_y - (bbound.height/2) < min_y){
+                    delta = +y2 - new_b_y;
+                    new_b_y = +y2;
+                    new_a_y += delta;
+                }
+                if (new_a_y + (abound.height/2) > max_y){
+                    delta = new_a_y - +y1;
+                    new_a_y = +y1;
+                    new_b_y -= delta;
+                } else if (new_b_y + (bbound.height/2) > max_y){
+                    delta = new_b_y - +y2;
+                    new_b_y = +y2;
+                    new_a_y -= delta;
+                }
+                da.attr("y",new_a_y);
+                db.attr("y",new_b_y);
+            });
+        });
+        if (again) {
+            // Adjust lines to follow the labels
+            if (data_layer.layout.label.lines){
+                var label_elements = data_layer.label_texts[0];
+                data_layer.label_lines.attr("y2",function(d,i) {
+                    var label_line = d3.select(label_elements[i]);
+                    return label_line.attr("y");
+                });
+            }
+            // Recurse
+            setTimeout(function(){
+                this.separate_labels();
+            }.bind(this), 1);
+        }
+    };
+
     // Implement the main render function
     this.render = function(){
 
@@ -2232,6 +2342,8 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, parent){
 
         // Generate labels first (if defined)
         if (this.layout.label){
+            var min_x = this.parent.layout.margin.left + this.layout.label.spacing;
+            var max_x = this.parent.layout.width - this.parent.layout.margin.left - this.parent.layout.margin.right - this.layout.label.spacing;
             var filtered_data = this.data.filter(function(d){
                 if (!data_layer.layout.label.filters){
                     return true;
@@ -2282,51 +2394,51 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, parent){
                 .attr({
                     "x": function(d){
                         var x = data_layer.parent[x_scale](d[data_layer.layout.x_axis.field])
-                            + (1.5 * Math.sqrt(data_layer.layout.point_size)) + 2;
+                              + Math.sqrt(data_layer.layout.point_size) + data_layer.layout.label.spacing
                         if (isNaN(x)){ x = -1000; }
                         return x;
                     },
                     "y": function(d){
-                        var y = data_layer.parent[y_scale](d[data_layer.layout.y_axis.field])
-                              + Math.sqrt(data_layer.layout.point_size);
+                        var y = data_layer.parent[y_scale](d[data_layer.layout.y_axis.field]);
                         if (isNaN(y)){ y = -1000; }
                         return y;
                     },
                     "text-anchor": function(d){
                         return "start";
                     }
-                });            
-            // Render label lines
-            this.label_lines = this.label_groups.append("line")
-                .attr("class", "lz-data_layer-scatter-label");
-            this.label_lines
-                .attr({
-                    "x1": function(d){
-                        var x = data_layer.parent[x_scale](d[data_layer.layout.x_axis.field]);
-                        if (isNaN(x)){ x = -1000; }
-                        return x;
-                    },
-                    "y1": function(d){
-                        var y = data_layer.parent[y_scale](d[data_layer.layout.y_axis.field]);
-                        if (isNaN(y)){ y = -1000; }
-                        return y;
-                    },
-                    "x2": function(d){
-                        var x = data_layer.parent[x_scale](d[data_layer.layout.x_axis.field])
-                              + (1.5 * Math.sqrt(data_layer.layout.point_size));
-                        if (isNaN(x)){ x = -1000; }
-                        return x;
-                    },
-                    "y2": function(d){
-                        var y = data_layer.parent[y_scale](d[data_layer.layout.y_axis.field])
-                              + Math.sqrt(data_layer.layout.point_size);
-                        if (isNaN(y)){ y = -1000; }
-                        return y;
-                    },
                 });
+            // Render label lines
+            if (data_layer.layout.label.lines){
+                this.label_lines = this.label_groups.append("line")
+                    .attr("class", "lz-data_layer-scatter-label");
+                this.label_lines
+                    .attr({
+                        "x1": function(d){
+                            var x = data_layer.parent[x_scale](d[data_layer.layout.x_axis.field]);
+                            if (isNaN(x)){ x = -1000; }
+                            return x;
+                        },
+                        "y1": function(d){
+                            var y = data_layer.parent[y_scale](d[data_layer.layout.y_axis.field]);
+                            if (isNaN(y)){ y = -1000; }
+                            return y;
+                        },
+                        "x2": function(d){
+                            var x = data_layer.parent[x_scale](d[data_layer.layout.x_axis.field])
+                                  + Math.sqrt(data_layer.layout.point_size) + (data_layer.layout.label.spacing/2)
+                            if (isNaN(x)){ x = -1000; }
+                            return x;
+                        },
+                        "y2": function(d){
+                            var y = data_layer.parent[y_scale](d[data_layer.layout.y_axis.field]);
+                            if (isNaN(y)){ y = -1000; }
+                            return y;
+                        },
+                    });
+            }
             this.label_groups.exit().remove();
         }
-
+            
         // Generate main scatter data elements
         var selection = this.svg.group
             .selectAll("path.lz-data_layer-scatter")
@@ -2437,83 +2549,11 @@ LocusZoom.DataLayers.add("scatter", function(id, layout, parent){
 
         // Apply method to keep labels from overlapping each other
         if (this.layout.label){
+            this.flip_labels();
+            this.seperate_iterations = 0;
             this.separate_labels();
         }
         
-    };
-
-    // Function to space labels apart immediately after initial render
-    // Adapted from thudfactor's fiddle here: https://jsfiddle.net/thudfactor/HdwTH/
-    // TODO: Make labels also aware of data elements
-    this.separate_labels = function(){
-        var data_layer = this;
-        var alpha = 0.5;
-        var padding = 2;
-        var again = false;
-        data_layer.label_texts.each(function (d, i) {
-            a = this;
-            da = d3.select(a);
-            y1 = da.attr("y");
-            data_layer.label_texts.each(function (d, j) {
-                b = this;
-                // a & b are the same element and don't collide.
-                if (a == b) return;
-                db = d3.select(b);
-                // a & b are on opposite sides of the chart and
-                // don't collide
-                if (da.attr("text-anchor") != db.attr("text-anchor")) return;
-                // Determine if the  bounding rects for the two text elements collide
-                abound = da.node().getBoundingClientRect();
-                bbound = db.node().getBoundingClientRect();
-                var collision = abound.left < bbound.left + bbound.width + (2*padding) &&
-                    abound.left + abound.width + (2*padding) > bbound.left &&
-                    abound.top < bbound.top + bbound.height + (2*padding) &&
-                    abound.height + abound.top + (2*padding) > bbound.top;
-                if (!collision) return;
-                
-                // If the labels collide, we'll push each
-                // of the two labels up and down a little bit.
-                again = true;
-                y2 = db.attr("y");
-                sign = abound.top < bbound.top ? 1 : -1;
-                adjust = sign * alpha;
-                new_a_y = +y1 - adjust;
-                new_b_y = +y2 + adjust;
-                // Keep new values from extending outside the data layer
-                var min_y = 2 * padding;
-                var max_y = data_layer.parent.layout.height - data_layer.parent.layout.margin.top - data_layer.parent.layout.margin.bottom - (2 * padding);
-                if (new_a_y - (abound.height/2) < min_y){
-                    delta = +y1 - new_a_y;
-                    new_a_y = +y1;
-                    new_b_y += delta;
-                } else if (new_b_y - (bbound.height/2) < min_y){
-                    delta = +y2 - new_b_y;
-                    new_b_y = +y2;
-                    new_a_y += delta;
-                }
-                if (new_a_y + (abound.height/2) > max_y){
-                    delta = new_a_y - +y1;
-                    new_a_y = +y1;
-                    new_b_y -= delta;
-                } else if (new_b_y + (bbound.height/2) > max_y){
-                    delta = new_b_y - +y2;
-                    new_b_y = +y2;
-                    new_a_y -= delta;
-                }
-                da.attr("y",new_a_y);
-                db.attr("y",new_b_y);
-            });
-        });
-        // Adjust our line leaders here
-        // so that they follow the labels. 
-        if (again) {
-            labelElements = data_layer.label_texts[0];
-            data_layer.label_lines.attr("y2",function(d,i) {
-                labelForLine = d3.select(labelElements[i]);
-                return labelForLine.attr("y");
-            });
-            this.separate_labels();
-        }
     };
        
     return this;

--- a/locuszoom.css
+++ b/locuszoom.css
@@ -64,6 +64,12 @@ svg.lz-locuszoom {
   svg.lz-locuszoom path.lz-data_layer-scatter-selected {
     stroke: rgba(24, 24, 24, 1);
     stroke-width: 4; }
+  svg.lz-locuszoom text.lz-data_layer-scatter-label {
+    fill: rgba(24, 24, 24, 1);
+    alignment-baseline: middle; }
+  svg.lz-locuszoom line.lz-data_layer-scatter-label {
+    stroke: rgba(24, 24, 24, 1);
+    stroke-width: 1px; }
   svg.lz-locuszoom g.lz-data_layer-gene {
     cursor: pointer; }
   svg.lz-locuszoom text.lz-data_layer-gene.lz-label {


### PR DESCRIPTION
## What

PheWAS and other plots need a means of labeling scatter points. Labels are fundamentally different from tool tips - they are a part of the SVG itself and are applied on a subset of a data set given some kind of filter (e.g. points above a certain y-value threshold).

This branch is a first pass at implementing such labels as an optional feature for scatter data layers. Attributes of this feature include:

* Dynamic label text using the same field-parsing approach as tool tip contents
* Full style control over label text in the layout
* Optionally defining lines to connect labels to scatter points with full style control in the layout
* Basic label collision detection and separation logic with a layout-definable spacing parameter