### PR TITLE
Recombination Rate Line

### DIFF
--- a/assets/css/locuszoom.scss
+++ b/assets/css/locuszoom.scss
@@ -119,9 +119,8 @@ svg.#{$namespace}-locuszoom {
   }
 
   path.#{$namespace}-data_layer-line-hitarea {
-    fill: transparent;
+    fill: none;
     stroke: transparent;
-    stroke-width: 12px;
     cursor: pointer;
   }
 

--- a/assets/css/locuszoom.scss
+++ b/assets/css/locuszoom.scss
@@ -269,6 +269,7 @@ div.#{$namespace}-data_layer-tooltip-arrow_bottom_right {
   font-family: "Helvetica Neue", Helvetica, Aria, sans-serif;
   font-size: 80%;
   padding-top: 4px;
+  padding-bottom: 4px;
   .#{$namespace}-controls-button {
     text-decoration: none;
     padding: 0.2em 0.5em 0.2em 0.5em;

--- a/assets/js/app/DataLayer.js
+++ b/assets/js/app/DataLayer.js
@@ -66,6 +66,13 @@ LocusZoom.DataLayer = function(id, layout, parent) {
                 .attr("class", "lz-data_layer-tooltip")
                 .attr("id", this.getBaseId() + ".tooltip." + id)
         };
+        this.updateTooltip(d, id);
+    };
+    this.updateTooltip = function(d, id){
+        // Empty the tooltip of all HTML (including its arrow!)
+        this.tooltips[id].selector.html('');
+        this.tooltips[id].arrow = null;
+        // Set the new HTML
         if (this.layout.tooltip.html){
             this.tooltips[id].selector.html(LocusZoom.parseFields(d, this.layout.tooltip.html));
         } else if (this.layout.tooltip.divs){
@@ -79,6 +86,7 @@ LocusZoom.DataLayer = function(id, layout, parent) {
                 if (div.html){ selection.html(LocusZoom.parseFields(d, div.html)); }
             }
         }
+        // Reposition and draw a new arrow
         this.positionTooltip(id);
     };
     this.destroyTooltip = function(id){

--- a/assets/js/app/DataLayer.js
+++ b/assets/js/app/DataLayer.js
@@ -70,7 +70,7 @@ LocusZoom.DataLayer = function(id, layout, parent) {
     };
     this.updateTooltip = function(d, id){
         // Empty the tooltip of all HTML (including its arrow!)
-        this.tooltips[id].selector.html('');
+        this.tooltips[id].selector.html("");
         this.tooltips[id].arrow = null;
         // Set the new HTML
         if (this.layout.tooltip.html){

--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -315,7 +315,7 @@ LocusZoom.StandardLayout = {
             height: 225,
             origin: { x: 0, y: 0 },
             min_width:  400,
-            min_height: 112.5,
+            min_height: 200,
             proportional_width: 1,
             proportional_height: 0.5,
             proportional_origin: { x: 0, y: 0 },
@@ -332,7 +332,7 @@ LocusZoom.StandardLayout = {
                     label_offset: 28
                 },
                 y2: {
-                    label: "Recombination Rate",
+                    label: "Recombination Rate (cM/Mb)",
                     label_offset: 40
                 }
             },

--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -319,7 +319,7 @@ LocusZoom.StandardLayout = {
             proportional_width: 1,
             proportional_height: 0.5,
             proportional_origin: { x: 0, y: 0 },
-            margin: { top: 20, right: 20, bottom: 35, left: 50 },
+            margin: { top: 20, right: 50, bottom: 35, left: 50 },
             inner_border: "rgba(210, 210, 210, 0.85)",
             axes: {
                 x: {
@@ -330,6 +330,10 @@ LocusZoom.StandardLayout = {
                 y1: {
                     label: "-log10 p-value",
                     label_offset: 28
+                },
+                y2: {
+                    label: "Recombination Rate",
+                    label_offset: 40
                 }
             },
             data_layers: {
@@ -354,12 +358,30 @@ LocusZoom.StandardLayout = {
                         html: "Significance Threshold: 3 × 10^-5"
                     }
                 },
+                recomb: {
+                    type: "line",
+                    fields: ["recomb:position", "recomb:recomb_rate"],
+                    z_index: 1,
+                    style: {
+                        "stroke": "#0000FF",
+                        "stroke-width": "1.5px"
+                    },
+                    x_axis: {
+                        field: "recomb:position"
+                    },
+                    y_axis: {
+                        axis: 2,
+                        field: "recomb:recomb_rate",
+                        floor: 0,
+                        ceiling: 100
+                    }
+                },
                 positions: {
                     type: "scatter",
                     point_shape: "circle",
                     point_size: 40,
                     fields: ["id", "position", "pvalue|scinotation", "pvalue|neglog10", "refAllele", "ld:state"],
-                    z_index: 1,
+                    z_index: 2,
                     x_axis: {
                         field: "position"
                     },
@@ -398,7 +420,7 @@ LocusZoom.StandardLayout = {
             proportional_width: 1,
             proportional_height: 0.5,
             proportional_origin: { x: 0, y: 0.5 },
-            margin: { top: 20, right: 20, bottom: 20, left: 50 },
+            margin: { top: 20, right: 50, bottom: 20, left: 50 },
             axes: {},
             data_layers: {
                 genes: {

--- a/assets/js/app/Panel.js
+++ b/assets/js/app/Panel.js
@@ -429,7 +429,7 @@ LocusZoom.Panel.prototype.render = function(){
             .domain([this.y1_extent[0], this.y1_extent[1]])
             .range([this.layout.cliparea.height, 0]);
     }
-    if (this.y_extent){
+    if (this.y2_extent){
         if (this.layout.axes.y2.ticks){
             this.y2_ticks = this.layout.axes.y2.ticks;
         } else {

--- a/assets/js/app/Singletons.js
+++ b/assets/js/app/Singletons.js
@@ -265,7 +265,6 @@ LocusZoom.TransformationFunctions.add("scinotation", function(x) {
 });
 
 
-
 /****************
   Scale Functions
 
@@ -607,11 +606,13 @@ LocusZoom.DataLayers.add("line", function(id, layout, parent){
     // Define a default layout for this DataLayer type and merge it with the passed argument
     this.DefaultLayout = {
         style: {
-            fill: "transparent"
+            fill: "transparent",
+            "stroke-width": "2px"
         },
         interpolate: "linear",
         x_axis: { field: "x" },
         y_axis: { field: "y", axis: 1 },
+        hitarea_width: 5,
         selectable: false
     };
     layout = LocusZoom.mergeLayouts(layout, this.DefaultLayout);
@@ -627,6 +628,42 @@ LocusZoom.DataLayers.add("line", function(id, layout, parent){
     // Apply the arguments to set LocusZoom.DataLayer as the prototype
     LocusZoom.DataLayer.apply(this, arguments);
 
+    // Helper function to get display and data objects representing
+    // the x/y coordinates of the current mouse event with respect to the line in terms of the display
+    // and the interpolated values of the x/y fields with respect to the line
+    this.getMouseDisplayAndData = function(){
+        var ret = {
+            display: {
+                x: d3.mouse(this.mouse_event)[0],
+                y: null
+            },
+            data: {},
+            slope: null
+        };
+        var x_field = this.layout.x_axis.field;
+        var y_field = this.layout.y_axis.field;
+        var x_scale = "x_scale";
+        var y_scale = "y" + this.layout.y_axis.axis + "_scale";
+        ret.data[x_field] = this.parent[x_scale].invert(ret.display.x);
+        var bisect = d3.bisector(function(datum) { return +datum[x_field]; }).left;
+        var index = bisect(this.data, ret.data[x_field]) - 1;
+        var startDatum = this.data[index];
+        var endDatum = this.data[index + 1];
+        var interpolate = d3.interpolateNumber(+startDatum[y_field], +endDatum[y_field]);
+        var range = +endDatum[x_field] - +startDatum[x_field];
+        ret.data[y_field] = interpolate((ret.data[x_field] % range) / range);
+        ret.display.y = this.parent[y_scale](ret.data[y_field]);
+        if (this.layout.tooltip.x_precision){
+            ret.data[x_field] = ret.data[x_field].toPrecision(this.layout.tooltip.x_precision);
+        }
+        if (this.layout.tooltip.y_precision){
+            ret.data[y_field] = ret.data[y_field].toPrecision(this.layout.tooltip.y_precision);
+        }
+        ret.slope = (this.parent[y_scale](endDatum[y_field]) - this.parent[y_scale](startDatum[y_field]))
+                  / (this.parent[x_scale](endDatum[x_field]) - this.parent[x_scale](startDatum[x_field]));
+        return ret;
+    };
+
     // Reimplement the positionTooltip() method to be line-specific
     this.positionTooltip = function(id){
         if (typeof id != "string"){
@@ -636,62 +673,82 @@ LocusZoom.DataLayers.add("line", function(id, layout, parent){
             throw ("Unable to position tooltip: id does not point to a valid tooltip");
         }
         var tooltip = this.tooltips[id];
+        var tooltip_box = tooltip.selector.node().getBoundingClientRect();
         var arrow_width = 7; // as defined in the default stylesheet
-        var stroke_width = 1; // as defined in the default stylesheet
+        var border_radius = 6; // as defined in the default stylesheet
+        var stroke_width = parseFloat(this.layout.style["stroke-width"]) || 1;
         var page_origin = this.getPageOrigin();
         var tooltip_box = tooltip.selector.node().getBoundingClientRect();
         var data_layer_height = this.parent.layout.height - (this.parent.layout.margin.top + this.parent.layout.margin.bottom);
         var data_layer_width = this.parent.layout.width - (this.parent.layout.margin.left + this.parent.layout.margin.right);
+        var top, left, arrow_top, arrow_left, arrow_type;
 
         // Determine x/y coordinates for display and data
-        var x_field = this.layout.x_axis.field;
-        var y_field = this.layout.y_axis.field;
-        var x_scale = "x_scale";
-        var y_scale = "y" + this.layout.y_axis.axis + "_scale";
-        var display = { x: d3.mouse(this.mouse_event)[0], y: null };
-        var data = { x: this.parent[x_scale].invert(display.x), y: null };
-        var bisect = d3.bisector(function(datum) { return datum[x_field]; }).left;
-        var index = bisect(this.data, data.x) - 1;
-        var startDatum = this.data[index];
-        var endDatum = this.data[index + 1];
-        var interpolate = d3.interpolateNumber(startDatum[y_field], endDatum[y_field]);
-        var range = endDatum[x_field] - startDatum[x_field];
-        data.y = interpolate((data.x % range) / range);
-        display.y = this.parent[y_scale](data.y);
+        var dd = this.getMouseDisplayAndData();
 
-        // Position horizontally: attempt to center on the mouse's x coordinate
-        // pad to either side if bumping up against the edge of the data layer
-        var offset_right = Math.max((tooltip_box.width / 2) - display.x, 0);
-        var offset_left = Math.max((tooltip_box.width / 2) + display.x - data_layer_width, 0);
-        var left = page_origin.x + display.x - (tooltip_box.width / 2) - offset_left + offset_right;
-        var min_arrow_left = arrow_width / 2;
-        var max_arrow_left = tooltip_box.width - (2.5 * arrow_width);
-        var arrow_left = (tooltip_box.width / 2) - arrow_width + offset_left - offset_right;
-        arrow_left = Math.min(Math.max(arrow_left, min_arrow_left), max_arrow_left);
+        // If the absolute value of the slope of the line at this point is above 1 (including Infinity)
+        // then position the tool tip left/right. Otherwise position top/bottom.
+        if (Math.abs(dd.slope) > 1){
 
-        // Position vertically above the line unless there's insufficient space
-        var top, arrow_type, arrow_top;
-        if (tooltip_box.height + stroke_width + arrow_width < data_layer_height - display.y){
-            top = page_origin.y + display.y + stroke_width + arrow_width;
-            arrow_type = "up";
-            arrow_top = 0 - stroke_width - arrow_width;
+            // Position horizontally on the left or the right depending on which side of the plot the point is on
+            if (dd.display.x <= this.parent.layout.width / 2){
+                left = page_origin.x + dd.display.x + stroke_width + arrow_width + stroke_width;
+                arrow_type = "left";
+                arrow_left = -1 * (arrow_width + stroke_width);
+            } else {
+                left = page_origin.x + dd.display.x - tooltip_box.width - stroke_width - arrow_width - stroke_width;
+                arrow_type = "right";
+                arrow_left = tooltip_box.width - stroke_width;
+            }
+            // Position vertically centered unless we're at the top or bottom of the plot
+            var data_layer_height = this.parent.layout.height - (this.parent.layout.margin.top + this.parent.layout.margin.bottom);
+            if (dd.display.y - (tooltip_box.height / 2) <= 0){ // Too close to the top, push it down
+                top = page_origin.y + dd.display.y - (1.5 * arrow_width) - border_radius;
+                arrow_top = border_radius;
+            } else if (dd.display.y + (tooltip_box.height / 2) >= data_layer_height){ // Too close to the bottom, pull it up
+                top = page_origin.y + dd.display.y + arrow_width + border_radius - tooltip_box.height;
+                arrow_top = tooltip_box.height - (2 * arrow_width) - border_radius;
+            } else { // vertically centered
+                top = page_origin.y + dd.display.y - (tooltip_box.height / 2);
+                arrow_top = (tooltip_box.height / 2) - arrow_width;
+            }
+
         } else {
-            top = page_origin.y + display.y - (tooltip_box.height + stroke_width + arrow_width);
-            arrow_type = "down";
-            arrow_top = tooltip_box.height - stroke_width;
+
+            // Position horizontally: attempt to center on the mouse's x coordinate
+            // pad to either side if bumping up against the edge of the data layer
+            var offset_right = Math.max((tooltip_box.width / 2) - dd.display.x, 0);
+            var offset_left = Math.max((tooltip_box.width / 2) + dd.display.x - data_layer_width, 0);
+            left = page_origin.x + dd.display.x - (tooltip_box.width / 2) - offset_left + offset_right;
+            var min_arrow_left = arrow_width / 2;
+            var max_arrow_left = tooltip_box.width - (2.5 * arrow_width);
+            arrow_left = (tooltip_box.width / 2) - arrow_width + offset_left - offset_right;
+            arrow_left = Math.min(Math.max(arrow_left, min_arrow_left), max_arrow_left);
+
+            // Position vertically above the line unless there's insufficient space
+            if (tooltip_box.height + stroke_width + arrow_width > dd.display.y){
+                top = page_origin.y + dd.display.y + stroke_width + arrow_width;
+                arrow_type = "up";
+                arrow_top = 0 - stroke_width - arrow_width;
+            } else {
+                top = page_origin.y + dd.display.y - (tooltip_box.height + stroke_width + arrow_width);
+                arrow_type = "down";
+                arrow_top = tooltip_box.height - stroke_width;
+            }
         }
 
         // Apply positions to the main div
-        tooltip.selector.style("left", left + "px").style("top", top + "px");
+        tooltip.selector.style({ left: left + "px", top: top + "px" });
         // Create / update position on arrow connecting tooltip to data
         if (!tooltip.arrow){
-            tooltip.arrow = tooltip.selector.append("div").style("position", "absolute");
+            tooltip.arrow = tooltip.selector.append("div").attr("id","fooarrow").style("position", "absolute");
         }
         tooltip.arrow
             .attr("class", "lz-data_layer-tooltip-arrow_" + arrow_type)
-            .style("left", arrow_left + "px")
-            .style("top", arrow_top + "px");
+            .style({ "left": arrow_left + "px", top: arrow_top + "px" });
+
     };
+
 
     // Implement the main render function
     this.render = function(){
@@ -737,12 +794,14 @@ LocusZoom.DataLayers.add("line", function(id, layout, parent){
         // Apply tooltip, etc
         if (this.layout.tooltip){
             // Generate an overlaying transparent "hit area" line for more intuitive mouse events
+            var hitarea_width = parseFloat(this.layout.hitarea_width).toString() + "px";
             var hitarea = this.svg.group
                 .selectAll("path.lz-data_layer-line-hitarea")
                 .data([this.data]);
             hitarea.enter()
                 .append("path")
-                .attr("class", "lz-data_layer-line-hitarea");
+                .attr("class", "lz-data_layer-line-hitarea")
+                .style("stroke-width", hitarea_width);
             var hitarea_line = d3.svg.line()
                 .x(function(d) { return panel[x_scale](d[x_field]); })
                 .y(function(d) { return panel[y_scale](d[y_field]); })
@@ -752,11 +811,14 @@ LocusZoom.DataLayers.add("line", function(id, layout, parent){
                 .on("mouseover", function(d){
                     clearTimeout(data_layer.tooltip_timeout);
                     data_layer.mouse_event = this;
-                    data_layer.createTooltip(d, data_layer.state_id);
+                    var dd = data_layer.getMouseDisplayAndData();
+                    data_layer.createTooltip(dd.data, data_layer.state_id);
                 })
                 .on("mousemove", function(){
                     clearTimeout(data_layer.tooltip_timeout);
                     data_layer.mouse_event = this;
+                    var dd = data_layer.getMouseDisplayAndData();
+                    data_layer.updateTooltip(dd.data, data_layer.state_id);
                     data_layer.positionTooltip(data_layer.state_id);
                 })
                 .on("mouseout", function(){
@@ -776,7 +838,6 @@ LocusZoom.DataLayers.add("line", function(id, layout, parent){
     return this;
 
 });
-
 
 /*********************
   Genes Data Layer

--- a/assets/js/app/Singletons.js
+++ b/assets/js/app/Singletons.js
@@ -678,7 +678,6 @@ LocusZoom.DataLayers.add("line", function(id, layout, parent){
         var border_radius = 6; // as defined in the default stylesheet
         var stroke_width = parseFloat(this.layout.style["stroke-width"]) || 1;
         var page_origin = this.getPageOrigin();
-        var tooltip_box = tooltip.selector.node().getBoundingClientRect();
         var data_layer_height = this.parent.layout.height - (this.parent.layout.margin.top + this.parent.layout.margin.bottom);
         var data_layer_width = this.parent.layout.width - (this.parent.layout.margin.left + this.parent.layout.margin.right);
         var top, left, arrow_top, arrow_left, arrow_type;
@@ -701,7 +700,6 @@ LocusZoom.DataLayers.add("line", function(id, layout, parent){
                 arrow_left = tooltip_box.width - stroke_width;
             }
             // Position vertically centered unless we're at the top or bottom of the plot
-            var data_layer_height = this.parent.layout.height - (this.parent.layout.margin.top + this.parent.layout.margin.bottom);
             if (dd.display.y - (tooltip_box.height / 2) <= 0){ // Too close to the top, push it down
                 top = page_origin.y + dd.display.y - (1.5 * arrow_width) - border_radius;
                 arrow_top = border_radius;
@@ -741,7 +739,7 @@ LocusZoom.DataLayers.add("line", function(id, layout, parent){
         tooltip.selector.style({ left: left + "px", top: top + "px" });
         // Create / update position on arrow connecting tooltip to data
         if (!tooltip.arrow){
-            tooltip.arrow = tooltip.selector.append("div").attr("id","fooarrow").style("position", "absolute");
+            tooltip.arrow = tooltip.selector.append("div").style("position", "absolute");
         }
         tooltip.arrow
             .attr("class", "lz-data_layer-tooltip-arrow_" + arrow_type)
@@ -808,7 +806,7 @@ LocusZoom.DataLayers.add("line", function(id, layout, parent){
                 .interpolate(this.layout.interpolate);
             hitarea
                 .attr("d", hitarea_line)
-                .on("mouseover", function(d){
+                .on("mouseover", function(){
                     clearTimeout(data_layer.tooltip_timeout);
                     data_layer.mouse_event = this;
                     var dd = data_layer.getMouseDisplayAndData();

--- a/demo.html
+++ b/demo.html
@@ -43,8 +43,8 @@
       .add("base", ["AssociationLZ", {url: apiBase + "single/", params: {analysis: 3}}])
       .add("ld", ["LDLZ" ,apiBase + "pair/LD/"])
       .add("gene", ["GeneLZ", { url: apiBase + "annotation/genes/", params: {source: 2} }])
-      .add("sig", ["StaticJSON", [{ "x": 0, "y": 4.522 }, { "x": 2881033286, "y": 4.522 }] ])
-      .add("recomb", ["RecombLZ", { url: apiBase + "recomb/results/", params: {source: 15} }]);
+      .add("recomb", ["RecombLZ", { url: apiBase + "annotation/recomb/results/", params: {source: 15} }])
+      .add("sig", ["StaticJSON", [{ "x": 0, "y": 4.522 }, { "x": 2881033286, "y": 4.522 }] ]);
 
     // Define custom LocusZoom layout object to allow manual resizing.
     // This will be merged with the default layout (LocusZoom.DefaultLayout)

--- a/demo_responsive.html
+++ b/demo_responsive.html
@@ -36,6 +36,7 @@
       .add("base", ["AssociationLZ", {url:apiBase + "single/", params: {analysis: 3}}])
       .add("ld", ["LDLZ" ,apiBase + "pair/LD/"])
       .add("gene", ["GeneLZ", { url: apiBase + "annotation/genes/", params: {source: 2} }])
+      .add("recomb", ["RecombLZ", { url: apiBase + "annotation/recomb/results/", params: {source: 15} }])
       .add("sig", ["StaticJSON", [{ "x": 0, "y": 4.522 }, { "x": 2881033286, "y": 4.522 }] ]);
 
     // Populate the div with a LocusZoom plot

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -329,7 +329,7 @@ LocusZoom.StandardLayout = {
             height: 225,
             origin: { x: 0, y: 0 },
             min_width:  400,
-            min_height: 112.5,
+            min_height: 200,
             proportional_width: 1,
             proportional_height: 0.5,
             proportional_origin: { x: 0, y: 0 },
@@ -346,7 +346,7 @@ LocusZoom.StandardLayout = {
                     label_offset: 28
                 },
                 y2: {
-                    label: "Recombination Rate",
+                    label: "Recombination Rate (cM/Mb)",
                     label_offset: 40
                 }
             },

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -333,7 +333,7 @@ LocusZoom.StandardLayout = {
             proportional_width: 1,
             proportional_height: 0.5,
             proportional_origin: { x: 0, y: 0 },
-            margin: { top: 20, right: 20, bottom: 35, left: 50 },
+            margin: { top: 20, right: 50, bottom: 35, left: 50 },
             inner_border: "rgba(210, 210, 210, 0.85)",
             axes: {
                 x: {
@@ -344,6 +344,10 @@ LocusZoom.StandardLayout = {
                 y1: {
                     label: "-log10 p-value",
                     label_offset: 28
+                },
+                y2: {
+                    label: "Recombination Rate",
+                    label_offset: 40
                 }
             },
             data_layers: {
@@ -368,12 +372,30 @@ LocusZoom.StandardLayout = {
                         html: "Significance Threshold: 3 × 10^-5"
                     }
                 },
+                recomb: {
+                    type: "line",
+                    fields: ["recomb:position", "recomb:recomb_rate"],
+                    z_index: 1,
+                    style: {
+                        "stroke": "#0000FF",
+                        "stroke-width": "1.5px"
+                    },
+                    x_axis: {
+                        field: "recomb:position"
+                    },
+                    y_axis: {
+                        axis: 2,
+                        field: "recomb:recomb_rate",
+                        floor: 0,
+                        ceiling: 100
+                    }
+                },
                 positions: {
                     type: "scatter",
                     point_shape: "circle",
                     point_size: 40,
                     fields: ["id", "position", "pvalue|scinotation", "pvalue|neglog10", "refAllele", "ld:state"],
-                    z_index: 1,
+                    z_index: 2,
                     x_axis: {
                         field: "position"
                     },
@@ -412,7 +434,7 @@ LocusZoom.StandardLayout = {
             proportional_width: 1,
             proportional_height: 0.5,
             proportional_origin: { x: 0, y: 0.5 },
-            margin: { top: 20, right: 20, bottom: 20, left: 50 },
+            margin: { top: 20, right: 50, bottom: 20, left: 50 },
             axes: {},
             data_layers: {
                 genes: {
@@ -1866,7 +1888,7 @@ LocusZoom.Panel.prototype.render = function(){
             .domain([this.y1_extent[0], this.y1_extent[1]])
             .range([this.layout.cliparea.height, 0]);
     }
-    if (this.y_extent){
+    if (this.y2_extent){
         if (this.layout.axes.y2.ticks){
             this.y2_ticks = this.layout.axes.y2.ticks;
         } else {
@@ -2069,6 +2091,13 @@ LocusZoom.DataLayer = function(id, layout, parent) {
                 .attr("class", "lz-data_layer-tooltip")
                 .attr("id", this.getBaseId() + ".tooltip." + id)
         };
+        this.updateTooltip(d, id);
+    };
+    this.updateTooltip = function(d, id){
+        // Empty the tooltip of all HTML (including its arrow!)
+        this.tooltips[id].selector.html('');
+        this.tooltips[id].arrow = null;
+        // Set the new HTML
         if (this.layout.tooltip.html){
             this.tooltips[id].selector.html(LocusZoom.parseFields(d, this.layout.tooltip.html));
         } else if (this.layout.tooltip.divs){
@@ -2082,6 +2111,7 @@ LocusZoom.DataLayer = function(id, layout, parent) {
                 if (div.html){ selection.html(LocusZoom.parseFields(d, div.html)); }
             }
         }
+        // Reposition and draw a new arrow
         this.positionTooltip(id);
     };
     this.destroyTooltip = function(id){
@@ -2524,7 +2554,6 @@ LocusZoom.TransformationFunctions.add("scinotation", function(x) {
 });
 
 
-
 /****************
   Scale Functions
 
@@ -2866,11 +2895,13 @@ LocusZoom.DataLayers.add("line", function(id, layout, parent){
     // Define a default layout for this DataLayer type and merge it with the passed argument
     this.DefaultLayout = {
         style: {
-            fill: "transparent"
+            fill: "transparent",
+            "stroke-width": "2px"
         },
         interpolate: "linear",
         x_axis: { field: "x" },
         y_axis: { field: "y", axis: 1 },
+        hitarea_width: 5,
         selectable: false
     };
     layout = LocusZoom.mergeLayouts(layout, this.DefaultLayout);
@@ -2886,6 +2917,42 @@ LocusZoom.DataLayers.add("line", function(id, layout, parent){
     // Apply the arguments to set LocusZoom.DataLayer as the prototype
     LocusZoom.DataLayer.apply(this, arguments);
 
+    // Helper function to get display and data objects representing
+    // the x/y coordinates of the current mouse event with respect to the line in terms of the display
+    // and the interpolated values of the x/y fields with respect to the line
+    this.getMouseDisplayAndData = function(){
+        var ret = {
+            display: {
+                x: d3.mouse(this.mouse_event)[0],
+                y: null
+            },
+            data: {},
+            slope: null
+        };
+        var x_field = this.layout.x_axis.field;
+        var y_field = this.layout.y_axis.field;
+        var x_scale = "x_scale";
+        var y_scale = "y" + this.layout.y_axis.axis + "_scale";
+        ret.data[x_field] = this.parent[x_scale].invert(ret.display.x);
+        var bisect = d3.bisector(function(datum) { return +datum[x_field]; }).left;
+        var index = bisect(this.data, ret.data[x_field]) - 1;
+        var startDatum = this.data[index];
+        var endDatum = this.data[index + 1];
+        var interpolate = d3.interpolateNumber(+startDatum[y_field], +endDatum[y_field]);
+        var range = +endDatum[x_field] - +startDatum[x_field];
+        ret.data[y_field] = interpolate((ret.data[x_field] % range) / range);
+        ret.display.y = this.parent[y_scale](ret.data[y_field]);
+        if (this.layout.tooltip.x_precision){
+            ret.data[x_field] = ret.data[x_field].toPrecision(this.layout.tooltip.x_precision);
+        }
+        if (this.layout.tooltip.y_precision){
+            ret.data[y_field] = ret.data[y_field].toPrecision(this.layout.tooltip.y_precision);
+        }
+        ret.slope = (this.parent[y_scale](endDatum[y_field]) - this.parent[y_scale](startDatum[y_field]))
+                  / (this.parent[x_scale](endDatum[x_field]) - this.parent[x_scale](startDatum[x_field]));
+        return ret;
+    };
+
     // Reimplement the positionTooltip() method to be line-specific
     this.positionTooltip = function(id){
         if (typeof id != "string"){
@@ -2895,62 +2962,82 @@ LocusZoom.DataLayers.add("line", function(id, layout, parent){
             throw ("Unable to position tooltip: id does not point to a valid tooltip");
         }
         var tooltip = this.tooltips[id];
+        var tooltip_box = tooltip.selector.node().getBoundingClientRect();
         var arrow_width = 7; // as defined in the default stylesheet
-        var stroke_width = 1; // as defined in the default stylesheet
+        var border_radius = 6; // as defined in the default stylesheet
+        var stroke_width = parseFloat(this.layout.style["stroke-width"]) || 1;
         var page_origin = this.getPageOrigin();
         var tooltip_box = tooltip.selector.node().getBoundingClientRect();
         var data_layer_height = this.parent.layout.height - (this.parent.layout.margin.top + this.parent.layout.margin.bottom);
         var data_layer_width = this.parent.layout.width - (this.parent.layout.margin.left + this.parent.layout.margin.right);
+        var top, left, arrow_top, arrow_left, arrow_type;
 
         // Determine x/y coordinates for display and data
-        var x_field = this.layout.x_axis.field;
-        var y_field = this.layout.y_axis.field;
-        var x_scale = "x_scale";
-        var y_scale = "y" + this.layout.y_axis.axis + "_scale";
-        var display = { x: d3.mouse(this.mouse_event)[0], y: null };
-        var data = { x: this.parent[x_scale].invert(display.x), y: null };
-        var bisect = d3.bisector(function(datum) { return datum[x_field]; }).left;
-        var index = bisect(this.data, data.x) - 1;
-        var startDatum = this.data[index];
-        var endDatum = this.data[index + 1];
-        var interpolate = d3.interpolateNumber(startDatum[y_field], endDatum[y_field]);
-        var range = endDatum[x_field] - startDatum[x_field];
-        data.y = interpolate((data.x % range) / range);
-        display.y = this.parent[y_scale](data.y);
+        var dd = this.getMouseDisplayAndData();
 
-        // Position horizontally: attempt to center on the mouse's x coordinate
-        // pad to either side if bumping up against the edge of the data layer
-        var offset_right = Math.max((tooltip_box.width / 2) - display.x, 0);
-        var offset_left = Math.max((tooltip_box.width / 2) + display.x - data_layer_width, 0);
-        var left = page_origin.x + display.x - (tooltip_box.width / 2) - offset_left + offset_right;
-        var min_arrow_left = arrow_width / 2;
-        var max_arrow_left = tooltip_box.width - (2.5 * arrow_width);
-        var arrow_left = (tooltip_box.width / 2) - arrow_width + offset_left - offset_right;
-        arrow_left = Math.min(Math.max(arrow_left, min_arrow_left), max_arrow_left);
+        // If the absolute value of the slope of the line at this point is above 1 (including Infinity)
+        // then position the tool tip left/right. Otherwise position top/bottom.
+        if (Math.abs(dd.slope) > 1){
 
-        // Position vertically above the line unless there's insufficient space
-        var top, arrow_type, arrow_top;
-        if (tooltip_box.height + stroke_width + arrow_width < data_layer_height - display.y){
-            top = page_origin.y + display.y + stroke_width + arrow_width;
-            arrow_type = "up";
-            arrow_top = 0 - stroke_width - arrow_width;
+            // Position horizontally on the left or the right depending on which side of the plot the point is on
+            if (dd.display.x <= this.parent.layout.width / 2){
+                left = page_origin.x + dd.display.x + stroke_width + arrow_width + stroke_width;
+                arrow_type = "left";
+                arrow_left = -1 * (arrow_width + stroke_width);
+            } else {
+                left = page_origin.x + dd.display.x - tooltip_box.width - stroke_width - arrow_width - stroke_width;
+                arrow_type = "right";
+                arrow_left = tooltip_box.width - stroke_width;
+            }
+            // Position vertically centered unless we're at the top or bottom of the plot
+            var data_layer_height = this.parent.layout.height - (this.parent.layout.margin.top + this.parent.layout.margin.bottom);
+            if (dd.display.y - (tooltip_box.height / 2) <= 0){ // Too close to the top, push it down
+                top = page_origin.y + dd.display.y - (1.5 * arrow_width) - border_radius;
+                arrow_top = border_radius;
+            } else if (dd.display.y + (tooltip_box.height / 2) >= data_layer_height){ // Too close to the bottom, pull it up
+                top = page_origin.y + dd.display.y + arrow_width + border_radius - tooltip_box.height;
+                arrow_top = tooltip_box.height - (2 * arrow_width) - border_radius;
+            } else { // vertically centered
+                top = page_origin.y + dd.display.y - (tooltip_box.height / 2);
+                arrow_top = (tooltip_box.height / 2) - arrow_width;
+            }
+
         } else {
-            top = page_origin.y + display.y - (tooltip_box.height + stroke_width + arrow_width);
-            arrow_type = "down";
-            arrow_top = tooltip_box.height - stroke_width;
+
+            // Position horizontally: attempt to center on the mouse's x coordinate
+            // pad to either side if bumping up against the edge of the data layer
+            var offset_right = Math.max((tooltip_box.width / 2) - dd.display.x, 0);
+            var offset_left = Math.max((tooltip_box.width / 2) + dd.display.x - data_layer_width, 0);
+            left = page_origin.x + dd.display.x - (tooltip_box.width / 2) - offset_left + offset_right;
+            var min_arrow_left = arrow_width / 2;
+            var max_arrow_left = tooltip_box.width - (2.5 * arrow_width);
+            arrow_left = (tooltip_box.width / 2) - arrow_width + offset_left - offset_right;
+            arrow_left = Math.min(Math.max(arrow_left, min_arrow_left), max_arrow_left);
+
+            // Position vertically above the line unless there's insufficient space
+            if (tooltip_box.height + stroke_width + arrow_width > dd.display.y){
+                top = page_origin.y + dd.display.y + stroke_width + arrow_width;
+                arrow_type = "up";
+                arrow_top = 0 - stroke_width - arrow_width;
+            } else {
+                top = page_origin.y + dd.display.y - (tooltip_box.height + stroke_width + arrow_width);
+                arrow_type = "down";
+                arrow_top = tooltip_box.height - stroke_width;
+            }
         }
 
         // Apply positions to the main div
-        tooltip.selector.style("left", left + "px").style("top", top + "px");
+        tooltip.selector.style({ left: left + "px", top: top + "px" });
         // Create / update position on arrow connecting tooltip to data
         if (!tooltip.arrow){
-            tooltip.arrow = tooltip.selector.append("div").style("position", "absolute");
+            tooltip.arrow = tooltip.selector.append("div").attr("id","fooarrow").style("position", "absolute");
         }
         tooltip.arrow
             .attr("class", "lz-data_layer-tooltip-arrow_" + arrow_type)
-            .style("left", arrow_left + "px")
-            .style("top", arrow_top + "px");
+            .style({ "left": arrow_left + "px", top: arrow_top + "px" });
+
     };
+
 
     // Implement the main render function
     this.render = function(){
@@ -2996,12 +3083,14 @@ LocusZoom.DataLayers.add("line", function(id, layout, parent){
         // Apply tooltip, etc
         if (this.layout.tooltip){
             // Generate an overlaying transparent "hit area" line for more intuitive mouse events
+            var hitarea_width = parseFloat(this.layout.hitarea_width).toString() + "px";
             var hitarea = this.svg.group
                 .selectAll("path.lz-data_layer-line-hitarea")
                 .data([this.data]);
             hitarea.enter()
                 .append("path")
-                .attr("class", "lz-data_layer-line-hitarea");
+                .attr("class", "lz-data_layer-line-hitarea")
+                .style("stroke-width", hitarea_width);
             var hitarea_line = d3.svg.line()
                 .x(function(d) { return panel[x_scale](d[x_field]); })
                 .y(function(d) { return panel[y_scale](d[y_field]); })
@@ -3011,11 +3100,14 @@ LocusZoom.DataLayers.add("line", function(id, layout, parent){
                 .on("mouseover", function(d){
                     clearTimeout(data_layer.tooltip_timeout);
                     data_layer.mouse_event = this;
-                    data_layer.createTooltip(d, data_layer.state_id);
+                    var dd = data_layer.getMouseDisplayAndData();
+                    data_layer.createTooltip(dd.data, data_layer.state_id);
                 })
                 .on("mousemove", function(){
                     clearTimeout(data_layer.tooltip_timeout);
                     data_layer.mouse_event = this;
+                    var dd = data_layer.getMouseDisplayAndData();
+                    data_layer.updateTooltip(dd.data, data_layer.state_id);
                     data_layer.positionTooltip(data_layer.state_id);
                 })
                 .on("mouseout", function(){
@@ -3035,7 +3127,6 @@ LocusZoom.DataLayers.add("line", function(id, layout, parent){
     return this;
 
 });
-
 
 /*********************
   Genes Data Layer

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -2095,7 +2095,7 @@ LocusZoom.DataLayer = function(id, layout, parent) {
     };
     this.updateTooltip = function(d, id){
         // Empty the tooltip of all HTML (including its arrow!)
-        this.tooltips[id].selector.html('');
+        this.tooltips[id].selector.html("");
         this.tooltips[id].arrow = null;
         // Set the new HTML
         if (this.layout.tooltip.html){
@@ -2967,7 +2967,6 @@ LocusZoom.DataLayers.add("line", function(id, layout, parent){
         var border_radius = 6; // as defined in the default stylesheet
         var stroke_width = parseFloat(this.layout.style["stroke-width"]) || 1;
         var page_origin = this.getPageOrigin();
-        var tooltip_box = tooltip.selector.node().getBoundingClientRect();
         var data_layer_height = this.parent.layout.height - (this.parent.layout.margin.top + this.parent.layout.margin.bottom);
         var data_layer_width = this.parent.layout.width - (this.parent.layout.margin.left + this.parent.layout.margin.right);
         var top, left, arrow_top, arrow_left, arrow_type;
@@ -2990,7 +2989,6 @@ LocusZoom.DataLayers.add("line", function(id, layout, parent){
                 arrow_left = tooltip_box.width - stroke_width;
             }
             // Position vertically centered unless we're at the top or bottom of the plot
-            var data_layer_height = this.parent.layout.height - (this.parent.layout.margin.top + this.parent.layout.margin.bottom);
             if (dd.display.y - (tooltip_box.height / 2) <= 0){ // Too close to the top, push it down
                 top = page_origin.y + dd.display.y - (1.5 * arrow_width) - border_radius;
                 arrow_top = border_radius;
@@ -3030,7 +3028,7 @@ LocusZoom.DataLayers.add("line", function(id, layout, parent){
         tooltip.selector.style({ left: left + "px", top: top + "px" });
         // Create / update position on arrow connecting tooltip to data
         if (!tooltip.arrow){
-            tooltip.arrow = tooltip.selector.append("div").attr("id","fooarrow").style("position", "absolute");
+            tooltip.arrow = tooltip.selector.append("div").style("position", "absolute");
         }
         tooltip.arrow
             .attr("class", "lz-data_layer-tooltip-arrow_" + arrow_type)
@@ -3097,7 +3095,7 @@ LocusZoom.DataLayers.add("line", function(id, layout, parent){
                 .interpolate(this.layout.interpolate);
             hitarea
                 .attr("d", hitarea_line)
-                .on("mouseover", function(d){
+                .on("mouseover", function(){
                     clearTimeout(data_layer.tooltip_timeout);
                     data_layer.mouse_event = this;
                     var dd = data_layer.getMouseDisplayAndData();

--- a/locuszoom.css
+++ b/locuszoom.css
@@ -199,7 +199,8 @@ div.lz-data_layer-tooltip-arrow_bottom_right {
 .lz-locuszoom-controls {
   font-family: "Helvetica Neue", Helvetica, Aria, sans-serif;
   font-size: 80%;
-  padding-top: 4px; }
+  padding-top: 4px;
+  padding-bottom: 4px; }
   .lz-locuszoom-controls .lz-controls-button {
     text-decoration: none;
     padding: 0.2em 0.5em 0.2em 0.5em;

--- a/locuszoom.css
+++ b/locuszoom.css
@@ -78,9 +78,8 @@ svg.lz-locuszoom {
     stroke-width: 1;
     cursor: pointer; }
   svg.lz-locuszoom path.lz-data_layer-line-hitarea {
-    fill: transparent;
+    fill: none;
     stroke: transparent;
-    stroke-width: 12px;
     cursor: pointer; }
   svg.lz-locuszoom g.lz-data_layer-gene {
     cursor: pointer; }

--- a/plot_builder.html
+++ b/plot_builder.html
@@ -97,6 +97,7 @@
       .add("base", ["AssociationLZ", {url:apiBase + "single/", params: { analysis: 3 }}])
       .add("ld", ["LDLZ" ,apiBase + "pair/LD/"])
       .add("gene", ["GeneLZ", { url: apiBase + "annotation/genes/", params: { source: 2 } }])
+      .add("recomb", ["RecombLZ", { url: apiBase + "annotation/recomb/results/", params: {source: 15} }])
       .add("sig", ["StaticJSON", [{ "x": 0, "y": 4.522 }, { "x": 2881033286, "y": 4.522 }] ]);
 
     function addAnalysis(){

--- a/test/Singletons.js
+++ b/test/Singletons.js
@@ -104,9 +104,9 @@ describe('LocusZoom Singletons', function(){
         });
         it("should have a method to list available label functions", function(){
             LocusZoom.TransformationFunctions.should.have.property("list").which.is.a.Function;
-            var returned_list = LocusZoom.TransformationFunctions.list();
-            var expected_list = ["neglog10", "scinotation"];
-            assert.deepEqual(returned_list, expected_list);
+            LocusZoom.TransformationFunctions.list().should.be.an.Array;
+            LocusZoom.TransformationFunctions.list().should.containEql("scinotation");
+            LocusZoom.TransformationFunctions.list().should.containEql("neglog10");
         });
         it("should have a general method to get a function or execute it for a result", function(){
             LocusZoom.TransformationFunctions.should.have.property("get").which.is.a.Function;
@@ -116,9 +116,7 @@ describe('LocusZoom Singletons', function(){
             LocusZoom.TransformationFunctions.should.have.property("add").which.is.a.Function;
             var foo = function(x){ return x + 1; };
             LocusZoom.TransformationFunctions.add("foo", foo);
-            var returned_list = LocusZoom.TransformationFunctions.list();
-            var expected_list = ["neglog10", "scinotation", "foo"];
-            assert.deepEqual(returned_list, expected_list);
+            LocusZoom.TransformationFunctions.list().should.containEql("foo");
             var returned_value = LocusZoom.TransformationFunctions.get("foo")(2);
             var expected_value = 3;
             assert.equal(returned_value, expected_value);
@@ -127,16 +125,12 @@ describe('LocusZoom Singletons', function(){
             LocusZoom.TransformationFunctions.should.have.property("set").which.is.a.Function;
             var foo_new = function(x){ return x * 2; };
             LocusZoom.TransformationFunctions.set("foo", foo_new);
-            var returned_list = LocusZoom.TransformationFunctions.list();
-            var expected_list = ["neglog10", "scinotation", "foo"];
-            assert.deepEqual(returned_list, expected_list);
+            LocusZoom.TransformationFunctions.list().should.containEql("foo");
             var returned_value = LocusZoom.TransformationFunctions.get("foo")(4);
             var expected_value = 8;
             assert.equal(returned_value, expected_value);
             LocusZoom.TransformationFunctions.set("foo");
-            var returned_list = LocusZoom.TransformationFunctions.list();
-            var expected_list = ["neglog10", "scinotation"];
-            assert.deepEqual(returned_list, expected_list);
+            LocusZoom.TransformationFunctions.list().should.not.containEql("foo");
         });
         it("should throw an exception if asked to get a function that has not been defined", function(){
             assert.throws(function(){


### PR DESCRIPTION
# What

This branch utilizes the new `recomb` data source to implement a basic recombination rate line.

While the line data layer already existed the tool tip positioning logic needed some iteration to behave a bit more intuitively for all lines in general.

## Changes

* Line tool tip positioning now takes place to the left/right of the line if the slope is greater than one (including `Infinity`) and to the top/bottom of the line if the slope is less than one.
* Abstract tool tips new have a flow of `createTooltip()` => `updateTooltip()` => `positionTooltip()` (as opposed to just `createTooltip()` => `positionTooltip()`). The new `updateTooltip()` function handles writing the contents to the tool tip. This doesn't change the behavior for tool tips on other data layers that create tool tips once for discrete data points, but lines are continuous data ranges so the update method allows for changing the contents of the tooltip as it is repositioned (e.g. as the mouse moves over the line - useful if the tooltip is showing dynamic data about that position on the line).
* The `StandardLayout` now includes a recombination rate data layer in the positions panel, arranged behind the scatter/association data but in front of the line of statistical significance.
* Tool tips for recombination rate are *not* enabled in the standard layout. This is because while tool tips for lines are functional they're still a bit clunky.

