### PR TITLE
Resolve Scalable Parameters

### DIFF
--- a/assets/js/app/DataLayer.js
+++ b/assets/js/app/DataLayer.js
@@ -293,6 +293,31 @@ LocusZoom.DataLayer.DefaultLayout = {
     y_axis: {}
 };
 
+// Resolve a scalable parameter for an element into a single value based on its layout and the element's data
+LocusZoom.DataLayer.prototype.resolveScalableParameter = function(layout, data){
+    var ret = null;
+    if (Array.isArray(layout)){
+        var idx = 0;
+        while (ret == null && idx < layout.length){
+            ret = this.resolveScalableParameter(layout[idx], data);
+            idx++;
+        }
+    } else {
+        switch (typeof layout){
+        case "number":
+        case "string":
+            ret = layout;
+            break;
+        case "object":
+            if (layout.scale_function && layout.field) {
+                ret = LocusZoom.ScaleFunctions.get(layout.scale_function, layout.parameters || {}, data[layout.field]);
+            }
+            break;
+        }
+    }
+    return ret;
+};
+
 // Generate dimension extent function based on layout parameters
 LocusZoom.DataLayer.prototype.getAxisExtent = function(dimension){
 

--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -375,15 +375,34 @@ LocusZoom.StandardLayout = {
                     type: "scatter",
                     point_shape: "circle",
                     point_size: {
-                        field: "ld:state",
-                        scale_function: "numerical_bin",
+                        scale_function: "if",
+                        field: "ld:isrefvar",
                         parameters: {
-                            breaks: [0, 0.99],
-                            values: [40, 80],
-                            null_value: 40
+                            field_value: 1,
+                            then: 80,
+                            else: 40
                         }
                     },
-                    fields: ["id", "position", "pvalue|scinotation", "pvalue|neglog10", "refAllele", "ld:state"],
+                    color: [
+                        {
+                            scale_function: "if",
+                            field: "ld:isrefvar",
+                            parameters: {
+                                field_value: 1,
+                                then: "#9632b8"
+                            }
+                        },
+                        {
+                            scale_function: "numerical_bin",
+                            field: "ld:state",
+                            parameters: {
+                                breaks: [0, 0.2, 0.4, 0.6, 0.8],
+                                values: ["#357ebd","#46b8da","#5cb85c","#eea236","#d43f3a"]
+                            }
+                        },
+                        "#B8B8B8"
+                    ],
+                    fields: ["id", "position", "pvalue|scinotation", "pvalue|neglog10", "refAllele", "ld:state", "ld:isrefvar"],
                     z_index: 2,
                     x_axis: {
                         field: "position"
@@ -395,22 +414,13 @@ LocusZoom.StandardLayout = {
                         upper_buffer: 0.05,
                         min_extent: [ 0, 10 ]
                     },
-                    color: {
-                        field: "ld:state",
-                        scale_function: "numerical_bin",
-                        parameters: {
-                            breaks: [0, 0.2, 0.4, 0.6, 0.8, 0.99],
-                            values: ["#357ebd","#46b8da","#5cb85c","#eea236","#d43f3a", "#9632b8"],
-                            null_value: "#B8B8B8"
-                        }
-                    },
                     selectable: "multiple",
                     tooltip: {
                         html: "<strong>{{id}}</strong><br>"
                             + "P Value: <strong>{{pvalue|scinotation}}</strong><br>"
                             + "Ref. Allele: <strong>{{refAllele}}</strong>",
                         closable: true
-                    },
+                    }
                     /*
                     label: {
                         text: "{{id}}",

--- a/plot_builder.html
+++ b/plot_builder.html
@@ -94,7 +94,7 @@
     var apiBase = "http://portaldev.sph.umich.edu/api/v1/";
     var data_sources = new LocusZoom.DataSources()
       .add("base", ["AssociationLZ", {url:apiBase + "single/", params: { analysis: 3 }}])
-      .add("ld", ["LDLZ", "http://portaldev.sph.umich.edu/flask/v1/statistic/pair/LD/"])
+      .add("ld", ["LDLZ", apiBase + "pair/LD/"])
       .add("gene", ["GeneLZ", { url: apiBase + "annotation/genes/", params: { source: 2 } }])
       .add("recomb", ["RecombLZ", { url: apiBase + "annotation/recomb/results/", params: {source: 15} }])
       .add("sig", ["StaticJSON", [{ "x": 0, "y": 4.522 }, { "x": 2881033286, "y": 4.522 }] ]);

--- a/plot_builder.html
+++ b/plot_builder.html
@@ -154,20 +154,40 @@
                   type: "scatter",
                   point_shape: "circle",
                   point_size: {
-                      field: "ld:state",
-                      scale_function: "numerical_bin",
+                      scale_function: "if",
+                      field: "ld:isrefvar",
                       parameters: {
-                          breaks: [0, 0.99],
-                          values: [40, 80],
-                          null_value: 40
+                          field_value: 1,
+                          then: 80,
+                          else: 40
                       }
                   },
+                  color: [
+                      {
+                          scale_function: "if",
+                          field: "ld:isrefvar",
+                          parameters: {
+                              field_value: 1,
+                              then: "#9632b8"
+                          }
+                      },
+                      {
+                          scale_function: "numerical_bin",
+                          field: "ld:state",
+                          parameters: {
+                              breaks: [0, 0.2, 0.4, 0.6, 0.8],
+                              values: ["#357ebd","#46b8da","#5cb85c","#eea236","#d43f3a"]
+                          }
+                      },
+                      "#B8B8B8"
+                  ],
                   fields: [ns+":id",
                            ns+":position",
                            ns+":pvalue|scinotation",
                            ns+":pvalue|neglog10",
                            ns+":refAllele",
-                           "ld:state"],
+                           "ld:state",
+                           "ld:isrefvar"],
                   id_field: ns+":id",
                   x_axis: {
                       field: ns+":position"
@@ -179,15 +199,7 @@
                       upper_buffer: 0.05,
                       min_extent: [ 0, 10 ]
                   },
-                  color: {
-                      field: "ld:state",
-                      scale_function: "numerical_bin",
-                      parameters: {
-                          breaks: [0, 0.2, 0.4, 0.6, 0.8, 0.99],
-                          values: ["#357ebd","#46b8da","#5cb85c","#eea236","#d43f3a", "#9632b8"],
-                          null_value: "#B8B8B8"
-                      }
-                  },
+                  selectable: "multiple",
                   tooltip: {
                       html: "<div><strong>{{"+ns+":id}}</strong></div>"
                           + "<div>P Value: <strong>{{"+ns+":pvalue|scinotation}}</strong></div>"

--- a/plot_builder.html
+++ b/plot_builder.html
@@ -94,7 +94,7 @@
     var apiBase = "http://portaldev.sph.umich.edu/api/v1/";
     var data_sources = new LocusZoom.DataSources()
       .add("base", ["AssociationLZ", {url:apiBase + "single/", params: { analysis: 3 }}])
-      .add("ld", ["LDLZ" ,apiBase + "pair/LD/"])
+      .add("ld", ["LDLZ", "http://portaldev.sph.umich.edu/flask/v1/statistic/pair/LD/"])
       .add("gene", ["GeneLZ", { url: apiBase + "annotation/genes/", params: { source: 2 } }])
       .add("recomb", ["RecombLZ", { url: apiBase + "annotation/recomb/results/", params: {source: 15} }])
       .add("sig", ["StaticJSON", [{ "x": 0, "y": 4.522 }, { "x": 2881033286, "y": 4.522 }] ]);

--- a/test/DataLayer.js
+++ b/test/DataLayer.js
@@ -67,6 +67,66 @@ describe('LocusZoom.DataLayer', function(){
         });
     });
 
+    describe("Scalable parameter resolution", function() {
+        it("has a method to resolve scalable parameters into discrete values", function() {
+            this.datalayer = new LocusZoom.DataLayer("test", {});
+            this.datalayer.resolveScalableParameter.should.be.a.Function;
+        });
+        it("passes numbers and strings directly through regardless of data", function() {
+            this.datalayer = new LocusZoom.DataLayer("test", {});
+            this.layout = { scale: "foo" };
+            assert.equal(this.datalayer.resolveScalableParameter(this.layout.scale, {}), "foo");
+            assert.equal(this.datalayer.resolveScalableParameter(this.layout.scale, { foo: "bar" }), "foo");
+            this.layout = { scale: 17 };
+            assert.equal(this.datalayer.resolveScalableParameter(this.layout.scale, {}), 17);
+            assert.equal(this.datalayer.resolveScalableParameter(this.layout.scale, { foo: "bar" }), 17);
+        });
+        it("executes a scale function for the data provided", function() {
+            this.datalayer = new LocusZoom.DataLayer("test", {});
+            this.layout = {
+                scale: {
+                    scale_function: "categorical_bin",
+                    field: "test",
+                    parameters: {
+                        categories: ["lion", "tiger", "bear"],
+                        values: ["dorothy", "toto", "scarecrow"],
+                    }
+                }
+            };
+            assert.equal(this.datalayer.resolveScalableParameter(this.layout.scale, { test: "lion" }), "dorothy");
+            assert.equal(this.datalayer.resolveScalableParameter(this.layout.scale, { test: "manatee" }), null);
+            assert.equal(this.datalayer.resolveScalableParameter(this.layout.scale, {}), null);
+        });
+        it("iterates over an array of options until exhausted or a non-null value is found", function() {
+            this.datalayer = new LocusZoom.DataLayer("test", {});
+            this.layout = {
+                scale: [
+                    {
+                        scale_function: "if",
+                        field: "test",
+                        parameters: {
+                            field_value: "wizard",
+                            then: "oz"
+                        }
+                    },
+                    {
+                        scale_function: "categorical_bin",
+                        field: "test",
+                        parameters: {
+                            categories: ["lion", "tiger", "bear"],
+                            values: ["dorothy", "toto", "scarecrow"],
+                        }
+                    },
+                    "munchkin"
+                ]
+            };
+            assert.equal(this.datalayer.resolveScalableParameter(this.layout.scale, { test: "wizard" }), "oz");
+            assert.equal(this.datalayer.resolveScalableParameter(this.layout.scale, { test: "tiger" }), "toto");
+            assert.equal(this.datalayer.resolveScalableParameter(this.layout.scale, { test: "witch" }), "munchkin");
+            assert.equal(this.datalayer.resolveScalableParameter(this.layout.scale, {}), "munchkin");
+        });
+    });
+
     describe("Extent generation", function() {
         it("has a method to generate an extent function for any axis", function() {
             this.datalayer = new LocusZoom.DataLayer("test", {});

--- a/test/Singletons.js
+++ b/test/Singletons.js
@@ -178,7 +178,7 @@ describe('LocusZoom Singletons', function(){
         it('should have a method to list available scale functions', function(){
             LocusZoom.ScaleFunctions.should.have.property('list').which.is.a.Function;
             var returned_list = LocusZoom.ScaleFunctions.list();
-            var expected_list = ["numerical_bin", "categorical_bin"];
+            var expected_list = ["if", "numerical_bin", "categorical_bin"];
             assert.deepEqual(returned_list, expected_list);
         });
         it('should have a general method to get a scale by function name', function(){
@@ -189,7 +189,7 @@ describe('LocusZoom Singletons', function(){
             var foo = function(parameters, value){ return "#000000"; };
             LocusZoom.ScaleFunctions.add("foo", foo);
             var returned_list = LocusZoom.ScaleFunctions.list();
-            var expected_list = ["numerical_bin", "categorical_bin", "foo"];
+            var expected_list = ["if", "numerical_bin", "categorical_bin", "foo"];
             assert.deepEqual(returned_list, expected_list);
             var returned_value = LocusZoom.ScaleFunctions.get("foo", {}, 0);
             var expected_value = "#000000";
@@ -200,14 +200,14 @@ describe('LocusZoom Singletons', function(){
             var foo_new = function(parameters, value){ return "#FFFFFF"; };
             LocusZoom.ScaleFunctions.set("foo", foo_new);
             var returned_list = LocusZoom.ScaleFunctions.list();
-            var expected_list = ["numerical_bin", "categorical_bin", "foo"];
+            var expected_list = ["if", "numerical_bin", "categorical_bin", "foo"];
             assert.deepEqual(returned_list, expected_list);
             var returned_value = LocusZoom.ScaleFunctions.get("foo", {}, 0);
             var expected_value = "#FFFFFF";
             assert.equal(returned_value, expected_value);
             LocusZoom.ScaleFunctions.set("foo");
             var returned_list = LocusZoom.ScaleFunctions.list();
-            var expected_list = ["numerical_bin", "categorical_bin"];
+            var expected_list = ["if", "numerical_bin", "categorical_bin"];
             assert.deepEqual(returned_list, expected_list);
         });
         it('should throw an exception if asked to get a function that has not been defined', function(){
@@ -221,8 +221,41 @@ describe('LocusZoom Singletons', function(){
                 LocusZoom.ScaleFunctions.add("categorical_bin", foo);
             });
         });
+        describe("if", function() {
+            it('should match against an arbitrary value, return null if not matched', function(){
+                var parameters = {
+                    field_value: 6,
+                    then: true
+                };
+                assert.equal(LocusZoom.ScaleFunctions.get("if", parameters, 0), null);
+                assert.equal(LocusZoom.ScaleFunctions.get("if", parameters, "foo"), null);
+                assert.equal(LocusZoom.ScaleFunctions.get("if", parameters, 6), true);
+            });
+            it('should optionally allow for defining an else', function(){
+                var parameters = {
+                    field_value: "kiwi",
+                    then: "pineapple",
+                    else: "watermelon"
+                };
+                assert.equal(LocusZoom.ScaleFunctions.get("if", parameters, 0), "watermelon");
+                assert.equal(LocusZoom.ScaleFunctions.get("if", parameters, "foo"), "watermelon");
+                assert.equal(LocusZoom.ScaleFunctions.get("if", parameters, "kiwi"), "pineapple");
+            });
+        });
         describe("numerical_bin", function() {
-            it('should work with arbitrarily many breaks/values', function(){
+           it('should work with arbitrarily many breaks/values', function(){
+                var parameters = {
+                    breaks: [-167, -46, 15, 23, 76.8, 952],
+                    values: ["value-167", "value-46", "value15", "value23", "value76.8", "value952"]
+                };
+                assert.equal(LocusZoom.ScaleFunctions.get("numerical_bin", parameters, -50000), "value-167");
+                assert.equal(LocusZoom.ScaleFunctions.get("numerical_bin", parameters, 0), "value-46");
+                assert.equal(LocusZoom.ScaleFunctions.get("numerical_bin", parameters, 76.799999999), "value23");
+                assert.equal(LocusZoom.ScaleFunctions.get("numerical_bin", parameters, 481329), "value952");
+                assert.equal(LocusZoom.ScaleFunctions.get("numerical_bin", parameters, "foo"), null);
+                assert.equal(LocusZoom.ScaleFunctions.get("numerical_bin", parameters), null);
+            });
+            it('should work with arbitrarily many breaks/values and an optional null_value parameter', function(){
                 var parameters = {
                     breaks: [0, 0.2, 0.4, 0.6, 0.8],
                     values: ["value0", "value0.2", "value0.4", "value0.6", "value0.8"],
@@ -235,20 +268,21 @@ describe('LocusZoom Singletons', function(){
                 assert.equal(LocusZoom.ScaleFunctions.get("numerical_bin", parameters, 3246), "value0.8");
                 assert.equal(LocusZoom.ScaleFunctions.get("numerical_bin", parameters, "foo"), "null_value");
                 assert.equal(LocusZoom.ScaleFunctions.get("numerical_bin", parameters), "null_value");
-                var parameters = {
-                    breaks: [-167, -46, 15, 23, 76.8, 952],
-                    values: ["value-167", "value-46", "value15", "value23", "value76.8", "value952"]
-                };
-                assert.equal(LocusZoom.ScaleFunctions.get("numerical_bin", parameters, -50000), "value-167");
-                assert.equal(LocusZoom.ScaleFunctions.get("numerical_bin", parameters, 0), "value-46");
-                assert.equal(LocusZoom.ScaleFunctions.get("numerical_bin", parameters, 76.799999999), "value23");
-                assert.equal(LocusZoom.ScaleFunctions.get("numerical_bin", parameters, 481329), "value952");
-                assert.equal(LocusZoom.ScaleFunctions.get("numerical_bin", parameters, "foo"), "value-167");
-                assert.equal(LocusZoom.ScaleFunctions.get("numerical_bin", parameters), "value-167");
             });
         });
         describe("categorical_bin", function() {
             it('should work with arbitrarily many categories/values', function(){
+                var parameters = {
+                    categories: ["oxygen", "fluorine", "tungsten"],
+                    values: ["value-oxygen", "value-fluorine", "value-tungsten"]
+                };
+                assert.equal(LocusZoom.ScaleFunctions.get("categorical_bin", parameters, "fluorine"), "value-fluorine");
+                assert.equal(LocusZoom.ScaleFunctions.get("categorical_bin", parameters, "tungsten"), "value-tungsten");
+                assert.equal(LocusZoom.ScaleFunctions.get("categorical_bin", parameters, 135), null);
+                assert.equal(LocusZoom.ScaleFunctions.get("categorical_bin", parameters, ["tungsten"]), null);
+                assert.equal(LocusZoom.ScaleFunctions.get("categorical_bin", parameters), null);
+            });
+            it('should work with arbitrarily many categories/values and an optional null_value parameter', function(){
                 var parameters = {
                     categories: ["dog", "cat", "hippo", "marmoset"],
                     values: ["value-dog", "value-cat", "value-hippo", "value-marmoset"],
@@ -259,14 +293,6 @@ describe('LocusZoom Singletons', function(){
                 assert.equal(LocusZoom.ScaleFunctions.get("categorical_bin", parameters, "CAT"), "null_value");
                 assert.equal(LocusZoom.ScaleFunctions.get("categorical_bin", parameters, 53), "null_value");
                 assert.equal(LocusZoom.ScaleFunctions.get("categorical_bin", parameters), "null_value");
-                var parameters = {
-                    categories: ["oxygen", "fluorine", "tungsten"],
-                    values: ["value-oxygen", "value-fluorine", "value-tungsten"]
-                };
-                assert.equal(LocusZoom.ScaleFunctions.get("categorical_bin", parameters, "fluorine"), "value-fluorine");
-                assert.equal(LocusZoom.ScaleFunctions.get("categorical_bin", parameters, 135), "value-oxygen");
-                assert.equal(LocusZoom.ScaleFunctions.get("categorical_bin", parameters, ["tungsten"]), "value-oxygen");
-                assert.equal(LocusZoom.ScaleFunctions.get("categorical_bin", parameters), "value-oxygen");
             });
         });
     });


### PR DESCRIPTION
This pull req generalizes the resolution of scalable parameters (e.g. color, size, or shape for scatter points) such that every such layout parameter can be defined as:

* A static value (number or string independent of data)
* An object implementing a scale function to be applied to a field on the element's data
* An array of arbitrarily many of the above, to be iterated over until a non-null value is found or all options are exhausted.

There's also a new scale function in this branch called `if` that allows for a very basic conditional. Put it all together and we can support this definition for the color of scatter elements on the positions panel when the LD reference variant needs to be colored differently (e.g. we're coloring on the values of `ld:state` and `ld:isrefvar` with strict order):

```json
color: [
  {
    scale_function: "if",
    field: "ld:isrefvar",
    parameters: {
      field_value: 1,
      then: "#9632b8"
    }
  },
  {
    scale_function: "numerical_bin",
    field: "ld:state",
    parameters: {
      breaks: [0, 0.2, 0.4, 0.6, 0.8],
      values: ["#357ebd","#46b8da","#5cb85c","#eea236","#d43f3a"]
    }
  },
  "#B8B8B8"
]
```

The above layout, for each point on the scatter plot, is sent to `LocusZoom.DataLayer.resolveScalableParameter()` along with the data for that point. The first element in the array (the `if` scale function) will return its `then` value only if `ld:isrefvar` is 1, otherwise it will return null. This passes through to the next scale function, `numerical_bin`, which will map the value of `ld:state` to a breakpoint color or (if `ld:state` is not defined or numeric) will return null. That then passes to the last value, which is a string, and that gets returned no matter what. This ensures that LD ref variants are always purple, all other variants with a defined numerical LD value get an appropriate color, and any leftover variants show up gray.

The same behavior now applies to `point_size` and `point_shape` for scatter plot elements as well.