### PR TITLE
Panel UI

### DIFF
--- a/assets/css/locuszoom.scss
+++ b/assets/css/locuszoom.scss
@@ -315,8 +315,8 @@ div.#{$namespace}-data_layer-tooltip-arrow_bottom_right {
 }
 
 .#{$namespace}-locuszoom-panel-controls {
-   padding-top: 4px;
-   padding-right: 4px;
+   padding-top: 6px;
+   padding-right: 2px;
 }
 
 div.#{$namespace}-panel-description {
@@ -328,4 +328,33 @@ div.#{$namespace}-panel-description {
   border: 1px solid #{$default_black};
   border-radius: 4px;
   box-shadow: 2px 2px 2px #{$default_black_shadow};
+}
+
+div.#{$namespace}-panel-boundary {
+  position: absolute;
+  height: 4px;
+  width: 200px;
+  border-radius: 2px;
+  background: rgba(235,240,228,0.5);
+  border: 1px solid #{$default_black_shadow};
+}
+
+div.#{$namespace}-panel-boundary {
+  position: absolute;
+  height: 3px;
+  width: 200px;
+  border-radius: 1px;
+  background: rgba(216,216,216,0.4);
+  border: 1px solid #{$default_black_shadow};
+  cursor: row-resize;
+}
+
+div.#{$namespace}-panel-boundary:hover {
+  background: rgba(216,216,216,1);
+  border: 1px solid #{$default_black};
+}
+
+div.#{$namespace}-panel-boundary:active {
+  background: rgba(51,51,51,1);
+  border: 1px solid rgba(216,216,216,1);
 }

--- a/assets/css/locuszoom.scss
+++ b/assets/css/locuszoom.scss
@@ -84,6 +84,11 @@ svg.#{$namespace}-locuszoom {
     stroke-linejoin: round;
   }
 
+  .#{$namespace}-panel-title {
+    font-size: 18px;
+    font-weight: 600;
+  }
+
   .#{$namespace}-axis path,
   .#{$namespace}-axis line {
   	fill: none;

--- a/assets/css/locuszoom.scss
+++ b/assets/css/locuszoom.scss
@@ -303,3 +303,8 @@ div.#{$namespace}-data_layer-tooltip-arrow_bottom_right {
     background-color: #D8D8D8;
   }
 }
+
+.#{$namespace}-locuszoom-panel-controls {
+   padding-top: 4px;
+   padding-right: 4px;
+}

--- a/assets/css/locuszoom.scss
+++ b/assets/css/locuszoom.scss
@@ -287,7 +287,17 @@ div.#{$namespace}-data_layer-tooltip-arrow_bottom_right {
   .#{$namespace}-controls-button:hover {
     cursor: pointer;
     background-color: #333333;
-    color: #D8D8D8
+    color: #D8D8D8;
+  }
+  .#{$namespace}-controls-button-selected {
+    text-decoration: none;
+    padding: 0.2em 0.5em 0.2em 0.5em;
+    border: 1px solid #333333;
+    border-radius: 4px;
+    pointer-events: auto;
+    cursor: pointer;
+    background-color: #333333;
+    color: #D8D8D8;
   }
   .#{$namespace}-controls-button-disabled {
     text-decoration: none;
@@ -307,4 +317,15 @@ div.#{$namespace}-data_layer-tooltip-arrow_bottom_right {
 .#{$namespace}-locuszoom-panel-controls {
    padding-top: 4px;
    padding-right: 4px;
+}
+
+div.#{$namespace}-panel-description {
+  font-family: "Helvetica Neue", Helvetica, Aria, sans-serif;
+  font-size: 12px;
+  position: absolute;
+  padding: 6px;
+  background: rgba(228,235,240,1);
+  border: 1px solid #{$default_black};
+  border-radius: 4px;
+  box-shadow: 2px 2px 2px #{$default_black_shadow};
 }

--- a/assets/css/locuszoom.scss
+++ b/assets/css/locuszoom.scss
@@ -57,9 +57,9 @@ svg.#{$namespace}-locuszoom {
 
   .#{$namespace}-ui-resize_handle {
     fill: rgb(210,210,210);
-    fill-opacity: 0.85;
+    fill-opacity: 0.4;
     stroke: rgb(45,45,45);
-    stroke-opacity: 0.85;
+    stroke-opacity: 0.4;
     stroke-width: 1;
     cursor: nwse-resize;
     stroke-linejoin: round;
@@ -317,6 +317,41 @@ div.#{$namespace}-data_layer-tooltip-arrow_bottom_right {
 .#{$namespace}-locuszoom-panel-controls {
    padding-top: 6px;
    padding-right: 2px;
+   .#{$namespace}-panel-controls-button {
+    text-decoration: none;
+    padding: 0.2em 0.5em 0.2em 0.5em;
+    background-color: rgba(216,216,216,0.4);
+    border: 1px solid rgba(51,51,51,0.4);
+    color: rgba(51,51,51,0.4);
+    border-radius: 4px;
+    pointer-events: auto;
+  }
+  .#{$namespace}-panel-controls-button:hover {
+    cursor: pointer;
+    background-color: rgba(216,216,216,1);
+    border: 1px solid rgba(51,51,51,1);
+    color: rgba(51,51,51,1);
+  }
+  .#{$namespace}-panel-controls-button-selected {
+    text-decoration: none;
+    padding: 0.2em 0.5em 0.2em 0.5em;
+    border: 1px solid rgba(51,51,51,1);
+    border-radius: 4px;
+    pointer-events: auto;
+    cursor: pointer;
+    background-color: rgba(51,51,51,1);
+    color: rgba(216,216,216,1);
+  }
+  .#{$namespace}-panel-controls-button-disabled {
+    text-decoration: none;
+    padding: 0.2em 0.5em 0.2em 0.5em;
+    background-color: rgba(216,216,216,0.4);
+    border: 1px solid rgba(153,153,153,0.4);
+    color: rgba(153,153,153,0.4);
+    border-radius: 4px;
+    pointer-events: none;
+    cursor: wait;
+  }
 }
 
 div.#{$namespace}-panel-description {

--- a/assets/js/app/DataLayer.js
+++ b/assets/js/app/DataLayer.js
@@ -123,24 +123,13 @@ LocusZoom.DataLayer = function(id, layout, parent) {
         }
     };
 
-    // Get an object with the x and y coordinates of this data layer's origin in terms of the entire page
-    // (useful for custom reimplementations this.positionTooltip())
+    // Get an object with the x and y coordinates of the panel's origin in terms of the entire page
+    // Necessary for positioning any HTML elements over the panel
     this.getPageOrigin = function(){
-        var bounding_client_rect = this.parent.parent.svg.node().getBoundingClientRect();
-        var x_offset = document.documentElement.scrollLeft || document.body.scrollLeft;
-        var y_offset = document.documentElement.scrollTop || document.body.scrollTop;
-        var container = this.parent.parent.svg.node();
-        while (container.parentNode != null){
-            container = container.parentNode;
-            if (container != document && d3.select(container).style("position") != "static"){
-                x_offset = -1 * container.getBoundingClientRect().left;
-                y_offset = -1 * container.getBoundingClientRect().top;
-                break;
-            }
-        }
+        var panel_origin = this.parent.getPageOrigin();
         return {
-            x: x_offset + bounding_client_rect.left + this.parent.layout.origin.x + this.parent.layout.margin.left,
-            y: y_offset + bounding_client_rect.top + this.parent.layout.origin.y + this.parent.layout.margin.top
+            x: panel_origin.x + this.parent.layout.margin.left,
+            y: panel_origin.y + this.parent.layout.margin.top
         };
     };
     

--- a/assets/js/app/Instance.js
+++ b/assets/js/app/Instance.js
@@ -47,6 +47,27 @@ LocusZoom.Instance = function(id, datasource, layout) {
     // Array of functions to call when the plot is updated
     this.onUpdateFunctions = [];
 
+    // Get an object with the x and y coordinates of the instance's origin in terms of the entire page
+    // Necessary for positioning any HTML elements over the plot
+    this.getPageOrigin = function(){
+        var bounding_client_rect = this.svg.node().getBoundingClientRect();
+        var x_offset = document.documentElement.scrollLeft || document.body.scrollLeft;
+        var y_offset = document.documentElement.scrollTop || document.body.scrollTop;
+        var container = this.svg.node();
+        while (container.parentNode != null){
+            container = container.parentNode;
+            if (container != document && d3.select(container).style("position") != "static"){
+                x_offset = -1 * container.getBoundingClientRect().left;
+                y_offset = -1 * container.getBoundingClientRect().top;
+                break;
+            }
+        }
+        return {
+            x: x_offset + bounding_client_rect.left,
+            y: y_offset + bounding_client_rect.top
+        };
+    };
+
     // Initialize the layout
     this.initializeLayout();
 
@@ -274,9 +295,6 @@ LocusZoom.Instance.prototype.addPanel = function(id, layout){
 LocusZoom.Instance.prototype.removePanel = function(id){
     if (!this.panels[id]){
         throw ("Unable to remove panel, ID not found: " + id);
-    }
-    if (!this.panels[id].layout.removable){
-        throw ("Unable to remove panel, panel is marked as not removable");
     }
 
     // Destroy all tooltips and state vars for all data layers on the panel
@@ -563,11 +581,11 @@ LocusZoom.Instance.prototype.initialize = function(){
     if (this.layout.controls.show == "always"){
         this.controls.show();
     } else if (this.layout.controls.show == "onmouseover"){
-        d3.select(this.svg.node().parentNode).on("mouseover", function(){
+        d3.select(this.svg.node().parentNode).on("mouseover." + this.id + ".controls", function(){
             clearTimeout(this.controls.hide_timeout);
             this.controls.show();
         }.bind(this));
-        d3.select(this.svg.node().parentNode).on("mouseout", function(){
+        d3.select(this.svg.node().parentNode).on("mouseout." + this.id + ".controls", function(){
             this.controls.hide_timeout = setTimeout(function(){
                 this.controls.hide();
             }.bind(this), this.layout.controls.hide_delay);

--- a/assets/js/app/Instance.js
+++ b/assets/js/app/Instance.js
@@ -23,6 +23,11 @@ LocusZoom.Instance = function(id, datasource, layout) {
 
     this.panels = {};
     this.panel_ids_by_y_index = [];
+    this.applyPanelYIndexesToPanelLayouts = function(){
+        this.panel_ids_by_y_index.forEach(function(pid, idx){
+            this.panels[pid].layout.y_index = idx;
+        }.bind(this));
+    };
 
     this.remap_promises = [];
 
@@ -199,6 +204,9 @@ LocusZoom.Instance.prototype.setDimensions = function(width, height){
             this.panels[panel_id].layout.proportional_origin.x = 0;
             this.panels[panel_id].layout.proportional_origin.y = y_offset / this.layout.height;
             y_offset += panel_height;
+            if (this.panels[panel_id].controls.selector){
+                this.panels[panel_id].controls.position();
+            }
         }.bind(this));
     }
 
@@ -264,9 +272,7 @@ LocusZoom.Instance.prototype.addPanel = function(id, layout){
             panel.layout.y_index = Math.max(this.panel_ids_by_y_index.length + panel.layout.y_index, 0);
         }
         this.panel_ids_by_y_index.splice(panel.layout.y_index, 0, panel.id);
-        this.panel_ids_by_y_index.forEach(function(pid, idx){
-            this.panels[pid].layout.y_index = idx;
-        }.bind(this));
+        this.applyPanelYIndexesToPanelLayouts();
     } else {
         var length = this.panel_ids_by_y_index.push(panel.id);
         this.panels[panel.id].layout.y_index = length - 1;

--- a/assets/js/app/Instance.js
+++ b/assets/js/app/Instance.js
@@ -92,7 +92,7 @@ LocusZoom.Instance.DefaultLayout = {
     panels: {},
     controls: {
         show: "onmouseover",
-        hide_delay: 500
+        hide_delay: 300
     },
     panel_boundaries: true
 };
@@ -208,6 +208,10 @@ LocusZoom.Instance.prototype.setDimensions = function(width, height){
                 this.panels[panel_id].controls.position();
             }
         }.bind(this));
+        // Reposition panel boundaries if showing
+        if (this.panel_boundaries && this.panel_boundaries.showing){
+            this.panel_boundaries.position();
+        }
     }
 
     // If width and height arguments were NOT passed (and panels exist) then determine the instance dimensions
@@ -413,6 +417,7 @@ LocusZoom.Instance.prototype.initialize = function(){
     this.ui = {
         svg: ui_svg,
         parent: this,
+        hide_timeout: null,
         is_resize_dragging: false,
         show: function(){
             this.svg.style("display", null);
@@ -692,12 +697,15 @@ LocusZoom.Instance.prototype.initialize = function(){
     // Define instance/svg level mouse events
     this.svg.on("mouseover", function(){
         if (!this.ui.is_resize_dragging){
+            clearTimeout(this.ui.hide_timeout);
             this.ui.show();
         }
     }.bind(this));
     this.svg.on("mouseout", function(){
         if (!this.ui.is_resize_dragging){
-            this.ui.hide();
+            this.ui.hide_timeout = setTimeout(function(){
+                this.ui.hide();
+            }.bind(this), 300);
         }
         this.mouse_guide.vertical.attr("x", -1);
         this.mouse_guide.horizontal.attr("y", -1);

--- a/assets/js/app/Instance.js
+++ b/assets/js/app/Instance.js
@@ -505,7 +505,7 @@ LocusZoom.Instance.prototype.initialize = function(){
         show: function(){
             if (!this.showing){
                 this.div = d3.select(this.parent.svg.node().parentNode).append("div")
-                    .attr("class", "lz-locuszoom-controls").attr("id", this.id + ".controls");
+                    .attr("class", "lz-locuszoom-controls").attr("id", this.parent.id + ".controls");
                 this.links = this.div.append("div")
                     .attr("id", this.parent.id + ".controls.links")
                     .style("float", "left");

--- a/assets/js/app/Instance.js
+++ b/assets/js/app/Instance.js
@@ -93,7 +93,8 @@ LocusZoom.Instance.DefaultLayout = {
     controls: {
         show: "onmouseover",
         hide_delay: 500
-    }
+    },
+    panel_boundaries: true
 };
 
 // Helper method to sum the proportional dimensions of panels, a value that's checked often as panels are added/removed
@@ -111,7 +112,6 @@ LocusZoom.Instance.prototype.sumProportional = function(dimension){
     }
     return total;
 };
-
 
 LocusZoom.Instance.prototype.onUpdate = function(func){
     if (typeof func == "undefined"){
@@ -490,6 +490,92 @@ LocusZoom.Instance.prototype.initialize = function(){
     this.curtain.svg.append("text")
         .attr("id", this.id + ".curtain_text")
         .attr("x", "1em").attr("y", "0em");
+
+    // Create the panel_boundaries object with show/position/hide methods
+    this.panel_boundaries = {
+        parent: this,
+        hide_timeout: null,
+        showing: false,
+        dragging: false,
+        selectors: [],
+        show: function(){
+            // Generate panel boundaries
+            if (!this.showing){
+                this.parent.panel_ids_by_y_index.forEach(function(panel_id, panel_idx){
+                    var selector = d3.select(this.parent.svg.node().parentNode).append("div")
+                        .attr("class", "lz-panel-boundary")
+                        .attr("title", "Resize panels");
+                    var panel_resize_drag = d3.behavior.drag();
+                    panel_resize_drag.on("dragstart", function(){ this.dragging = true; }.bind(this));
+                    panel_resize_drag.on("dragend", function(){ this.dragging = false; }.bind(this));
+                    panel_resize_drag.on("drag", function(){
+                        // First set the dimensions on the panel we're resizing
+                        var this_panel = this.parent.panels[this.parent.panel_ids_by_y_index[panel_idx]];
+                        var original_panel_height = this_panel.layout.height;
+                        this_panel.setDimensions(this_panel.layout.width, this_panel.layout.height + d3.event.dy);
+                        var panel_height_change = this_panel.layout.height - original_panel_height;
+                        var new_calculated_plot_height = this.parent.layout.height + panel_height_change;
+                        // Next loop through all panels.
+                        // Update proportional dimensions for all panels including the one we've resized using discrete heights.
+                        // Reposition panels with a greater y-index than this panel to their appropriate new origin.
+                        this.parent.panel_ids_by_y_index.forEach(function(loop_panel_id, loop_panel_idx){
+                            var loop_panel = this.parent.panels[this.parent.panel_ids_by_y_index[loop_panel_idx]];
+                            loop_panel.layout.proportional_height = loop_panel.layout.height / new_calculated_plot_height;
+                            if (loop_panel_idx > panel_idx){
+                                loop_panel.setOrigin(loop_panel.layout.origin.x, loop_panel.layout.origin.y + panel_height_change);
+                                if (loop_panel.layout.controls){
+                                    loop_panel.controls.position();
+                                }
+                            }
+                        }.bind(this));
+                        // Reset dimensions on the entire plot and reposition panel boundaries
+                        this.parent.positionPanels();
+                        this.position();
+                    }.bind(this));
+                    selector.call(panel_resize_drag);
+                    this.parent.panel_boundaries.selectors.push(selector);
+                }.bind(this));
+                this.showing = true;
+            }
+            this.position();
+        },
+        position: function(){
+            // Position panel boundaries
+            var plot_page_origin = this.parent.getPageOrigin();
+            this.selectors.forEach(function(selector, panel_idx){
+                var panel_page_origin = this.parent.panels[this.parent.panel_ids_by_y_index[panel_idx]].getPageOrigin();
+                var left = plot_page_origin.x;
+                var top = panel_page_origin.y + this.parent.panels[this.parent.panel_ids_by_y_index[panel_idx]].layout.height - 2;
+                var width = this.parent.layout.width - 1;
+                selector.style({
+                    top: top + "px",
+                    left: left + "px",
+                    width: width + "px"
+                });
+            }.bind(this));
+        },
+        hide: function(){
+            // Remove panel boundaries
+            this.selectors.forEach(function(selector){
+                selector.remove();
+            });
+            this.selectors = [];
+            this.showing = false;
+        }
+    };
+
+    // Show panel boundaries stipulated by the layout (basic toggle, only show on mouse over plot)
+    if (this.layout.panel_boundaries){
+        d3.select(this.svg.node().parentNode).on("mouseover." + this.id + ".panel_boundaries", function(){
+            clearTimeout(this.panel_boundaries.hide_timeout);
+            this.panel_boundaries.show();
+        }.bind(this));
+        d3.select(this.svg.node().parentNode).on("mouseout." + this.id + ".panel_boundaries", function(){
+            this.panel_boundaries.hide_timeout = setTimeout(function(){
+                this.panel_boundaries.hide();
+            }.bind(this), 300);
+        }.bind(this));
+    }
 
     // Create the controls object with show/update/hide methods
     var css_string = "";

--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -308,7 +308,7 @@ LocusZoom.StandardLayout = {
     aspect_ratio: (16/9),
     panels: {
         positions: {
-            title: "Lorem Ispum",
+            title: "Analysis ID: 3",
             description: "<b>Lorem ipsum</b> dolor sit amet, consectetur adipiscing elit.",
             width: 800,
             height: 225,

--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -321,7 +321,7 @@ LocusZoom.StandardLayout = {
             proportional_width: 1,
             proportional_height: 0.5,
             proportional_origin: { x: 0, y: 0 },
-            margin: { top: 35, right: 20, bottom: 35, left: 50 },
+            margin: { top: 35, right: 20, bottom: 40, left: 50 },
             inner_border: "rgba(210, 210, 210, 0.85)",
             axes: {
                 x: {

--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -308,6 +308,8 @@ LocusZoom.StandardLayout = {
     aspect_ratio: (16/9),
     panels: {
         positions: {
+            title: "Lorem Ispum",
+            description: "<b>Lorem ipsum</b> dolor sit amet, consectetur adipiscing elit.",
             width: 800,
             height: 225,
             origin: { x: 0, y: 0 },
@@ -316,7 +318,7 @@ LocusZoom.StandardLayout = {
             proportional_width: 1,
             proportional_height: 0.5,
             proportional_origin: { x: 0, y: 0 },
-            margin: { top: 20, right: 20, bottom: 35, left: 50 },
+            margin: { top: 35, right: 20, bottom: 35, left: 50 },
             inner_border: "rgba(210, 210, 210, 0.85)",
             axes: {
                 x: {

--- a/assets/js/app/Panel.js
+++ b/assets/js/app/Panel.js
@@ -269,7 +269,7 @@ LocusZoom.Panel.prototype.initialize = function(){
             // Reposition buttons
             if (this.layout.controls.reposition){
                 this.controls.link_selectors.reposition_up = this.controls.selector.append("a")
-                    .attr("class", "lz-controls-button-disabled")
+                    .attr("class", "lz-panel-controls-button-disabled")
                     .attr("title", "Move panel up")
                     .style({ "font-weight": "bold" })
                     .text("▴")
@@ -282,7 +282,7 @@ LocusZoom.Panel.prototype.initialize = function(){
                         }
                     }.bind(this));
                 this.controls.link_selectors.reposition_down = this.controls.selector.append("a")
-                    .attr("class", "lz-controls-button-disabled")
+                    .attr("class", "lz-panel-controls-button-disabled")
                     .attr("title", "Move panel down")
                     .style({ "font-weight": "bold" })
                     .text("▾")
@@ -298,7 +298,7 @@ LocusZoom.Panel.prototype.initialize = function(){
             // Description button
             if (this.layout.controls.description && this.layout.description){
                 this.controls.link_selectors.description = this.controls.selector.append("a")
-                    .attr("class", "lz-controls-button")
+                    .attr("class", "lz-panel-controls-button")
                     .attr("title", "View panel information")
                     .style({ "font-weight": "bold" })
                     .text("?")
@@ -314,7 +314,7 @@ LocusZoom.Panel.prototype.initialize = function(){
                     is_showing: false,
                     selector: null,
                     show: function(){
-                        this.controls.link_selectors.description.attr("class", "lz-controls-button-selected");
+                        this.controls.link_selectors.description.attr("class", "lz-panel-controls-button-selected");
                         this.controls.description.selector = d3.select(this.parent.svg.node().parentNode).append("div")
                             .attr("class", "lz-panel-description")
                             .attr("id", this.getBaseId() + ".description")
@@ -331,7 +331,7 @@ LocusZoom.Panel.prototype.initialize = function(){
                         this.controls.description.selector.style({ top: top, left: left });
                     }.bind(this),
                     hide: function(){
-                        this.controls.link_selectors.description.attr("class", "lz-controls-button");
+                        this.controls.link_selectors.description.attr("class", "lz-panel-controls-button");
                         this.controls.description.selector.remove();
                         this.controls.description.is_showing = false;
                     }.bind(this)
@@ -340,7 +340,7 @@ LocusZoom.Panel.prototype.initialize = function(){
             // Remove button
             if (this.layout.controls.remove){
                 this.controls.link_selectors.remove = this.controls.selector.append("a")
-                    .attr("class", "lz-controls-button")
+                    .attr("class", "lz-panel-controls-button")
                     .attr("title", "Remove panel")
                     .style({ "font-weight": "bold" })
                     .text("×")
@@ -368,10 +368,10 @@ LocusZoom.Panel.prototype.initialize = function(){
             }
             // Apply appropriate classes to reposition buttons as needed
             if (this.controls.link_selectors.reposition_up){
-                this.controls.link_selectors.reposition_up.attr("class", (this.layout.y_index == 0) ? "lz-controls-button-disabled" : "lz-controls-button");
+                this.controls.link_selectors.reposition_up.attr("class", (this.layout.y_index == 0) ? "lz-panel-controls-button-disabled" : "lz-panel-controls-button");
             }
             if (this.controls.link_selectors.reposition_down){
-                this.controls.link_selectors.reposition_down.attr("class", (this.layout.y_index == this.parent.panel_ids_by_y_index.length - 1) ? "lz-controls-button-disabled" : "lz-controls-button");
+                this.controls.link_selectors.reposition_down.attr("class", (this.layout.y_index == this.parent.panel_ids_by_y_index.length - 1) ? "lz-panel-controls-button-disabled" : "lz-panel-controls-button");
             }
         }.bind(this),
         hide: function(){
@@ -395,7 +395,7 @@ LocusZoom.Panel.prototype.initialize = function(){
         d3.select(this.parent.svg.node().parentNode).on("mouseout." + this.getBaseId() + ".controls", function(){
             this.controls.hide_timeout = setTimeout(function(){
                 this.controls.hide();
-            }.bind(this), 100);
+            }.bind(this), 300);
         }.bind(this));
     }
 

--- a/assets/js/app/Panel.js
+++ b/assets/js/app/Panel.js
@@ -62,6 +62,8 @@ LocusZoom.Panel = function(id, layout, parent) {
 };
 
 LocusZoom.Panel.DefaultLayout = {
+    title: null,
+    description: null,
     y_index: null,
     width:  0,
     height: 0,
@@ -243,6 +245,24 @@ LocusZoom.Panel.prototype.initialize = function(){
     // If the layout defines an inner border render it before rendering axes
     if (this.layout.inner_border){
         this.inner_border = this.svg.group.append("rect");
+    }
+
+    // Add the title, if defined
+    if (this.layout.title){
+        var default_x = 10;
+        var default_y = 22;
+        if (typeof this.layout.title == "string"){
+            this.layout.title = {
+                text: this.layout.title,
+                x: default_x,
+                y: default_y
+            };
+        }
+        this.svg.group.append("text")
+            .attr("class", "lz-panel-title")
+            .attr("x", parseFloat(this.layout.title.x) || default_x)
+            .attr("y", parseFloat(this.layout.title.y) || default_y)
+            .text(this.layout.title.text);
     }
 
     // Initialize Axes

--- a/assets/js/app/Panel.js
+++ b/assets/js/app/Panel.js
@@ -266,11 +266,40 @@ LocusZoom.Panel.prototype.initialize = function(){
                 .attr("class", "lz-locuszoom-controls lz-locuszoom-panel-controls")
                 .attr("id", this.getBaseId() + ".controls")
                 .style({ position: "absolute" });
+            // Reposition buttons
+            if (this.layout.controls.reposition){
+                this.controls.link_selectors.reposition_up = this.controls.selector.append("a")
+                    .attr("class", "lz-controls-button-disabled")
+                    .attr("title", "Move panel up")
+                    .style({ "font-weight": "bold" })
+                    .text("▴")
+                    .on("click", function(){
+                        if (this.parent.panel_ids_by_y_index[this.layout.y_index - 1]){
+                            this.parent.panel_ids_by_y_index[this.layout.y_index] = this.parent.panel_ids_by_y_index[this.layout.y_index - 1];
+                            this.parent.panel_ids_by_y_index[this.layout.y_index - 1] = this.id;
+                            this.parent.applyPanelYIndexesToPanelLayouts();
+                            this.parent.positionPanels();
+                        }
+                    }.bind(this));
+                this.controls.link_selectors.reposition_down = this.controls.selector.append("a")
+                    .attr("class", "lz-controls-button-disabled")
+                    .attr("title", "Move panel down")
+                    .style({ "font-weight": "bold" })
+                    .text("▾")
+                    .on("click", function(){
+                        if (this.parent.panel_ids_by_y_index[this.layout.y_index + 1]){
+                            this.parent.panel_ids_by_y_index[this.layout.y_index] = this.parent.panel_ids_by_y_index[this.layout.y_index + 1];
+                            this.parent.panel_ids_by_y_index[this.layout.y_index + 1] = this.id;
+                            this.parent.applyPanelYIndexesToPanelLayouts();
+                            this.parent.positionPanels();
+                        }
+                    }.bind(this));
+            }
             // Description button
             if (this.layout.controls.description && this.layout.description){
                 this.controls.link_selectors.description = this.controls.selector.append("a")
                     .attr("class", "lz-controls-button")
-                    .attr("title", "Panel information")
+                    .attr("title", "View panel information")
                     .style({ "font-weight": "bold" })
                     .text("?")
                     .on("click", function(){
@@ -333,6 +362,17 @@ LocusZoom.Panel.prototype.initialize = function(){
             var top = page_origin.y.toString() + "px";
             var left = (page_origin.x + this.layout.width - client_rect.width).toString() + "px";
             this.controls.selector.style({ position: "absolute", top: top, left: left });
+            // Position description box if it's showing
+            if (this.controls.description && this.controls.description.is_showing){
+                this.controls.description.position();
+            }
+            // Apply appropriate classes to reposition buttons as needed
+            if (this.controls.link_selectors.reposition_up){
+                this.controls.link_selectors.reposition_up.attr("class", (this.layout.y_index == 0) ? "lz-controls-button-disabled" : "lz-controls-button");
+            }
+            if (this.controls.link_selectors.reposition_down){
+                this.controls.link_selectors.reposition_down.attr("class", (this.layout.y_index == this.parent.panel_ids_by_y_index.length - 1) ? "lz-controls-button-disabled" : "lz-controls-button");
+            }
         }.bind(this),
         hide: function(){
             if (!this.layout.controls || !this.controls.selector){ return; }

--- a/assets/js/app/Panel.js
+++ b/assets/js/app/Panel.js
@@ -334,7 +334,7 @@ LocusZoom.Panel.prototype.initialize = function(){
                         this.controls.link_selectors.description.attr("class", "lz-controls-button");
                         this.controls.description.selector.remove();
                         this.controls.description.is_showing = false;
-                    }.bind(this),
+                    }.bind(this)
                 };
             }
             // Remove button
@@ -378,6 +378,8 @@ LocusZoom.Panel.prototype.initialize = function(){
             if (!this.layout.controls || !this.controls.selector){ return; }
             // Do not hide if this panel is showing a description
             if (this.controls.description && this.controls.description.is_showing){ return; }
+            // Do not hide if actively in an instance-level drag event
+            if (this.parent.ui.dragging || this.parent.panel_boundaries.dragging){ return; }
             this.controls.selector.remove();
             this.controls.selector = null;
         }.bind(this)

--- a/assets/js/app/Panel.js
+++ b/assets/js/app/Panel.js
@@ -259,6 +259,7 @@ LocusZoom.Panel.prototype.initialize = function(){
     this.controls = {
         selector: null,
         hide_timeout: null,
+        link_selectors: {},
         show: function(){
             if (!this.layout.controls || this.controls.selector){ return; }
             this.controls.selector = d3.select(this.parent.svg.node().parentNode).append("div")
@@ -266,16 +267,50 @@ LocusZoom.Panel.prototype.initialize = function(){
                 .attr("id", this.getBaseId() + ".controls")
                 .style({ position: "absolute" });
             // Description button
-            if (this.layout.controls.description){
-                this.controls.selector.append("a")
+            if (this.layout.controls.description && this.layout.description){
+                this.controls.link_selectors.description = this.controls.selector.append("a")
                     .attr("class", "lz-controls-button")
                     .attr("title", "Panel information")
                     .style({ "font-weight": "bold" })
-                    .text("?");
+                    .text("?")
+                    .on("click", function(){
+                        if (this.controls.description.is_showing){
+                            this.controls.description.hide();
+                        } else {
+                            this.controls.description.show();
+                            this.controls.description.position();
+                        }
+                    }.bind(this));
+                this.controls.description = {
+                    is_showing: false,
+                    selector: null,
+                    show: function(){
+                        this.controls.link_selectors.description.attr("class", "lz-controls-button-selected");
+                        this.controls.description.selector = d3.select(this.parent.svg.node().parentNode).append("div")
+                            .attr("class", "lz-panel-description")
+                            .attr("id", this.getBaseId() + ".description")
+                            .html(this.layout.description);
+                        this.controls.description.is_showing = true;
+                    }.bind(this),
+                    position: function(){
+                        var padding = 4; // is there a better place to store this?
+                        var page_origin = this.getPageOrigin();
+                        var controls_client_rect = this.controls.selector.node().getBoundingClientRect();
+                        var desc_client_rect = this.controls.description.selector.node().getBoundingClientRect();
+                        var top = (page_origin.y + controls_client_rect.height + padding).toString() + "px";
+                        var left = Math.max(page_origin.x + this.layout.width - desc_client_rect.width - padding, page_origin.x + padding).toString() + "px";
+                        this.controls.description.selector.style({ top: top, left: left });
+                    }.bind(this),
+                    hide: function(){
+                        this.controls.link_selectors.description.attr("class", "lz-controls-button");
+                        this.controls.description.selector.remove();
+                        this.controls.description.is_showing = false;
+                    }.bind(this),
+                };
             }
             // Remove button
             if (this.layout.controls.remove){
-                this.controls.selector.append("a")
+                this.controls.link_selectors.remove = this.controls.selector.append("a")
                     .attr("class", "lz-controls-button")
                     .attr("title", "Remove panel")
                     .style({ "font-weight": "bold" })
@@ -292,6 +327,8 @@ LocusZoom.Panel.prototype.initialize = function(){
         }.bind(this),
         hide: function(){
             if (!this.layout.controls || !this.controls.selector){ return; }
+            // Do not hide if this panel is showing a description
+            if (this.controls.description && this.controls.description.is_showing){ return; }
             this.controls.selector.remove();
             this.controls.selector = null;
         }.bind(this)

--- a/assets/js/app/Panel.js
+++ b/assets/js/app/Panel.js
@@ -86,7 +86,7 @@ LocusZoom.Panel.DefaultLayout = {
     margin: { top: 0, right: 0, bottom: 0, left: 0 },
     controls: {
         description: true,
-        y_index: true,
+        reposition: true,
         remove: true
     },
     cliparea: {
@@ -265,6 +265,15 @@ LocusZoom.Panel.prototype.initialize = function(){
                 .attr("class", "lz-locuszoom-controls lz-locuszoom-panel-controls")
                 .attr("id", this.getBaseId() + ".controls")
                 .style({ position: "absolute" });
+            // Description button
+            if (this.layout.controls.description){
+                this.controls.selector.append("a")
+                    .attr("class", "lz-controls-button")
+                    .attr("title", "Panel information")
+                    .style({ "font-weight": "bold" })
+                    .text("?");
+            }
+            // Remove button
             if (this.layout.controls.remove){
                 this.controls.selector.append("a")
                     .attr("class", "lz-controls-button")

--- a/assets/js/app/Panel.js
+++ b/assets/js/app/Panel.js
@@ -315,7 +315,16 @@ LocusZoom.Panel.prototype.initialize = function(){
                     .attr("title", "Remove panel")
                     .style({ "font-weight": "bold" })
                     .text("×")
-                    .on("click", function(){ this.parent.removePanel(this.id) }.bind(this));
+                    .on("click", function(){
+                        // Hide description and controls
+                        if (this.controls.description && this.controls.description.is_showing){ this.controls.description.hide(); }
+                        this.controls.hide();
+                        // Remove mouse event listeners for these controls
+                        d3.select(this.parent.svg.node().parentNode).on("mouseover." + this.getBaseId() + ".controls", null);
+                        d3.select(this.parent.svg.node().parentNode).on("mouseout." + this.getBaseId() + ".controls", null);
+                        // Remove the panel
+                        this.parent.removePanel(this.id);
+                    }.bind(this));
             }
         }.bind(this),
         position: function(){

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -322,6 +322,8 @@ LocusZoom.StandardLayout = {
     aspect_ratio: (16/9),
     panels: {
         positions: {
+            title: "Lorem Ispum",
+            description: "<b>Lorem ipsum</b> dolor sit amet, consectetur adipiscing elit.",
             width: 800,
             height: 225,
             origin: { x: 0, y: 0 },
@@ -330,7 +332,7 @@ LocusZoom.StandardLayout = {
             proportional_width: 1,
             proportional_height: 0.5,
             proportional_origin: { x: 0, y: 0 },
-            margin: { top: 20, right: 20, bottom: 35, left: 50 },
+            margin: { top: 35, right: 20, bottom: 35, left: 50 },
             inner_border: "rgba(210, 210, 210, 0.85)",
             axes: {
                 x: {
@@ -1494,6 +1496,8 @@ LocusZoom.Panel = function(id, layout, parent) {
 };
 
 LocusZoom.Panel.DefaultLayout = {
+    title: null,
+    description: null,
     y_index: null,
     width:  0,
     height: 0,
@@ -1675,6 +1679,24 @@ LocusZoom.Panel.prototype.initialize = function(){
     // If the layout defines an inner border render it before rendering axes
     if (this.layout.inner_border){
         this.inner_border = this.svg.group.append("rect");
+    }
+
+    // Add the title, if defined
+    if (this.layout.title){
+        var default_x = 10;
+        var default_y = 22;
+        if (typeof this.layout.title == "string"){
+            this.layout.title = {
+                text: this.layout.title,
+                x: default_x,
+                y: default_y
+            };
+        }
+        this.svg.group.append("text")
+            .attr("class", "lz-panel-title")
+            .attr("x", parseFloat(this.layout.title.x) || default_x)
+            .attr("y", parseFloat(this.layout.title.y) || default_y)
+            .text(this.layout.title.text);
     }
 
     // Initialize Axes

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -1262,7 +1262,7 @@ LocusZoom.Instance.prototype.initialize = function(){
         show: function(){
             if (!this.showing){
                 this.div = d3.select(this.parent.svg.node().parentNode).append("div")
-                    .attr("class", "lz-locuszoom-controls").attr("id", this.id + ".controls");
+                    .attr("class", "lz-locuszoom-controls").attr("id", this.parent.id + ".controls");
                 this.links = this.div.append("div")
                     .attr("id", this.parent.id + ".controls.links")
                     .style("float", "left");
@@ -1769,7 +1769,16 @@ LocusZoom.Panel.prototype.initialize = function(){
                     .attr("title", "Remove panel")
                     .style({ "font-weight": "bold" })
                     .text("×")
-                    .on("click", function(){ this.parent.removePanel(this.id) }.bind(this));
+                    .on("click", function(){
+                        // Hide description and controls
+                        if (this.controls.description && this.controls.description.is_showing){ this.controls.description.hide(); }
+                        this.controls.hide();
+                        // Remove mouse event listeners for these controls
+                        d3.select(this.parent.svg.node().parentNode).on("mouseover." + this.getBaseId() + ".controls", null);
+                        d3.select(this.parent.svg.node().parentNode).on("mouseout." + this.getBaseId() + ".controls", null);
+                        // Remove the panel
+                        this.parent.removePanel(this.id);
+                    }.bind(this));
             }
         }.bind(this),
         position: function(){

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -322,7 +322,7 @@ LocusZoom.StandardLayout = {
     aspect_ratio: (16/9),
     panels: {
         positions: {
-            title: "Lorem Ispum",
+            title: "Analysis ID: 3",
             description: "<b>Lorem ipsum</b> dolor sit amet, consectetur adipiscing elit.",
             width: 800,
             height: 225,
@@ -1538,7 +1538,7 @@ LocusZoom.Panel.DefaultLayout = {
     margin: { top: 0, right: 0, bottom: 0, left: 0 },
     controls: {
         description: true,
-        y_index: true,
+        reposition: true,
         remove: true
     },
     cliparea: {
@@ -1717,6 +1717,15 @@ LocusZoom.Panel.prototype.initialize = function(){
                 .attr("class", "lz-locuszoom-controls lz-locuszoom-panel-controls")
                 .attr("id", this.getBaseId() + ".controls")
                 .style({ position: "absolute" });
+            // Description button
+            if (this.layout.controls.description){
+                this.controls.selector.append("a")
+                    .attr("class", "lz-controls-button")
+                    .attr("title", "Panel information")
+                    .style({ "font-weight": "bold" })
+                    .text("?");
+            }
+            // Remove button
             if (this.layout.controls.remove){
                 this.controls.selector.append("a")
                     .attr("class", "lz-controls-button")

--- a/locuszoom.css
+++ b/locuszoom.css
@@ -216,6 +216,15 @@ div.lz-data_layer-tooltip-arrow_bottom_right {
     cursor: pointer;
     background-color: #333333;
     color: #D8D8D8; }
+  .lz-locuszoom-controls .lz-controls-button-selected {
+    text-decoration: none;
+    padding: 0.2em 0.5em 0.2em 0.5em;
+    border: 1px solid #333333;
+    border-radius: 4px;
+    pointer-events: auto;
+    cursor: pointer;
+    background-color: #333333;
+    color: #D8D8D8; }
   .lz-locuszoom-controls .lz-controls-button-disabled {
     text-decoration: none;
     padding: 0.2em 0.5em 0.2em 0.5em;
@@ -231,3 +240,13 @@ div.lz-data_layer-tooltip-arrow_bottom_right {
 .lz-locuszoom-panel-controls {
   padding-top: 4px;
   padding-right: 4px; }
+
+div.lz-panel-description {
+  font-family: "Helvetica Neue", Helvetica, Aria, sans-serif;
+  font-size: 12px;
+  position: absolute;
+  padding: 6px;
+  background: #e4ebf0;
+  border: 1px solid rgba(24, 24, 24, 1);
+  border-radius: 4px;
+  box-shadow: 2px 2px 2px rgba(24, 24, 24, 0.4); }

--- a/locuszoom.css
+++ b/locuszoom.css
@@ -55,6 +55,9 @@ svg.lz-locuszoom {
     stroke-width: 2;
     cursor: nwse-resize;
     stroke-linejoin: round; }
+  svg.lz-locuszoom .lz-panel-title {
+    font-size: 18px;
+    font-weight: 600; }
   svg.lz-locuszoom .lz-axis path,
   svg.lz-locuszoom .lz-axis line {
     fill: none;

--- a/locuszoom.css
+++ b/locuszoom.css
@@ -227,3 +227,7 @@ div.lz-data_layer-tooltip-arrow_bottom_right {
   .lz-locuszoom-controls .lz-controls-button-disabled:hover {
     cursor: wait;
     background-color: #D8D8D8; }
+
+.lz-locuszoom-panel-controls {
+  padding-top: 4px;
+  padding-right: 4px; }

--- a/locuszoom.css
+++ b/locuszoom.css
@@ -34,9 +34,9 @@ svg.lz-locuszoom {
     border-radius: 3px; }
   svg.lz-locuszoom .lz-ui-resize_handle {
     fill: #d2d2d2;
-    fill-opacity: 0.85;
+    fill-opacity: 0.4;
     stroke: #2d2d2d;
-    stroke-opacity: 0.85;
+    stroke-opacity: 0.4;
     stroke-width: 1;
     cursor: nwse-resize;
     stroke-linejoin: round; }
@@ -240,6 +240,37 @@ div.lz-data_layer-tooltip-arrow_bottom_right {
 .lz-locuszoom-panel-controls {
   padding-top: 6px;
   padding-right: 2px; }
+  .lz-locuszoom-panel-controls .lz-panel-controls-button {
+    text-decoration: none;
+    padding: 0.2em 0.5em 0.2em 0.5em;
+    background-color: rgba(216, 216, 216, 0.4);
+    border: 1px solid rgba(51, 51, 51, 0.4);
+    color: rgba(51, 51, 51, 0.4);
+    border-radius: 4px;
+    pointer-events: auto; }
+  .lz-locuszoom-panel-controls .lz-panel-controls-button:hover {
+    cursor: pointer;
+    background-color: #d8d8d8;
+    border: 1px solid #333333;
+    color: #333333; }
+  .lz-locuszoom-panel-controls .lz-panel-controls-button-selected {
+    text-decoration: none;
+    padding: 0.2em 0.5em 0.2em 0.5em;
+    border: 1px solid #333333;
+    border-radius: 4px;
+    pointer-events: auto;
+    cursor: pointer;
+    background-color: #333333;
+    color: #d8d8d8; }
+  .lz-locuszoom-panel-controls .lz-panel-controls-button-disabled {
+    text-decoration: none;
+    padding: 0.2em 0.5em 0.2em 0.5em;
+    background-color: rgba(216, 216, 216, 0.4);
+    border: 1px solid rgba(153, 153, 153, 0.4);
+    color: rgba(153, 153, 153, 0.4);
+    border-radius: 4px;
+    pointer-events: none;
+    cursor: wait; }
 
 div.lz-panel-description {
   font-family: "Helvetica Neue", Helvetica, Aria, sans-serif;

--- a/locuszoom.css
+++ b/locuszoom.css
@@ -238,8 +238,8 @@ div.lz-data_layer-tooltip-arrow_bottom_right {
     background-color: #D8D8D8; }
 
 .lz-locuszoom-panel-controls {
-  padding-top: 4px;
-  padding-right: 4px; }
+  padding-top: 6px;
+  padding-right: 2px; }
 
 div.lz-panel-description {
   font-family: "Helvetica Neue", Helvetica, Aria, sans-serif;
@@ -250,3 +250,28 @@ div.lz-panel-description {
   border: 1px solid rgba(24, 24, 24, 1);
   border-radius: 4px;
   box-shadow: 2px 2px 2px rgba(24, 24, 24, 0.4); }
+
+div.lz-panel-boundary {
+  position: absolute;
+  height: 4px;
+  width: 200px;
+  border-radius: 2px;
+  background: rgba(235, 240, 228, 0.5);
+  border: 1px solid rgba(24, 24, 24, 0.4); }
+
+div.lz-panel-boundary {
+  position: absolute;
+  height: 3px;
+  width: 200px;
+  border-radius: 1px;
+  background: rgba(216, 216, 216, 0.4);
+  border: 1px solid rgba(24, 24, 24, 0.4);
+  cursor: row-resize; }
+
+div.lz-panel-boundary:hover {
+  background: #d8d8d8;
+  border: 1px solid rgba(24, 24, 24, 1); }
+
+div.lz-panel-boundary:active {
+  background: #333333;
+  border: 1px solid #d8d8d8; }

--- a/plot_builder.html
+++ b/plot_builder.html
@@ -120,10 +120,12 @@
                       ];
       data_sources.add(ns, assoc_source).add(ns + "_ld", ld_source);
       var layout = {
+          title: ns,
+          description: ns,
           y_index: -1,
           min_width:  400,
           min_height: 112.5,
-          margin: { top: 20, right: 20, bottom: 35, left: 50 },
+          margin: { top: 35, right: 20, bottom: 35, left: 50 },
           inner_border: "rgba(210, 210, 210, 0.85)",
           axes: {
               x: {

--- a/plot_builder.html
+++ b/plot_builder.html
@@ -74,7 +74,6 @@
 
     <div class="row" id="panels">
       <button onclick="addAnalysis();">Add Analysis</button>
-      <button id="remove_positions" onclick="plot.removePanel('positions'); $('#remove_positions').remove();">Remove positions</button>
     </div>
 
   </div>
@@ -200,7 +199,6 @@
           }
       };
       plot.addPanel(ns, layout);
-      $("#panels").append("<button id=\"remove_" + ns + "\" onclick=\"plot.removePanel('" + ns + "'); $('#remove_" + ns + "').remove();\">Remove " + ns + "</button>");
     }
 
     var plot;

--- a/plot_builder.html
+++ b/plot_builder.html
@@ -100,11 +100,11 @@
 
     function addAnalysis(){
       var ns = "a" + Math.floor(Math.random()*Math.pow(10,8));
-      var shape = ["circle", "cross", "diamond", "square", "triangle-down", "triangle-up"][Math.floor(Math.random()*6)];
+      var analysis = [23, 24, 25][Math.floor(Math.random()*3)];
       var assoc_source = [ "AssociationLZ",
                            { url: apiBase + "single/",
                              params: {
-                               analysis: 3
+                               analysis: analysis
                              }
                            }
                          ];
@@ -119,7 +119,7 @@
                       ];
       data_sources.add(ns, assoc_source).add(ns + "_ld", ld_source);
       var layout = {
-          title: ns,
+          title: "Analysis ID: " + analysis,
           description: ns,
           y_index: -1,
           min_width:  400,
@@ -160,7 +160,7 @@
               },
               positions: {
                   type: "scatter",
-                  point_shape: shape,
+                  point_shape: "circle",
                   point_size: 40,
                   fields: [ns+":id",
                            ns+":position",


### PR DESCRIPTION
# Overview

This branch expands panel-level user interface to include the following:

* The ability to define a panel title that appears in the top left corner of a panel
* A "panel controls" element that appears in the top right corner of a panel, including the following items:
  * A button to remove the panel
  * A button to display a panel description that can also be defined in the layout with arbitrary HTML
  * Buttons to move the panel up or down in terms of its y-index relative to adjacent panels
* All three panel control buttons are configurable in the layout, allowing for any combination of the three to be shown on a per-panel basis (default is to show all)
* Panel boundaries - draggable elements between panels that allow for adjusting the heights of panels one at a time

## Notes on the standard layout

Note that for the standard layout there is some dummy data in there for panel titles and descriptions that we'll likely want to remove or replace in consideration with how the Broad will consume the standard layout. Personally I think that such information is *very* implementation-specific and thus doesn't really belong in the standard layout at all.

Next week when we're working with Broad devs we can look at pulling things out of the standard layout into a Broad portal custom layout defined in their environment, or possibly look at spinning off a new layout (`BroadPortalLayout`?) that can live in the core library for now and allow the standard layout to be a bit more general.

## Feedback / Release outlook

While code review is always in season this branch is heavily about integration--how the final product feels to use. Is the new UI introduced on the branch intuitive? Clean? Is it obvious how it's supposed to work, and does it actually work that way? Where does it feel a bit clunky, or a bit loose?

It will be a subjective call as to when this branch is ready for master as the last 5% of any tight and snappy UI is a long tail that isn't necessarily in scope of this branch. It would be good to get this rolled into new release (0.3.9) by EOD Monday, May 23 in advance of the next integration session with LocusZoom's current primary consumer.