### PR TITLE
Annotation Tacks Data Source and Caching

### DIFF
--- a/assets/js/app/Data.js
+++ b/assets/js/app/Data.js
@@ -305,6 +305,22 @@ LocusZoom.Data.RecombinationRateSource.prototype.getURL = function(state, chain,
 };
 
 /**
+  Known Data Source for Annotation Track (BED Track) Data
+*/
+
+LocusZoom.Data.BEDTrackSource = LocusZoom.Data.Source.extend(function(init) {
+    this.parseInit(init);
+}, "BEDLZ");
+
+LocusZoom.Data.BEDTrackSource.prototype.getURL = function(state, chain, fields) {
+    var source = state.bedtracksource || chain.header.bedtracksource || this.params.source || 16;
+    return this.url + "?filter=id in " + source + 
+        " and chromosome eq '" + state.chr + "'" + 
+        " and start le " + state.end +
+        " and end ge " + state.start;
+};
+
+/**
   Known Data Source for Static JSON Data
 */
 LocusZoom.Data.StaticSource = LocusZoom.Data.Source.extend(function(data) {

--- a/assets/js/app/Data.js
+++ b/assets/js/app/Data.js
@@ -65,22 +65,28 @@ LocusZoom.Data.Source.prototype.parseInit = function(init) {
     }
 
 };
+
+LocusZoom.Data.Source.prototype.getPossiblyCachedRequest = function(url) {
+    if (url == this._lastURL && this._cachedResponse) {
+        return Q.when(this._cachedResponse);
+    } else {
+        return this.getUnCachedRequest(url).then(function(x) {
+            this._lastURL = url;
+            return this._cachedResponse = x;
+        }.bind(this));
+    }
+};
+
+LocusZoom.Data.Source.prototype.getUnCachedRequest = function(url) {
+    return LocusZoom.createCORSPromise("GET", url); 
+};
+
 LocusZoom.Data.Source.prototype.getRequest = function(state, chain, fields) {
-    var getPromise = function(url) {
-        return LocusZoom.createCORSPromise("GET", url); 
-    };
     var url = this.getURL(state, chain, fields);
     if (this.cacheURLResponse) {
-        if (url == this._lastURL && this._cachedResponse) {
-            return Q.when(this._cachedResponse);
-        } else {
-            return getPromise(url).then(function(x) {
-                this._lastURL = url;
-                return this._cachedResponse = x;
-            }.bind(this));
-        }
+        return this.getPossiblyCachedRequest(url);
     }
-    return getPromise(url);
+    return this.getUnCachedRequest(url);
 };
 
 LocusZoom.Data.Source.prototype.getData = function(state, fields, outnames, trans) {

--- a/assets/js/app/Data.js
+++ b/assets/js/app/Data.js
@@ -66,7 +66,21 @@ LocusZoom.Data.Source.prototype.parseInit = function(init) {
 
 };
 LocusZoom.Data.Source.prototype.getRequest = function(state, chain, fields) {
-    return LocusZoom.createCORSPromise("GET", this.getURL(state, chain, fields));
+    var getPromise = function(url) {
+        return LocusZoom.createCORSPromise("GET", url); 
+    };
+    var url = this.getURL(state, chain, fields);
+    if (this.cacheURLResponse) {
+        if (url == this._lastURL && this._cachedResponse) {
+            return Q.when(this._cachedResponse);
+        } else {
+            return getPromise(url).then(function(x) {
+                this._lastURL = url;
+                return this._cachedResponse = x;
+            }.bind(this));
+        }
+    }
+    return getPromise(url);
 };
 
 LocusZoom.Data.Source.prototype.getData = function(state, fields, outnames, trans) {
@@ -173,6 +187,7 @@ LocusZoom.Data.Source.prototype.toJSON = function() {
 */
 LocusZoom.Data.AssociationSource = LocusZoom.Data.Source.extend(function(init) {
     this.parseInit(init);
+    this.cacheURLResponse = true;
 }, "AssociationLZ");
 
 LocusZoom.Data.AssociationSource.prototype.preGetData = function(state, fields, outnames, trans) {
@@ -199,6 +214,7 @@ LocusZoom.Data.AssociationSource.prototype.getURL = function(state, chain, field
 */
 LocusZoom.Data.LDSource = LocusZoom.Data.Source.extend(function(init) {
     this.parseInit(init);
+    this.cacheURLResponse = true;
     if (!this.params.id_field) {
         this.params.id_field = "id";
     }
@@ -276,6 +292,7 @@ LocusZoom.Data.LDSource.prototype.parseResponse = function(resp, chain, fields, 
 */
 LocusZoom.Data.GeneSource = LocusZoom.Data.Source.extend(function(init) {
     this.parseInit(init);
+    this.cacheURLResponse = true;
 }, "GeneLZ");
 
 LocusZoom.Data.GeneSource.prototype.getURL = function(state, chain, fields) {
@@ -294,6 +311,7 @@ LocusZoom.Data.GeneSource.prototype.parseResponse = function(resp, chain, fields
 */
 LocusZoom.Data.RecombinationRateSource = LocusZoom.Data.Source.extend(function(init) {
     this.parseInit(init);
+    this.cacheURLResponse = true;
 }, "RecombLZ");
 
 LocusZoom.Data.RecombinationRateSource.prototype.getURL = function(state, chain, fields) {
@@ -310,6 +328,7 @@ LocusZoom.Data.RecombinationRateSource.prototype.getURL = function(state, chain,
 
 LocusZoom.Data.BEDTrackSource = LocusZoom.Data.Source.extend(function(init) {
     this.parseInit(init);
+    this.cacheURLResponse = true;
 }, "BEDLZ");
 
 LocusZoom.Data.BEDTrackSource.prototype.getURL = function(state, chain, fields) {

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -739,6 +739,22 @@ LocusZoom.Data.RecombinationRateSource.prototype.getURL = function(state, chain,
 };
 
 /**
+  Known Data Source for Annotation Track (BED Track) Data
+*/
+
+LocusZoom.Data.BEDTrackSource = LocusZoom.Data.Source.extend(function(init) {
+    this.parseInit(init);
+}, "BEDLZ");
+
+LocusZoom.Data.BEDTrackSource.prototype.getURL = function(state, chain, fields) {
+    var source = state.bedtracksource || chain.header.bedtracksource || this.params.source || 16;
+    return this.url + "?filter=id in " + source + 
+        " and chromosome eq '" + state.chr + "'" + 
+        " and start le " + state.end +
+        " and end ge " + state.start;
+};
+
+/**
   Known Data Source for Static JSON Data
 */
 LocusZoom.Data.StaticSource = LocusZoom.Data.Source.extend(function(data) {

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -499,22 +499,28 @@ LocusZoom.Data.Source.prototype.parseInit = function(init) {
     }
 
 };
+
+LocusZoom.Data.Source.prototype.getPossiblyCachedRequest = function(url) {
+    if (url == this._lastURL && this._cachedResponse) {
+        return Q.when(this._cachedResponse);
+    } else {
+        return this.getUnCachedRequest(url).then(function(x) {
+            this._lastURL = url;
+            return this._cachedResponse = x;
+        }.bind(this));
+    }
+};
+
+LocusZoom.Data.Source.prototype.getUnCachedRequest = function(url) {
+    return LocusZoom.createCORSPromise("GET", url); 
+};
+
 LocusZoom.Data.Source.prototype.getRequest = function(state, chain, fields) {
-    var getPromise = function(url) {
-        return LocusZoom.createCORSPromise("GET", url); 
-    };
     var url = this.getURL(state, chain, fields);
     if (this.cacheURLResponse) {
-        if (url == this._lastURL && this._cachedResponse) {
-            return Q.when(this._cachedResponse);
-        } else {
-            return getPromise(url).then(function(x) {
-                this._lastURL = url;
-                return this._cachedResponse = x;
-            }.bind(this));
-        }
+        return this.getPossiblyCachedRequest(url);
     }
-    return getPromise(url);
+    return this.getUnCachedRequest(url);
 };
 
 LocusZoom.Data.Source.prototype.getData = function(state, fields, outnames, trans) {

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -500,7 +500,21 @@ LocusZoom.Data.Source.prototype.parseInit = function(init) {
 
 };
 LocusZoom.Data.Source.prototype.getRequest = function(state, chain, fields) {
-    return LocusZoom.createCORSPromise("GET", this.getURL(state, chain, fields));
+    var getPromise = function(url) {
+        return LocusZoom.createCORSPromise("GET", url); 
+    };
+    var url = this.getURL(state, chain, fields);
+    if (this.cacheURLResponse) {
+        if (url == this._lastURL && this._cachedResponse) {
+            return Q.when(this._cachedResponse);
+        } else {
+            return getPromise(url).then(function(x) {
+                this._lastURL = url;
+                return this._cachedResponse = x;
+            }.bind(this));
+        }
+    }
+    return getPromise(url);
 };
 
 LocusZoom.Data.Source.prototype.getData = function(state, fields, outnames, trans) {
@@ -607,6 +621,7 @@ LocusZoom.Data.Source.prototype.toJSON = function() {
 */
 LocusZoom.Data.AssociationSource = LocusZoom.Data.Source.extend(function(init) {
     this.parseInit(init);
+    this.cacheURLResponse = true;
 }, "AssociationLZ");
 
 LocusZoom.Data.AssociationSource.prototype.preGetData = function(state, fields, outnames, trans) {
@@ -633,6 +648,7 @@ LocusZoom.Data.AssociationSource.prototype.getURL = function(state, chain, field
 */
 LocusZoom.Data.LDSource = LocusZoom.Data.Source.extend(function(init) {
     this.parseInit(init);
+    this.cacheURLResponse = true;
     if (!this.params.id_field) {
         this.params.id_field = "id";
     }
@@ -710,6 +726,7 @@ LocusZoom.Data.LDSource.prototype.parseResponse = function(resp, chain, fields, 
 */
 LocusZoom.Data.GeneSource = LocusZoom.Data.Source.extend(function(init) {
     this.parseInit(init);
+    this.cacheURLResponse = true;
 }, "GeneLZ");
 
 LocusZoom.Data.GeneSource.prototype.getURL = function(state, chain, fields) {
@@ -728,6 +745,7 @@ LocusZoom.Data.GeneSource.prototype.parseResponse = function(resp, chain, fields
 */
 LocusZoom.Data.RecombinationRateSource = LocusZoom.Data.Source.extend(function(init) {
     this.parseInit(init);
+    this.cacheURLResponse = true;
 }, "RecombLZ");
 
 LocusZoom.Data.RecombinationRateSource.prototype.getURL = function(state, chain, fields) {
@@ -744,6 +762,7 @@ LocusZoom.Data.RecombinationRateSource.prototype.getURL = function(state, chain,
 
 LocusZoom.Data.BEDTrackSource = LocusZoom.Data.Source.extend(function(init) {
     this.parseInit(init);
+    this.cacheURLResponse = true;
 }, "BEDLZ");
 
 LocusZoom.Data.BEDTrackSource.prototype.getURL = function(state, chain, fields) {

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -485,7 +485,10 @@ LocusZoom.Data.Requester = function(sources) {
   Base Data Source Class
   This can be extended with .extend() to create custom data sources
 */
-LocusZoom.Data.Source = function() {};
+LocusZoom.Data.Source = function() {
+    this.enableCache = true;
+};
+
 LocusZoom.Data.Source.prototype.parseInit = function(init) {
     if (typeof init === "string") {
         this.url = init;
@@ -500,27 +503,31 @@ LocusZoom.Data.Source.prototype.parseInit = function(init) {
 
 };
 
-LocusZoom.Data.Source.prototype.getPossiblyCachedRequest = function(url) {
-    if (url == this._lastURL && this._cachedResponse) {
-        return Q.when(this._cachedResponse);
-    } else {
-        return this.getUnCachedRequest(url).then(function(x) {
-            this._lastURL = url;
-            return this._cachedResponse = x;
-        }.bind(this));
-    }
+LocusZoom.Data.Source.prototype.getCacheKey = function(state, chain, fields) {
+    var url = this.getURL(state, chain, fields);
+    return url;
 };
 
-LocusZoom.Data.Source.prototype.getUnCachedRequest = function(url) {
+LocusZoom.Data.Source.prototype.fetchRequest = function(state, chain, fields) {
+    var url = this.getURL(state, chain, fields);
     return LocusZoom.createCORSPromise("GET", url); 
 };
 
 LocusZoom.Data.Source.prototype.getRequest = function(state, chain, fields) {
-    var url = this.getURL(state, chain, fields);
-    if (this.cacheURLResponse) {
-        return this.getPossiblyCachedRequest(url);
+    var req;
+    var cacheKey = this.getCacheKey(state, chain, fields);
+    if (this.enableCache & cacheKey == this._cachedKey) {
+        req = Q.when(this._cachedResponse);
+    } else {
+        req = this.fetchRequest(state, chain, fields);
+        if (this.enableCache) {
+            req = req.then(function(x) {
+                this._cachedKey = cacheKey;
+                return this._cachedResponse = x;
+            }.bind(this));
+        }
     }
-    return this.getUnCachedRequest(url);
+    return req;
 };
 
 LocusZoom.Data.Source.prototype.getData = function(state, fields, outnames, trans) {
@@ -608,7 +615,7 @@ LocusZoom.Data.Source.prototype.parseData = function(x, fields, outnames, trans)
 
 LocusZoom.Data.Source.extend = function(constructorFun, uniqueName) {
     constructorFun = constructorFun || function() {};
-    constructorFun.prototype = Object.create(LocusZoom.Data.Source.prototype);
+    constructorFun.prototype = new LocusZoom.Data.Source();
     constructorFun.prototype.constructor = constructorFun;
     if (uniqueName) {
         constructorFun.SOURCE_NAME = uniqueName;
@@ -627,7 +634,6 @@ LocusZoom.Data.Source.prototype.toJSON = function() {
 */
 LocusZoom.Data.AssociationSource = LocusZoom.Data.Source.extend(function(init) {
     this.parseInit(init);
-    this.cacheURLResponse = true;
 }, "AssociationLZ");
 
 LocusZoom.Data.AssociationSource.prototype.preGetData = function(state, fields, outnames, trans) {
@@ -654,7 +660,6 @@ LocusZoom.Data.AssociationSource.prototype.getURL = function(state, chain, field
 */
 LocusZoom.Data.LDSource = LocusZoom.Data.Source.extend(function(init) {
     this.parseInit(init);
-    this.cacheURLResponse = true;
     if (!this.params.id_field) {
         this.params.id_field = "id";
     }
@@ -732,7 +737,6 @@ LocusZoom.Data.LDSource.prototype.parseResponse = function(resp, chain, fields, 
 */
 LocusZoom.Data.GeneSource = LocusZoom.Data.Source.extend(function(init) {
     this.parseInit(init);
-    this.cacheURLResponse = true;
 }, "GeneLZ");
 
 LocusZoom.Data.GeneSource.prototype.getURL = function(state, chain, fields) {
@@ -751,7 +755,6 @@ LocusZoom.Data.GeneSource.prototype.parseResponse = function(resp, chain, fields
 */
 LocusZoom.Data.RecombinationRateSource = LocusZoom.Data.Source.extend(function(init) {
     this.parseInit(init);
-    this.cacheURLResponse = true;
 }, "RecombLZ");
 
 LocusZoom.Data.RecombinationRateSource.prototype.getURL = function(state, chain, fields) {
@@ -768,7 +771,6 @@ LocusZoom.Data.RecombinationRateSource.prototype.getURL = function(state, chain,
 
 LocusZoom.Data.BEDTrackSource = LocusZoom.Data.Source.extend(function(init) {
     this.parseInit(init);
-    this.cacheURLResponse = true;
 }, "BEDLZ");
 
 LocusZoom.Data.BEDTrackSource.prototype.getURL = function(state, chain, fields) {


### PR DESCRIPTION
Here are two small updates for the data sources. This first wraps the annotation tracks (or BED tracks, more generally) as an API data source end point. A simple test on the default demo page can be run with adding the data source

     data_sources.add("ann", ["BEDLZ", apiBase + "annotation/intervals/results/"])

and then requesting data

    demo_instance.lzd.
      getData(demo_instance.state, ["ann:start", "ann:end","ann:state_name"]).
      then(console.log.bind(console)).done();

The second update allows for URL level caching on data sources that they can opt into. For example, on the default page. Running

    demo_instance.refresh()

shouldn't trigger any new data requests. and running 

    demo_instance.applyState({ldrefvar:"10:114808902_G/T"})

should only trigger one call to the LD source.
