### PR TITLE
Independent Select / Highlight / Tool Tip Logic

### DIFF
--- a/assets/css/locuszoom.scss
+++ b/assets/css/locuszoom.scss
@@ -107,7 +107,7 @@ svg.#{$namespace}-locuszoom {
     cursor: pointer;
   }
 
-  path.#{$namespace}-data_layer-scatter-hovered {
+  path.#{$namespace}-data_layer-scatter-highlighted {
     stroke: #{$default_black_shadow};
     stroke-width: 4;
   }
@@ -153,7 +153,7 @@ svg.#{$namespace}-locuszoom {
     stroke-width: 0;
   }
 
-  rect.#{$namespace}-data_layer-genes.#{$namespace}-data_layer-genes-bounding_box-hovered {
+  rect.#{$namespace}-data_layer-genes.#{$namespace}-data_layer-genes-bounding_box-highlighted {
     fill: rgb(54, 54, 150);
     fill-opacity: 0.1;
     stroke-width: 0;

--- a/assets/js/app/DataLayer.js
+++ b/assets/js/app/DataLayer.js
@@ -28,6 +28,9 @@ LocusZoom.DataLayer = function(id, layout, parent) {
         this.state = this.parent.state;
         this.state_id = this.parent.id + "." + this.id;
         this.state[this.state_id] = this.state[this.state_id] || {};
+        if (this.layout.highlightable){
+            this.state[this.state_id].highlighted = this.state[this.state_id].highlighted || [];
+        }
         if (this.layout.selectable){
             this.state[this.state_id].selected = this.state[this.state_id].selected || [];
         }
@@ -36,253 +39,9 @@ LocusZoom.DataLayer = function(id, layout, parent) {
         this.state_id = null;
     }
 
+    // Initialize parameters for storing data and tool tips
     this.data = [];
-
-    this.getBaseId = function(){
-        return this.parent.parent.id + "." + this.parent.id + "." + this.id;
-    };
-
-    this.onUpdate = function(){
-        this.parent.onUpdate();
-    };
-
-    // Tooltip methods
     this.tooltips = {};
-    this.createTooltip = function(d, id){
-        if (typeof this.layout.tooltip != "object"){
-            throw ("DataLayer [" + this.id + "] layout does not define a tooltip");
-        }
-        if (typeof id != "string"){
-            throw ("Unable to create tooltip: id is not a string");
-        }
-        if (this.tooltips[id]){
-            this.positionTooltip(id);
-            return;
-        }
-        this.tooltips[id] = {
-            data: d,
-            arrow: null,
-            closed: false,
-            selector: d3.select(this.parent.parent.svg.node().parentNode).append("div")
-                .attr("class", "lz-data_layer-tooltip")
-                .attr("id", this.getBaseId() + ".tooltip." + id)
-        };
-        this.updateTooltip(d, id);
-    };
-    this.updateTooltip = function(d, id){
-        // Empty the tooltip of all HTML (including its arrow!)
-        this.tooltips[id].selector.html("");
-        this.tooltips[id].arrow = null;
-        // Set the new HTML
-        if (this.layout.tooltip.html){
-            this.tooltips[id].selector.html(LocusZoom.parseFields(d, this.layout.tooltip.html));
-        }
-        // If the layout allows tool tips on this data layer to be closable then add the close button
-        // and add padding to the tooltip to accomodate it
-        if (this.layout.tooltip.closable){
-            this.tooltips[id].selector.style("padding-right", "24px");
-            this.tooltips[id].selector.append("a")
-                .attr("class", "lz-tooltip-close-button")
-                .attr("title", "Close")
-                .html("×")
-                .on("click", function(){
-                    this.closeTooltip(id);
-                }.bind(this));
-        }
-        // Reposition and draw a new arrow
-        this.positionTooltip(id);
-    };
-    // Close tool tip - hide the tool tip element and flag it as closed, but don't destroy it
-    this.closeTooltip = function(id){
-        if (typeof id != "string"){
-            throw ("Unable to close tooltip: id is not a string");
-        }
-        if (this.tooltips[id]){
-            if (typeof this.tooltips[id].selector == "object"){
-                this.tooltips[id].selector.style("display", "none");
-            }
-            this.tooltips[id].closed = true;
-        }
-    };
-    // Unclose tool tip - reveal and position a previously closed tool tip (rather than creating it anew)
-    this.uncloseTooltip = function(id){
-        if (typeof id != "string"){
-            throw ("Unable to unclose tooltip: id is not a string");
-        }
-        if (this.tooltips[id] && this.tooltips[id].closed){
-            if (typeof this.tooltips[id].selector == "object"){
-                this.tooltips[id].selector.style("display", null);
-            }
-            this.positionTooltip(id);
-            this.tooltips[id].closed = false;
-        }
-    };
-    // Destroy tool tip - remove the tool tip element from the DOM and delete the tool tip's record on the data layer
-    this.destroyTooltip = function(id){
-        if (typeof id != "string"){
-            throw ("Unable to destroy tooltip: id is not a string");
-        }
-        if (this.tooltips[id]){
-            if (typeof this.tooltips[id].selector == "object"){
-                this.tooltips[id].selector.remove();
-            }
-            delete this.tooltips[id];
-        }
-    };
-    this.destroyAllTooltips = function(){
-        var id;
-        for (id in this.tooltips){
-            this.destroyTooltip(id);
-        }
-    };
-    // Position tool tip - naive function to place a tool tip to the lower right of the current mouse element
-    // Most data layers reimplement this method to position tool tips specifically for the data they display
-    this.positionTooltip = function(id){
-        if (typeof id != "string"){
-            throw ("Unable to position tooltip: id is not a string");
-        }
-        // Position the div itself
-        this.tooltips[id].selector
-            .style("left", (d3.event.pageX) + "px")
-            .style("top", (d3.event.pageY) + "px");
-        // Create / update position on arrow connecting tooltip to data
-        if (!this.tooltips[id].arrow){
-            this.tooltips[id].arrow = this.tooltips[id].selector.append("div")
-                .style("position", "absolute")
-                .attr("class", "lz-data_layer-tooltip-arrow_top_left");
-        }
-        this.tooltips[id].arrow
-            .style("left", "-1px")
-            .style("top", "-1px");
-    };
-    this.positionAllTooltips = function(){
-        var id;
-        for (id in this.tooltips){
-            this.positionTooltip(id);
-        }
-    };
-
-    // Standard approach to applying unit-based selectability and general tooltip behavior (one and/or multiple)
-    // on a selection of data elements
-    this.enableTooltips = function(selection){
-        
-        if (typeof selection != "object"){ return; }
-        if (!this.layout.id_field){
-            console.warn("Data layer " + this.id + " tried to enable tooltips but does not have a valid id_field defined in the layout");
-            return;
-        }
-        
-        // Enable mouseover/mouseout tooltip show/hide behavior
-        selection.on("mouseover", function(d){
-            var id = this.parent.id + "_" + d[this.layout.id_field].replace(/\W/g,"");
-            var select_id = id;
-            var attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-hovered";
-            if (this.layout.hover_element){
-                select_id += "_" + this.layout.hover_element;
-                attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element + "-hovered";
-            }
-            if (this.state[this.state_id].selected.indexOf(id) == -1){
-                d3.select("#" + select_id).attr("class", attr_class);
-                if (this.layout.tooltip){ this.createTooltip(d, id); }
-            }
-        }.bind(this))
-        .on("mouseout", function(d){
-            var id = this.parent.id + "_" + d[this.layout.id_field].replace(/\W/g,"");
-            var select_id = id;
-            var attr_class = "lz-data_layer-" + this.layout.type;
-            if (this.layout.hover_element){
-                select_id += "_" + this.layout.hover_element;
-                attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element;
-            }
-            if (this.state[this.state_id].selected.indexOf(id) == -1){
-                d3.select("#" + select_id).attr("class", attr_class);
-                if (this.layout.tooltip){ this.destroyTooltip(id); }
-            }
-        }.bind(this));
-        
-        if (this.layout.selectable){
-
-            var select_id, attr_class;
-            
-            // Enable selectability
-            selection.on("click", function(d){
-                var id = this.parent.id + "_" + d[this.layout.id_field].replace(/\W/g,"");
-                var selected_idx = this.state[this.state_id].selected.indexOf(id);
-                // If this element IS currently selected...
-                if (selected_idx != -1){
-                    // If in selectable:multiple mode and this tooltip was closed then unclose it and be done
-                    if (this.layout.selectable == "multiple" && this.tooltips[id] && this.tooltips[id].closed){
-                        this.uncloseTooltip(id);
-                    // Otherwise unselect the element but leave the tool tip in place (to be destroyed on mouse out)
-                    } else {
-                        this.state[this.state_id].selected.splice(selected_idx, 1);
-                        select_id = id;
-                        attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-hovered";
-                        if (this.layout.hover_element){
-                            select_id += "_" + this.layout.hover_element;
-                            attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element + "-hovered";
-                        }
-                        d3.select("#" + select_id).attr("class", attr_class);
-                    }
-
-                // If this element IS NOT currently selected...
-                } else {
-                    // If in selectable:one mode then deselect any current selection
-                    if (this.layout.selectable == "one" && this.state[this.state_id].selected.length){
-                        this.destroyTooltip(this.state[this.state_id].selected[0]);
-                        select_id = this.state[this.state_id].selected[0];
-                        attr_class = "lz-data_layer-" + this.layout.type;
-                        if (this.layout.hover_element){
-                            select_id += "_" + this.layout.hover_element;
-                            attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element;
-                        }
-                        d3.select("#" + select_id).attr("class", attr_class);
-                        this.state[this.state_id].selected = [];
-                    }
-                    // Select the clicked element    
-                    this.state[this.state_id].selected.push(id);
-                    select_id = id;
-                    attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-selected";
-                    if (this.layout.hover_element){
-                        select_id += "_" + this.layout.hover_element;
-                        attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element + "-selected";
-                    }
-                    d3.select("#" + select_id).attr("class", attr_class);
-                }
-                this.onUpdate();
-            }.bind(this));
-
-            // Apply existing elements from state
-            if (Array.isArray(this.state[this.state_id].selected) && this.state[this.state_id].selected.length){
-                this.state[this.state_id].selected.forEach(function(selected_id, idx){
-                    if (d3.select("#" + selected_id).empty()){
-                        console.warn("State elements for " + this.state_id + " contains an ID that is not or is no longer present on the plot: " + selected_id);
-                        this.state[this.state_id].selected.splice(idx, 1);
-                    } else {
-                        if (this.tooltips[selected_id] && !this.tooltips[selected_id].closed){
-                            this.positionTooltip(selected_id);
-                        } else {
-                            this.state[this.state_id].selected.splice(idx, 1);
-                            var d = d3.select("#" + selected_id).datum();
-                            d3.select("#" + selected_id).on("mouseover")(d);
-                            d3.select("#" + selected_id).on("click")(d);
-                        }
-                    }
-                }.bind(this));
-            }
-            
-        }
-    };
-
-    // Get an object with the x and y coordinates of the panel's origin in terms of the entire page
-    // Necessary for positioning any HTML elements over the panel
-    this.getPageOrigin = function(){
-        var panel_origin = this.parent.getPageOrigin();
-        return {
-            x: panel_origin.x + this.parent.layout.margin.left,
-            y: panel_origin.y + this.parent.layout.margin.top
-        };
-    };
     
     return this;
 
@@ -292,7 +51,43 @@ LocusZoom.DataLayer.DefaultLayout = {
     type: "",
     fields: [],
     x_axis: {},
-    y_axis: {}
+    y_axis: {},
+    highlightable: "onmouseover",
+    selectable: false,
+    tooltip: false
+};
+
+LocusZoom.DataLayer.prototype.getBaseId = function(){
+    return this.parent.parent.id + "." + this.parent.id + "." + this.id;
+};
+
+LocusZoom.DataLayer.prototype.getElementId = function(element){
+    return this.getBaseId() + "." + element[this.layout.id_field].replace(/\W/g,"");
+};
+
+LocusZoom.DataLayer.prototype.onUpdate = function(){
+    this.parent.onUpdate();
+};
+
+// Initialize a data layer
+LocusZoom.DataLayer.prototype.initialize = function(){
+
+    // Append a container group element to house the main data layer group element and the clip path
+    this.svg.container = this.parent.svg.group.append("g")
+        .attr("id", this.getBaseId() + ".data_layer_container");
+        
+    // Append clip path to the container element
+    this.svg.clipRect = this.svg.container.append("clipPath")
+        .attr("id", this.getBaseId() + ".clip")
+        .append("rect");
+    
+    // Append svg group for rendering all data layer elements, clipped by the clip path
+    this.svg.group = this.svg.container.append("g")
+        .attr("id", this.getBaseId() + ".data_layer")
+        .attr("clip-path", "url(#" + this.getBaseId() + ".clip)");
+
+    return this;
+
 };
 
 // Resolve a scalable parameter for an element into a single value based on its layout and the element's data
@@ -373,26 +168,410 @@ LocusZoom.DataLayer.prototype.getAxisExtent = function(dimension){
 
 };
 
-// Initialize a data layer
-LocusZoom.DataLayer.prototype.initialize = function(){
-
-    // Append a container group element to house the main data layer group element and the clip path
-    this.svg.container = this.parent.svg.group.append("g")
-        .attr("id", this.getBaseId() + ".data_layer_container");
-        
-    // Append clip path to the container element
-    this.svg.clipRect = this.svg.container.append("clipPath")
-        .attr("id", this.getBaseId() + ".clip")
-        .append("rect");
-    
-    // Append svg group for rendering all data layer elements, clipped by the clip path
-    this.svg.group = this.svg.container.append("g")
-        .attr("id", this.getBaseId() + ".data_layer")
-        .attr("clip-path", "url(#" + this.getBaseId() + ".clip)");
-
-    return this;
-
+// Generate a tool tip for a given element
+LocusZoom.DataLayer.prototype.createTooltip = function(d, id){
+    if (typeof this.layout.tooltip != "object"){
+        throw ("DataLayer [" + this.id + "] layout does not define a tooltip");
+    }
+    if (typeof id != "string"){
+        throw ("Unable to create tooltip: id is not a string");
+    }
+    if (this.tooltips[id]){
+        this.positionTooltip(id);
+        return;
+    }
+    this.tooltips[id] = {
+        data: d,
+        arrow: null,
+        closed: false,
+        selector: d3.select(this.parent.parent.svg.node().parentNode).append("div")
+            .attr("class", "lz-data_layer-tooltip")
+            .attr("id", this.getBaseId() + ".tooltip." + id)
+    };
+    this.updateTooltip(d, id);
 };
+
+// Update a tool tip (generate its inner HTML)
+LocusZoom.DataLayer.prototype.updateTooltip = function(d, id){
+    // Empty the tooltip of all HTML (including its arrow!)
+    this.tooltips[id].selector.html("");
+    this.tooltips[id].arrow = null;
+    // Set the new HTML
+    if (this.layout.tooltip.html){
+        this.tooltips[id].selector.html(LocusZoom.parseFields(d, this.layout.tooltip.html));
+    }
+    // If the layout allows tool tips on this data layer to be closable then add the close button
+    // and add padding to the tooltip to accomodate it
+    if (this.layout.tooltip.closable){
+        this.tooltips[id].selector.style("padding-right", "24px");
+        this.tooltips[id].selector.append("a")
+            .attr("class", "lz-tooltip-close-button")
+            .attr("title", "Close")
+            .html("×")
+            .on("click", function(){
+                this.closeTooltip(id);
+            }.bind(this));
+    }
+    // Reposition and draw a new arrow
+    this.positionTooltip(id);
+};
+
+// Destroy tool tip - remove the tool tip element from the DOM and delete the tool tip's record on the data layer
+LocusZoom.DataLayer.prototype.destroyTooltip = function(id){
+    if (typeof id != "string"){
+        throw ("Unable to destroy tooltip: id is not a string");
+    }
+    if (this.tooltips[id]){
+        if (typeof this.tooltips[id].selector == "object"){
+            this.tooltips[id].selector.remove();
+        }
+        delete this.tooltips[id];
+    }
+};
+
+// Loop through and destroy all tool tips on this data layer
+LocusZoom.DataLayer.prototype.destroyAllTooltips = function(){
+    for (var id in this.tooltips){
+        this.destroyTooltip(id);
+    }
+};
+
+// Position tool tip - naive function to place a tool tip to the lower right of the current mouse element
+// Most data layers reimplement this method to position tool tips specifically for the data they display
+LocusZoom.DataLayer.prototype.positionTooltip = function(id){
+    if (typeof id != "string"){
+        throw ("Unable to position tooltip: id is not a string");
+    }
+    // Position the div itself
+    this.tooltips[id].selector
+        .style("left", (d3.event.pageX) + "px")
+        .style("top", (d3.event.pageY) + "px");
+    // Create / update position on arrow connecting tooltip to data
+    if (!this.tooltips[id].arrow){
+        this.tooltips[id].arrow = this.tooltips[id].selector.append("div")
+            .style("position", "absolute")
+            .attr("class", "lz-data_layer-tooltip-arrow_top_left");
+    }
+    this.tooltips[id].arrow
+        .style("left", "-1px")
+        .style("top", "-1px");
+};
+
+// Loop through and position all tool tips on this data layer
+LocusZoom.DataLayer.prototype.positionAllTooltips = function(){
+    for (var id in this.tooltips){
+        this.positionTooltip(id);
+    }
+};
+
+// Show or hide a tool tip by ID depending on directives in the layout and state values relative to the ID
+LocusZoom.DataLayer.prototype.showOrHideTooltip = function(id){
+    
+    if (typeof this.layout.tooltip != "object"){ return; }
+
+    var resolveStatus = function(element, directive, operator){
+        var status = null;
+        if (typeof element != "object" || element == null){ return null; }
+        if (typeof directive == "object"){
+            var sub_status;
+            for (var sub_operator in directive){
+                sub_status = resolveStatus(element, directive[sub_operator], sub_operator);
+                if (status == null){
+                    status = sub_status;
+                } else if (operator == "and"){
+                    status = status && sub_status;
+                } else if (operator == "or"){
+                    status = status || sub_status;
+                }
+            }
+        } else if (typeof directive == "array"){
+            if (typeof operator == "undefined"){ operator = "and"; }
+            if (directive.length == 1){
+                status = element[directive[0]];
+            } else {
+                status = directive.reduce(function(previousValue, currentValue) {
+                    if (operator == "and"){
+                        return previousValue && currentValue;
+                    } else if (operator == "or"){
+                        return previousValue || currentValue;
+                    }
+                    return null;
+                });
+            }
+        }
+        return status;
+    };
+
+    var show_directive = {};
+    if (typeof this.layout.tooltip.show == "string"){
+        show_directive = { and: [ this.layout.tooltip.show ] };
+    } else if (typeof this.layout.tooltip.show == "object"){
+        show_directive = this.layout.tooltip.show;
+    }
+
+    var hide_directive = {};
+    if (typeof this.layout.tooltip.hide == "string"){
+        hide_directive = { and: [ this.layout.tooltip.hide ] };
+    } else if (typeof this.layout.tooltip.hide == "object"){
+        hide_directive = this.layout.tooltip.hide;
+    }
+
+    var element = {};
+    element.highlighted = this.state[this.state_id].highlighted.indexOf(id) != -1;
+    element.unhighlighted = !element.highlighted;
+    element.selected = this.state[this.state_id].selected.indexOf(id) != -1;
+    element.unselected = !element.selected;
+
+    var show_resolved = resolveStatus(element, show_directive);
+    var hide_resolved = resolveStatus(element, hide_directive);
+
+    // Only show tooltip if the resolved logic explicitly shows and explicitly not hides the tool tip
+    var show_tooltip = show_resolved && !hide_resolved;
+    
+    // ...
+};
+
+// Toggle the highlighted status of an element
+LocusZoom.DataLayer.prototype.highlightElement = function(id, toggle){
+    this.toggleElementStatus("highlighted", id, toggle);
+};
+LocusZoom.DataLayer.prototype.unhighlightElement = function(id){
+    this.highlightElement(id, false);
+};
+
+// Toggle the highlighted status of all elements
+LocusZoom.DataLayer.prototype.highlightAllElements = function(toggle){
+    this.toggleAllElementStatus("highlighted", toggle);
+};
+LocusZoom.DataLayer.prototype.unhighlightAllElements = function(){
+    this.highlightAllElements(false);
+}
+
+// Toggle the selected status of an element
+LocusZoom.DataLayer.prototype.selectElement = function(id, toggle){
+    this.toggleElementStatus("selected", id, toggle);
+};
+LocusZoom.DataLayer.prototype.unselectElement = function(id){
+    this.selectElement(id, false);
+};
+
+// Toggle the selected status of all elements
+LocusZoom.DataLayer.prototype.selectAllElements = function(toggle){
+    this.toggleAllElementStatus("selected", toggle);
+};
+LocusZoom.DataLayer.prototype.unselectAllElements = function(){
+    this.selectAllElements(false);
+};
+
+// Toggle a status (e.g. highlighted, selected) on an element
+LocusZoom.DataLayer.prototype.toggleElementStatus = function(status, id, toggle){
+    
+    // Sanity checks
+    if (typeof status == "undefined" || ["highlighted","selected"].indexOf(status) == -1){ return; }
+    if (typeof id != "string"){ return; }
+    if (typeof toggle == "undefined"){ var toggle = true; }
+    
+    // Set/unset the proper status class on the appropriate DOM element
+    var element_id = id;
+    var attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-" + status;
+    if (this.layout.hover_element){
+        element_id += "_" + this.layout.hover_element;
+        attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element + "-" + status;
+    }
+    d3.select("#" + element_id).classed(attr_class, toggle);
+    
+    // Track element ID in the proper status state array
+    var element_status_idx = this.state[this.state_id][status].indexOf(id);
+    if (toggle && element_status_idx == -1){
+        this.state[this.state_id][status].push(id);
+    }
+    if (!toggle && element_status_idx != -1){
+        this.state[this.state_id][status].splice(element_status_idx, 1);
+    }
+    
+    // Trigger tool tip show/hide logic
+    this.showOrHideTooltip(id);
+    
+};
+
+// Toggle a status on an all elements in the data layer
+LocusZoom.DataLayer.prototype.toggleAllElementStatus = function(status, toggle){
+    
+    // Sanity check
+    if (typeof status == "undefined" || ["highlighted","selected"].indexOf(status) == -1){ return; }
+    if (typeof toggle == "undefined"){ var toggle = true; }
+
+    // Apply statuses
+    if (toggle){
+        this.data.forEach(function(element){
+            var id = this.getElementId(element);
+            if (this.state[this.state_id][status].indexOf(id) == -1){
+                this.toggleElementStatus(status, id, true);
+            }
+        }.bind(this));
+    } else {
+        var status_ids = this.state[this.state_id][status].slice();
+        status_ids.forEach(function(id){
+            this.toggleElementStatus(status, id, false);
+        }.bind(this));
+    }
+    
+};
+
+// Apply element highlight behavior from directives in the layout
+LocusZoom.DataLayer.prototype.applyHighlight = function(selection){
+    
+    if (this.layout.highlight == "onmouseover"){
+        
+        // Sanity checks: valid d3 selection and defined ID field
+        if (typeof selection != "object"){
+            console.warn("Data layer " + this.id + " tried to apply highlight behavior but valid d3 selection not supplied");
+            return;
+        }
+        if (!this.layout.id_field){
+            console.warn("Data layer " + this.id + " tried to apply highlight behavior but valid id_field not defined in the layout");
+            return;
+        }
+        
+        // Bind mouse events
+        selection
+            .on("mouseover", function(d){
+                this.highlightElement(this.getElementId(d), true);
+            }.bind(this))
+            .on("mouseout", function(d){
+                this.highlightElement(this.getElementId(d), false);
+            }.bind(this));
+        
+    }
+    
+};
+
+// Apply element selectability behavior from directives in the layout
+LocusZoom.DataLayer.prototype.applySelectability = function(selection){
+};
+
+// Standard approach to applying unit-based selectability and general tooltip behavior (one and/or multiple)
+// on a selection of data elements
+LocusZoom.DataLayer.prototype.enableTooltips = function(selection){
+
+    if (typeof selection != "object"){ return; }
+    if (!this.layout.id_field){
+        console.warn("Data layer " + this.id + " tried to enable tooltips but does not have a valid id_field defined in the layout");
+        return;
+    }
+    
+    // Enable mouseover/mouseout tooltip show/hide behavior
+    selection.on("mouseover", function(d){
+        var id = this.parent.id + "_" + d[this.layout.id_field].replace(/\W/g,"");
+        var select_id = id;
+        var attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-hovered";
+        if (this.layout.hover_element){
+            select_id += "_" + this.layout.hover_element;
+            attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element + "-hovered";
+        }
+        if (this.state[this.state_id].selected.indexOf(id) == -1){
+            d3.select("#" + select_id).attr("class", attr_class);
+            if (this.layout.tooltip){ this.createTooltip(d, id); }
+        }
+    }.bind(this))
+        .on("mouseout", function(d){
+            var id = this.parent.id + "_" + d[this.layout.id_field].replace(/\W/g,"");
+            var select_id = id;
+            var attr_class = "lz-data_layer-" + this.layout.type;
+            if (this.layout.hover_element){
+                select_id += "_" + this.layout.hover_element;
+                attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element;
+            }
+            if (this.state[this.state_id].selected.indexOf(id) == -1){
+                d3.select("#" + select_id).attr("class", attr_class);
+                if (this.layout.tooltip){ this.destroyTooltip(id); }
+            }
+        }.bind(this));
+    
+    if (this.layout.selectable){
+
+        var select_id, attr_class;
+        
+        // Enable selectability
+        selection.on("click", function(d){
+            var id = this.parent.id + "_" + d[this.layout.id_field].replace(/\W/g,"");
+            var selected_idx = this.state[this.state_id].selected.indexOf(id);
+            // If this element IS currently selected...
+            if (selected_idx != -1){
+                // If in selectable:multiple mode and this tooltip was closed then unclose it and be done
+                if (this.layout.selectable == "multiple" && this.tooltips[id] && this.tooltips[id].closed){
+                    this.uncloseTooltip(id);
+                    // Otherwise unselect the element but leave the tool tip in place (to be destroyed on mouse out)
+                } else {
+                    this.state[this.state_id].selected.splice(selected_idx, 1);
+                    select_id = id;
+                    attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-hovered";
+                    if (this.layout.hover_element){
+                        select_id += "_" + this.layout.hover_element;
+                        attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element + "-hovered";
+                    }
+                    d3.select("#" + select_id).attr("class", attr_class);
+                }
+
+                // If this element IS NOT currently selected...
+            } else {
+                // If in selectable:one mode then deselect any current selection
+                if (this.layout.selectable == "one" && this.state[this.state_id].selected.length){
+                    this.destroyTooltip(this.state[this.state_id].selected[0]);
+                    select_id = this.state[this.state_id].selected[0];
+                    attr_class = "lz-data_layer-" + this.layout.type;
+                    if (this.layout.hover_element){
+                        select_id += "_" + this.layout.hover_element;
+                        attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element;
+                    }
+                    d3.select("#" + select_id).attr("class", attr_class);
+                    this.state[this.state_id].selected = [];
+                }
+                // Select the clicked element    
+                this.state[this.state_id].selected.push(id);
+                select_id = id;
+                attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-selected";
+                if (this.layout.hover_element){
+                    select_id += "_" + this.layout.hover_element;
+                    attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element + "-selected";
+                }
+                d3.select("#" + select_id).attr("class", attr_class);
+            }
+            this.onUpdate();
+        }.bind(this));
+
+        // Apply existing elements from state
+        if (Array.isArray(this.state[this.state_id].selected) && this.state[this.state_id].selected.length){
+            this.state[this.state_id].selected.forEach(function(selected_id, idx){
+                if (d3.select("#" + selected_id).empty()){
+                    console.warn("State elements for " + this.state_id + " contains an ID that is not or is no longer present on the plot: " + selected_id);
+                    this.state[this.state_id].selected.splice(idx, 1);
+                } else {
+                    if (this.tooltips[selected_id] && !this.tooltips[selected_id].closed){
+                        this.positionTooltip(selected_id);
+                    } else {
+                        this.state[this.state_id].selected.splice(idx, 1);
+                        var d = d3.select("#" + selected_id).datum();
+                        d3.select("#" + selected_id).on("mouseover")(d);
+                        d3.select("#" + selected_id).on("click")(d);
+                    }
+                }
+            }.bind(this));
+        }
+        
+    }
+};
+
+// Get an object with the x and y coordinates of the panel's origin in terms of the entire page
+// Necessary for positioning any HTML elements over the panel
+LocusZoom.DataLayer.prototype.getPageOrigin = function(){
+    var panel_origin = this.parent.getPageOrigin();
+    return {
+        x: panel_origin.x + this.parent.layout.margin.left,
+        y: panel_origin.y + this.parent.layout.margin.top
+    };
+};
+
 
 LocusZoom.DataLayer.prototype.draw = function(){
     this.svg.container.attr("transform", "translate(" + this.parent.layout.cliparea.origin.x +  "," + this.parent.layout.cliparea.origin.y + ")");

--- a/assets/js/app/DataLayer.js
+++ b/assets/js/app/DataLayer.js
@@ -61,7 +61,17 @@ LocusZoom.DataLayer.prototype.getBaseId = function(){
 };
 
 LocusZoom.DataLayer.prototype.getElementId = function(element){
-    return (this.getBaseId() + "-" + element[this.layout.id_field].replace(/\W/g,"")).replace(/\./g,"-");
+    var element_id = "element";
+    if (typeof element == "string"){
+        element_id = element;
+    } else if (typeof element == "object"){
+        var id_field = this.layout.id_field || "id";
+        if (typeof element[id_field] == "undefined"){
+            throw("Unable to generate element ID");
+        }
+        element_id = element[id_field].replace(/\W/g,"");
+    }
+    return (this.getBaseId() + "-" + element_id).replace(/\./g,"-");
 };
 
 LocusZoom.DataLayer.prototype.onUpdate = function(){
@@ -168,13 +178,11 @@ LocusZoom.DataLayer.prototype.getAxisExtent = function(dimension){
 };
 
 // Generate a tool tip for a given element
-LocusZoom.DataLayer.prototype.createTooltip = function(d, id){
+LocusZoom.DataLayer.prototype.createTooltip = function(d){
     if (typeof this.layout.tooltip != "object"){
         throw ("DataLayer [" + this.id + "] layout does not define a tooltip");
     }
-    if (typeof id != "string"){
-        throw ("Unable to create tooltip: id is not a string");
-    }
+    var id = this.getElementId(d);
     if (this.tooltips[id]){
         this.positionTooltip(id);
         return;
@@ -182,16 +190,18 @@ LocusZoom.DataLayer.prototype.createTooltip = function(d, id){
     this.tooltips[id] = {
         data: d,
         arrow: null,
-        closed: false,
         selector: d3.select(this.parent.parent.svg.node().parentNode).append("div")
             .attr("class", "lz-data_layer-tooltip")
-            .attr("id", this.getBaseId() + ".tooltip." + id)
+            .attr("id", id + "-tooltip")
     };
     this.updateTooltip(d, id);
 };
 
 // Update a tool tip (generate its inner HTML)
 LocusZoom.DataLayer.prototype.updateTooltip = function(d, id){
+    if (typeof id == "undefined"){
+        var id = this.getElementId(d);
+    }
     // Empty the tooltip of all HTML (including its arrow!)
     this.tooltips[id].selector.html("");
     this.tooltips[id].arrow = null;
@@ -208,7 +218,7 @@ LocusZoom.DataLayer.prototype.updateTooltip = function(d, id){
             .attr("title", "Close")
             .html("×")
             .on("click", function(){
-                this.closeTooltip(id);
+                this.destroyTooltip(id);
             }.bind(this));
     }
     // Reposition and draw a new arrow
@@ -327,7 +337,7 @@ LocusZoom.DataLayer.prototype.showOrHideTooltip = function(d, id){
     // Only show tooltip if the resolved logic explicitly shows and explicitly not hides the tool tip
     // Otherwise ensure tooltip does not exist
     if (show_resolved && !hide_resolved){
-        this.createTooltip(d, id);
+        this.createTooltip(d);
     } else {
         this.destroyTooltip(id);
     }

--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -416,10 +416,13 @@ LocusZoom.StandardLayout = {
                         upper_buffer: 0.05,
                         min_extent: [ 0, 10 ]
                     },
-                    highlighted: "onmouseover",
+                    highlighted: {
+                        onmouseover: "on",
+                        onmouseout: "off"
+                    },
                     selected: {
-                        toggle: "onclick",
-                        allow_multiple: "onshiftclick"
+                        onclick: "toggle_exclusive",
+                        onshiftclick: "toggle"
                     },
                     tooltip: {
                         show: { or: ["highlighted", "selected"] },
@@ -447,9 +450,13 @@ LocusZoom.StandardLayout = {
                     type: "genes",
                     fields: ["gene:gene", "constraint:constraint"],
                     id_field: "gene_id",
-                    highlighted: "onmouseover",
+                    highlighted: {
+                        onmouseover: "on",
+                        onmouseout: "off"
+                    },
                     selected: {
-                        toggle: "onclick"
+                        onclick: "toggle_exclusive",
+                        onshiftclick: "toggle"
                     },
                     tooltip: {
                         show: { or: ["highlighted", "selected"] },

--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -416,8 +416,14 @@ LocusZoom.StandardLayout = {
                         upper_buffer: 0.05,
                         min_extent: [ 0, 10 ]
                     },
-                    selectable: "one",
+                    highlightable: "onmouseover",
+                    selectable: {
+                        toggle: "onclick",
+                        allow_multiple: "onshiftclick"
+                    },
                     tooltip: {
+                        show: { or: ["highlighted", "selected"] },
+                        hide: { and: ["unhighlighted", "unselected"] },
                         html: "<strong>{{id}}</strong><br>"
                             + "P Value: <strong>{{pvalue|scinotation}}</strong><br>"
                             + "Ref. Allele: <strong>{{refAllele}}</strong>"
@@ -441,8 +447,13 @@ LocusZoom.StandardLayout = {
                     type: "genes",
                     fields: ["gene:gene", "constraint:constraint"],
                     id_field: "gene_id",
-                    selectable: "one",
+                    highlightable: "onmouseover",
+                    selectable: {
+                        toggle: "onclick"
+                    },
                     tooltip: {
+                        show: { or: ["highlighted", "selected"] },
+                        hide: { and: ["unhighlighted", "unselected"] },
                         html: "<h4><strong><i>{{gene_name}}</i></strong></h4>"
                             + "<div style=\"float: left;\">Gene ID: <strong>{{gene_id}}</strong></div>"
                             + "<div style=\"float: right;\">Transcript ID: <strong>{{transcript_id}}</strong></div>"

--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -425,6 +425,7 @@ LocusZoom.StandardLayout = {
                         onshiftclick: "toggle"
                     },
                     tooltip: {
+                        closable: true,
                         show: { or: ["highlighted", "selected"] },
                         hide: { and: ["unhighlighted", "unselected"] },
                         html: "<strong>{{id}}</strong><br>"
@@ -459,6 +460,7 @@ LocusZoom.StandardLayout = {
                         onshiftclick: "toggle"
                     },
                     tooltip: {
+                        closable: true,
                         show: { or: ["highlighted", "selected"] },
                         hide: { and: ["unhighlighted", "unselected"] },
                         html: "<h4><strong><i>{{gene_name}}</i></strong></h4>"

--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -416,8 +416,8 @@ LocusZoom.StandardLayout = {
                         upper_buffer: 0.05,
                         min_extent: [ 0, 10 ]
                     },
-                    highlightable: "onmouseover",
-                    selectable: {
+                    highlighted: "onmouseover",
+                    selected: {
                         toggle: "onclick",
                         allow_multiple: "onshiftclick"
                     },
@@ -447,8 +447,8 @@ LocusZoom.StandardLayout = {
                     type: "genes",
                     fields: ["gene:gene", "constraint:constraint"],
                     id_field: "gene_id",
-                    highlightable: "onmouseover",
-                    selectable: {
+                    highlighted: "onmouseover",
+                    selected: {
                         toggle: "onclick"
                     },
                     tooltip: {

--- a/assets/js/app/Singletons.js
+++ b/assets/js/app/Singletons.js
@@ -755,7 +755,7 @@ LocusZoom.DataLayers.add("scatter", function(id, layout){
         selection.enter()
             .append("path")
             .attr("class", "lz-data_layer-scatter")
-            .attr("id", function(d){ return this.parent.id + "_" + d[this.layout.id_field].replace(/\W/g,""); }.bind(this));
+            .attr("id", function(d){ return this.getElementId(d); }.bind(this));
 
         // Generate new values (or functions for them) for position, color, size, and shape
         var transform = function(d) {
@@ -1221,7 +1221,7 @@ LocusZoom.DataLayers.add("genes", function(id, layout){
         selection.enter().append("g")
             .attr("class", "lz-data_layer-genes");
         
-        selection.attr("id", function(d){ return this.parent.id + "_" + d[this.layout.id_field].replace(/\W/g,""); }.bind(this))
+        selection.attr("id", function(d){ return this.getElementId(d); }.bind(this))
             .each(function(gene){
 
                 var data_layer = gene.parent;
@@ -1235,7 +1235,7 @@ LocusZoom.DataLayers.add("genes", function(id, layout){
 
                 bboxes
                     .attr("id", function(d){
-                        return data_layer.parent.id + "_" + d[data_layer.layout.id_field].replace(/\W/g,"") + "_bounding_box";
+                        return data_layer.getElementId(d) + "_bounding_box";
                     })
                     .attr("x", function(d){
                         return d.display_range.start;
@@ -1350,7 +1350,7 @@ LocusZoom.DataLayers.add("genes", function(id, layout){
 
                 clickareas
                     .attr("id", function(d){
-                        return data_layer.parent.id + "_" + d[data_layer.layout.id_field].replace(/\W/g,"") + "_clickarea";
+                        return data_layer.getElementId(d) + "_clickarea";
                     })
                     .attr("x", function(d){
                         return d.display_range.start;
@@ -1397,7 +1397,7 @@ LocusZoom.DataLayers.add("genes", function(id, layout){
         var stroke_width = 1; // as defined in the default stylesheet
         var page_origin = this.getPageOrigin();
         var tooltip_box = tooltip.selector.node().getBoundingClientRect();
-        var gene_bbox_id = this.parent.id + "_" + tooltip.data[this.layout.id_field].replace(/\W/g,"") + "_bounding_box";
+        var gene_bbox_id = this.getElementId(tooltip.data) + "_bounding_box";
         var gene_bbox = d3.select("#" + gene_bbox_id).node().getBBox();
         var data_layer_height = this.parent.layout.height - (this.parent.layout.margin.top + this.parent.layout.margin.bottom);
         var data_layer_width = this.parent.layout.width - (this.parent.layout.margin.left + this.parent.layout.margin.right);

--- a/assets/js/app/Singletons.js
+++ b/assets/js/app/Singletons.js
@@ -789,7 +789,7 @@ LocusZoom.DataLayers.add("scatter", function(id, layout){
         }
 
         // Apply selectable, tooltip, etc
-        this.enableTooltips(selection);
+        this.applyAllStatusBehaviors(selection);
 
         // Remove old elements as needed
         selection.exit().remove();
@@ -1375,7 +1375,7 @@ LocusZoom.DataLayers.add("genes", function(id, layout){
                 clickareas.exit().remove();
 
                 // Apply selectable, tooltip, etc to clickareas
-                data_layer.enableTooltips(clickareas);
+                data_layer.applyAllStatusBehaviors(clickareas);
 
             });
 

--- a/assets/js/app/Singletons.js
+++ b/assets/js/app/Singletons.js
@@ -1022,19 +1022,19 @@ LocusZoom.DataLayers.add("line", function(id, layout){
                     clearTimeout(data_layer.tooltip_timeout);
                     data_layer.mouse_event = this;
                     var dd = data_layer.getMouseDisplayAndData();
-                    data_layer.createTooltip(dd.data, data_layer.state_id);
+                    data_layer.createTooltip(dd.data);
                 })
                 .on("mousemove", function(){
                     clearTimeout(data_layer.tooltip_timeout);
                     data_layer.mouse_event = this;
                     var dd = data_layer.getMouseDisplayAndData();
-                    data_layer.updateTooltip(dd.data, data_layer.state_id);
-                    data_layer.positionTooltip(data_layer.state_id);
+                    data_layer.updateTooltip(dd.data);
+                    data_layer.positionTooltip(data_layer.getElementId());
                 })
                 .on("mouseout", function(){
                     data_layer.tooltip_timeout = setTimeout(function(){
                         data_layer.mouse_event = null;
-                        data_layer.destroyTooltip(data_layer.state_id);
+                        data_layer.destroyTooltip(data_layer.getElementId());
                     }, 300);
                 });
             hitarea.exit().remove();

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -448,8 +448,14 @@ LocusZoom.StandardLayout = {
                         upper_buffer: 0.05,
                         min_extent: [ 0, 10 ]
                     },
-                    selectable: "one",
+                    highlightable: "onmouseover",
+                    selectable: {
+                        toggle: "onclick",
+                        allow_multiple: "onshiftclick"
+                    },
                     tooltip: {
+                        show: { or: ["highlighted", "selected"] },
+                        hide: { and: ["unhighlighted", "unselected"] },
                         html: "<strong>{{id}}</strong><br>"
                             + "P Value: <strong>{{pvalue|scinotation}}</strong><br>"
                             + "Ref. Allele: <strong>{{refAllele}}</strong>"
@@ -473,8 +479,13 @@ LocusZoom.StandardLayout = {
                     type: "genes",
                     fields: ["gene:gene", "constraint:constraint"],
                     id_field: "gene_id",
-                    selectable: "one",
+                    highlightable: "onmouseover",
+                    selectable: {
+                        toggle: "onclick"
+                    },
                     tooltip: {
+                        show: { or: ["highlighted", "selected"] },
+                        hide: { and: ["unhighlighted", "unselected"] },
                         html: "<h4><strong><i>{{gene_name}}</i></strong></h4>"
                             + "<div style=\"float: left;\">Gene ID: <strong>{{gene_id}}</strong></div>"
                             + "<div style=\"float: right;\">Transcript ID: <strong>{{transcript_id}}</strong></div>"
@@ -523,6 +534,9 @@ LocusZoom.DataLayer = function(id, layout, parent) {
         this.state = this.parent.state;
         this.state_id = this.parent.id + "." + this.id;
         this.state[this.state_id] = this.state[this.state_id] || {};
+        if (this.layout.highlightable){
+            this.state[this.state_id].highlighted = this.state[this.state_id].highlighted || [];
+        }
         if (this.layout.selectable){
             this.state[this.state_id].selected = this.state[this.state_id].selected || [];
         }
@@ -531,253 +545,9 @@ LocusZoom.DataLayer = function(id, layout, parent) {
         this.state_id = null;
     }
 
+    // Initialize parameters for storing data and tool tips
     this.data = [];
-
-    this.getBaseId = function(){
-        return this.parent.parent.id + "." + this.parent.id + "." + this.id;
-    };
-
-    this.onUpdate = function(){
-        this.parent.onUpdate();
-    };
-
-    // Tooltip methods
     this.tooltips = {};
-    this.createTooltip = function(d, id){
-        if (typeof this.layout.tooltip != "object"){
-            throw ("DataLayer [" + this.id + "] layout does not define a tooltip");
-        }
-        if (typeof id != "string"){
-            throw ("Unable to create tooltip: id is not a string");
-        }
-        if (this.tooltips[id]){
-            this.positionTooltip(id);
-            return;
-        }
-        this.tooltips[id] = {
-            data: d,
-            arrow: null,
-            closed: false,
-            selector: d3.select(this.parent.parent.svg.node().parentNode).append("div")
-                .attr("class", "lz-data_layer-tooltip")
-                .attr("id", this.getBaseId() + ".tooltip." + id)
-        };
-        this.updateTooltip(d, id);
-    };
-    this.updateTooltip = function(d, id){
-        // Empty the tooltip of all HTML (including its arrow!)
-        this.tooltips[id].selector.html("");
-        this.tooltips[id].arrow = null;
-        // Set the new HTML
-        if (this.layout.tooltip.html){
-            this.tooltips[id].selector.html(LocusZoom.parseFields(d, this.layout.tooltip.html));
-        }
-        // If the layout allows tool tips on this data layer to be closable then add the close button
-        // and add padding to the tooltip to accomodate it
-        if (this.layout.tooltip.closable){
-            this.tooltips[id].selector.style("padding-right", "24px");
-            this.tooltips[id].selector.append("a")
-                .attr("class", "lz-tooltip-close-button")
-                .attr("title", "Close")
-                .html("×")
-                .on("click", function(){
-                    this.closeTooltip(id);
-                }.bind(this));
-        }
-        // Reposition and draw a new arrow
-        this.positionTooltip(id);
-    };
-    // Close tool tip - hide the tool tip element and flag it as closed, but don't destroy it
-    this.closeTooltip = function(id){
-        if (typeof id != "string"){
-            throw ("Unable to close tooltip: id is not a string");
-        }
-        if (this.tooltips[id]){
-            if (typeof this.tooltips[id].selector == "object"){
-                this.tooltips[id].selector.style("display", "none");
-            }
-            this.tooltips[id].closed = true;
-        }
-    };
-    // Unclose tool tip - reveal and position a previously closed tool tip (rather than creating it anew)
-    this.uncloseTooltip = function(id){
-        if (typeof id != "string"){
-            throw ("Unable to unclose tooltip: id is not a string");
-        }
-        if (this.tooltips[id] && this.tooltips[id].closed){
-            if (typeof this.tooltips[id].selector == "object"){
-                this.tooltips[id].selector.style("display", null);
-            }
-            this.positionTooltip(id);
-            this.tooltips[id].closed = false;
-        }
-    };
-    // Destroy tool tip - remove the tool tip element from the DOM and delete the tool tip's record on the data layer
-    this.destroyTooltip = function(id){
-        if (typeof id != "string"){
-            throw ("Unable to destroy tooltip: id is not a string");
-        }
-        if (this.tooltips[id]){
-            if (typeof this.tooltips[id].selector == "object"){
-                this.tooltips[id].selector.remove();
-            }
-            delete this.tooltips[id];
-        }
-    };
-    this.destroyAllTooltips = function(){
-        var id;
-        for (id in this.tooltips){
-            this.destroyTooltip(id);
-        }
-    };
-    // Position tool tip - naive function to place a tool tip to the lower right of the current mouse element
-    // Most data layers reimplement this method to position tool tips specifically for the data they display
-    this.positionTooltip = function(id){
-        if (typeof id != "string"){
-            throw ("Unable to position tooltip: id is not a string");
-        }
-        // Position the div itself
-        this.tooltips[id].selector
-            .style("left", (d3.event.pageX) + "px")
-            .style("top", (d3.event.pageY) + "px");
-        // Create / update position on arrow connecting tooltip to data
-        if (!this.tooltips[id].arrow){
-            this.tooltips[id].arrow = this.tooltips[id].selector.append("div")
-                .style("position", "absolute")
-                .attr("class", "lz-data_layer-tooltip-arrow_top_left");
-        }
-        this.tooltips[id].arrow
-            .style("left", "-1px")
-            .style("top", "-1px");
-    };
-    this.positionAllTooltips = function(){
-        var id;
-        for (id in this.tooltips){
-            this.positionTooltip(id);
-        }
-    };
-
-    // Standard approach to applying unit-based selectability and general tooltip behavior (one and/or multiple)
-    // on a selection of data elements
-    this.enableTooltips = function(selection){
-        
-        if (typeof selection != "object"){ return; }
-        if (!this.layout.id_field){
-            console.warn("Data layer " + this.id + " tried to enable tooltips but does not have a valid id_field defined in the layout");
-            return;
-        }
-        
-        // Enable mouseover/mouseout tooltip show/hide behavior
-        selection.on("mouseover", function(d){
-            var id = this.parent.id + "_" + d[this.layout.id_field].replace(/\W/g,"");
-            var select_id = id;
-            var attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-hovered";
-            if (this.layout.hover_element){
-                select_id += "_" + this.layout.hover_element;
-                attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element + "-hovered";
-            }
-            if (this.state[this.state_id].selected.indexOf(id) == -1){
-                d3.select("#" + select_id).attr("class", attr_class);
-                if (this.layout.tooltip){ this.createTooltip(d, id); }
-            }
-        }.bind(this))
-        .on("mouseout", function(d){
-            var id = this.parent.id + "_" + d[this.layout.id_field].replace(/\W/g,"");
-            var select_id = id;
-            var attr_class = "lz-data_layer-" + this.layout.type;
-            if (this.layout.hover_element){
-                select_id += "_" + this.layout.hover_element;
-                attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element;
-            }
-            if (this.state[this.state_id].selected.indexOf(id) == -1){
-                d3.select("#" + select_id).attr("class", attr_class);
-                if (this.layout.tooltip){ this.destroyTooltip(id); }
-            }
-        }.bind(this));
-        
-        if (this.layout.selectable){
-
-            var select_id, attr_class;
-            
-            // Enable selectability
-            selection.on("click", function(d){
-                var id = this.parent.id + "_" + d[this.layout.id_field].replace(/\W/g,"");
-                var selected_idx = this.state[this.state_id].selected.indexOf(id);
-                // If this element IS currently selected...
-                if (selected_idx != -1){
-                    // If in selectable:multiple mode and this tooltip was closed then unclose it and be done
-                    if (this.layout.selectable == "multiple" && this.tooltips[id] && this.tooltips[id].closed){
-                        this.uncloseTooltip(id);
-                    // Otherwise unselect the element but leave the tool tip in place (to be destroyed on mouse out)
-                    } else {
-                        this.state[this.state_id].selected.splice(selected_idx, 1);
-                        select_id = id;
-                        attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-hovered";
-                        if (this.layout.hover_element){
-                            select_id += "_" + this.layout.hover_element;
-                            attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element + "-hovered";
-                        }
-                        d3.select("#" + select_id).attr("class", attr_class);
-                    }
-
-                // If this element IS NOT currently selected...
-                } else {
-                    // If in selectable:one mode then deselect any current selection
-                    if (this.layout.selectable == "one" && this.state[this.state_id].selected.length){
-                        this.destroyTooltip(this.state[this.state_id].selected[0]);
-                        select_id = this.state[this.state_id].selected[0];
-                        attr_class = "lz-data_layer-" + this.layout.type;
-                        if (this.layout.hover_element){
-                            select_id += "_" + this.layout.hover_element;
-                            attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element;
-                        }
-                        d3.select("#" + select_id).attr("class", attr_class);
-                        this.state[this.state_id].selected = [];
-                    }
-                    // Select the clicked element    
-                    this.state[this.state_id].selected.push(id);
-                    select_id = id;
-                    attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-selected";
-                    if (this.layout.hover_element){
-                        select_id += "_" + this.layout.hover_element;
-                        attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element + "-selected";
-                    }
-                    d3.select("#" + select_id).attr("class", attr_class);
-                }
-                this.onUpdate();
-            }.bind(this));
-
-            // Apply existing elements from state
-            if (Array.isArray(this.state[this.state_id].selected) && this.state[this.state_id].selected.length){
-                this.state[this.state_id].selected.forEach(function(selected_id, idx){
-                    if (d3.select("#" + selected_id).empty()){
-                        console.warn("State elements for " + this.state_id + " contains an ID that is not or is no longer present on the plot: " + selected_id);
-                        this.state[this.state_id].selected.splice(idx, 1);
-                    } else {
-                        if (this.tooltips[selected_id] && !this.tooltips[selected_id].closed){
-                            this.positionTooltip(selected_id);
-                        } else {
-                            this.state[this.state_id].selected.splice(idx, 1);
-                            var d = d3.select("#" + selected_id).datum();
-                            d3.select("#" + selected_id).on("mouseover")(d);
-                            d3.select("#" + selected_id).on("click")(d);
-                        }
-                    }
-                }.bind(this));
-            }
-            
-        }
-    };
-
-    // Get an object with the x and y coordinates of the panel's origin in terms of the entire page
-    // Necessary for positioning any HTML elements over the panel
-    this.getPageOrigin = function(){
-        var panel_origin = this.parent.getPageOrigin();
-        return {
-            x: panel_origin.x + this.parent.layout.margin.left,
-            y: panel_origin.y + this.parent.layout.margin.top
-        };
-    };
     
     return this;
 
@@ -787,7 +557,43 @@ LocusZoom.DataLayer.DefaultLayout = {
     type: "",
     fields: [],
     x_axis: {},
-    y_axis: {}
+    y_axis: {},
+    highlightable: "onmouseover",
+    selectable: false,
+    tooltip: false
+};
+
+LocusZoom.DataLayer.prototype.getBaseId = function(){
+    return this.parent.parent.id + "." + this.parent.id + "." + this.id;
+};
+
+LocusZoom.DataLayer.prototype.getElementId = function(element){
+    return this.getBaseId() + "." + element[this.layout.id_field].replace(/\W/g,"");
+};
+
+LocusZoom.DataLayer.prototype.onUpdate = function(){
+    this.parent.onUpdate();
+};
+
+// Initialize a data layer
+LocusZoom.DataLayer.prototype.initialize = function(){
+
+    // Append a container group element to house the main data layer group element and the clip path
+    this.svg.container = this.parent.svg.group.append("g")
+        .attr("id", this.getBaseId() + ".data_layer_container");
+        
+    // Append clip path to the container element
+    this.svg.clipRect = this.svg.container.append("clipPath")
+        .attr("id", this.getBaseId() + ".clip")
+        .append("rect");
+    
+    // Append svg group for rendering all data layer elements, clipped by the clip path
+    this.svg.group = this.svg.container.append("g")
+        .attr("id", this.getBaseId() + ".data_layer")
+        .attr("clip-path", "url(#" + this.getBaseId() + ".clip)");
+
+    return this;
+
 };
 
 // Resolve a scalable parameter for an element into a single value based on its layout and the element's data
@@ -868,26 +674,417 @@ LocusZoom.DataLayer.prototype.getAxisExtent = function(dimension){
 
 };
 
-// Initialize a data layer
-LocusZoom.DataLayer.prototype.initialize = function(){
-
-    // Append a container group element to house the main data layer group element and the clip path
-    this.svg.container = this.parent.svg.group.append("g")
-        .attr("id", this.getBaseId() + ".data_layer_container");
-        
-    // Append clip path to the container element
-    this.svg.clipRect = this.svg.container.append("clipPath")
-        .attr("id", this.getBaseId() + ".clip")
-        .append("rect");
-    
-    // Append svg group for rendering all data layer elements, clipped by the clip path
-    this.svg.group = this.svg.container.append("g")
-        .attr("id", this.getBaseId() + ".data_layer")
-        .attr("clip-path", "url(#" + this.getBaseId() + ".clip)");
-
-    return this;
-
+// Generate a tool tip for a given element
+LocusZoom.DataLayer.prototype.createTooltip = function(d, id){
+    if (typeof this.layout.tooltip != "object"){
+        throw ("DataLayer [" + this.id + "] layout does not define a tooltip");
+    }
+    if (typeof id != "string"){
+        throw ("Unable to create tooltip: id is not a string");
+    }
+    if (this.tooltips[id]){
+        this.positionTooltip(id);
+        return;
+    }
+    this.tooltips[id] = {
+        data: d,
+        arrow: null,
+        closed: false,
+        selector: d3.select(this.parent.parent.svg.node().parentNode).append("div")
+            .attr("class", "lz-data_layer-tooltip")
+            .attr("id", this.getBaseId() + ".tooltip." + id)
+    };
+    this.updateTooltip(d, id);
 };
+
+// Update a tool tip (generate its inner HTML)
+LocusZoom.DataLayer.prototype.updateTooltip = function(d, id){
+    // Empty the tooltip of all HTML (including its arrow!)
+    this.tooltips[id].selector.html("");
+    this.tooltips[id].arrow = null;
+    // Set the new HTML
+    if (this.layout.tooltip.html){
+        this.tooltips[id].selector.html(LocusZoom.parseFields(d, this.layout.tooltip.html));
+    }
+    // If the layout allows tool tips on this data layer to be closable then add the close button
+    // and add padding to the tooltip to accomodate it
+    if (this.layout.tooltip.closable){
+        this.tooltips[id].selector.style("padding-right", "24px");
+        this.tooltips[id].selector.append("a")
+            .attr("class", "lz-tooltip-close-button")
+            .attr("title", "Close")
+            .html("×")
+            .on("click", function(){
+                this.closeTooltip(id);
+            }.bind(this));
+    }
+    // Reposition and draw a new arrow
+    this.positionTooltip(id);
+};
+
+// Close tool tip - hide the tool tip element and flag it as closed, but don't destroy it
+LocusZoom.DataLayer.prototype.closeTooltip = function(id){
+    if (typeof id != "string"){
+        throw ("Unable to close tooltip: id is not a string");
+    }
+    if (this.tooltips[id]){
+        if (typeof this.tooltips[id].selector == "object"){
+            this.tooltips[id].selector.style("display", "none");
+        }
+        this.tooltips[id].closed = true;
+    }
+};
+
+// Unclose tool tip - reveal and position a previously closed tool tip (rather than creating it anew)
+LocusZoom.DataLayer.prototype.uncloseTooltip = function(id){
+    if (typeof id != "string"){
+        throw ("Unable to unclose tooltip: id is not a string");
+    }
+    if (this.tooltips[id] && this.tooltips[id].closed){
+        if (typeof this.tooltips[id].selector == "object"){
+            this.tooltips[id].selector.style("display", null);
+        }
+        this.positionTooltip(id);
+        this.tooltips[id].closed = false;
+    }
+};
+
+// Destroy tool tip - remove the tool tip element from the DOM and delete the tool tip's record on the data layer
+LocusZoom.DataLayer.prototype.destroyTooltip = function(id){
+    if (typeof id != "string"){
+        throw ("Unable to destroy tooltip: id is not a string");
+    }
+    if (this.tooltips[id]){
+        if (typeof this.tooltips[id].selector == "object"){
+            this.tooltips[id].selector.remove();
+        }
+        delete this.tooltips[id];
+    }
+};
+
+// Loop through and destroy all tool tips on this data layer
+LocusZoom.DataLayer.prototype.destroyAllTooltips = function(){
+    for (var id in this.tooltips){
+        this.destroyTooltip(id);
+    }
+};
+
+// Position tool tip - naive function to place a tool tip to the lower right of the current mouse element
+// Most data layers reimplement this method to position tool tips specifically for the data they display
+LocusZoom.DataLayer.prototype.positionTooltip = function(id){
+    if (typeof id != "string"){
+        throw ("Unable to position tooltip: id is not a string");
+    }
+    // Position the div itself
+    this.tooltips[id].selector
+        .style("left", (d3.event.pageX) + "px")
+        .style("top", (d3.event.pageY) + "px");
+    // Create / update position on arrow connecting tooltip to data
+    if (!this.tooltips[id].arrow){
+        this.tooltips[id].arrow = this.tooltips[id].selector.append("div")
+            .style("position", "absolute")
+            .attr("class", "lz-data_layer-tooltip-arrow_top_left");
+    }
+    this.tooltips[id].arrow
+        .style("left", "-1px")
+        .style("top", "-1px");
+};
+
+// Loop through and position all tool tips on this data layer
+LocusZoom.DataLayer.prototype.positionAllTooltips = function(){
+    for (var id in this.tooltips){
+        this.positionTooltip(id);
+    }
+};
+
+// Show or hide a tool tip by ID depending on directives in the layout and state values relative to the ID
+LocusZoom.DataLayer.prototype.showOrHideTooltip = function(id){
+    
+    if (typeof this.layout.tooltip != "object"){ return; }
+
+    var resolveStatus = function(element, directive, operator){
+        var status = null;
+        if (typeof element != "object" || element == null){ return null; }
+        if (typeof directive == "object"){
+            var sub_status;
+            for (var sub_operator in directive){
+                sub_status = resolveStatus(element, directive[sub_operator], sub_operator);
+                if (status == null){
+                    status = sub_status;
+                } else if (operator == "and"){
+                    status = status && sub_status;
+                } else if (operator == "or"){
+                    status = status || sub_status;
+                }
+            }
+        } else if (typeof directive == "array"){
+            if (typeof operator == "undefined"){ operator = "and"; }
+            if (directive.length == 1){
+                status = element[directive[0]];
+            } else {
+                status = directive.reduce(function(previousValue, currentValue) {
+                    if (operator == "and"){
+                        return previousValue && currentValue;
+                    } else if (operator == "or"){
+                        return previousValue || currentValue;
+                    }
+                    return null;
+                });
+            }
+        }
+        return status;
+    };
+
+    var show_directive = {};
+    if (typeof this.layout.tooltip.show == "string"){
+        show_directive = { and: [ this.layout.tooltip.show ] };
+    } else if (typeof this.layout.tooltip.show == "object"){
+        show_directive = this.layout.tooltip.show;
+    }
+
+    var hide_directive = {};
+    if (typeof this.layout.tooltip.hide == "string"){
+        hide_directive = { and: [ this.layout.tooltip.hide ] };
+    } else if (typeof this.layout.tooltip.hide == "object"){
+        hide_directive = this.layout.tooltip.hide;
+    }
+
+    var element = {};
+    element.highlighted = this.state[this.state_id].highlighted.indexOf(id) != -1;
+    element.unhighlighted = !element.highlighted;
+    element.selected = this.state[this.state_id].selected.indexOf(id) != -1;
+    element.unselected = !element.selected;
+
+    var show_resolved = resolveStatus(element, show_directive);
+    var hide_resolved = resolveStatus(element, hide_directive);
+
+    // Only show tooltip if the resolved logic explicitly shows and explicitly not hides the tool tip
+    var show_tooltip = show_resolved && !hide_resolved;
+    
+    // ...
+};
+
+// Toggle the highlighted status of an element
+LocusZoom.DataLayer.prototype.highlightElement = function(id, toggle){
+    if (typeof toggle == "undefined"){ var toggle = true; }
+    // Set/unset the highlight class on the appropriate DOM element
+    var highlight_element_id = id;
+    var attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-hovered";
+    if (this.layout.hover_element){
+        highlight_element_id += "_" + this.layout.hover_element;
+        attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element + "-hovered";
+    }
+    d3.select("#" + highlight_element_id).classed(attr_class, toggle);
+    // Track element ID in highlighted state array
+    var highlighted_idx = this.state[this.state_id].highlighted.indexOf(id);
+    if (toggle && highlighted_idx == -1){
+        this.state[this.state_id].highlighted.push(id);
+    }
+    if (!toggle && highlighted_idx != -1){
+        this.state[this.state_id].highlighted.splice(highlighted_idx, 1);
+    }
+    // Trigger tool tip show/hide logic
+    this.showOrHideTooltip(id);
+};
+LocusZoom.DataLayer.prototype.unhighlightElement = function(id){
+    this.highlightElement(id, false);
+};
+
+// Toggle the highlighted status of all elements
+LocusZoom.DataLayer.prototype.highlightAllElements = function(toggle){
+    if (typeof toggle == "undefined"){ var toggle = true; }
+    if (toggle){
+        this.data.forEach(function(element){
+            var id = this.getElementId(element);
+            if (this.state[this.state_id].highlighted.indexOf(id) == -1){
+                this.highlightElement(id, true);
+            }
+        }.bind(this));
+    } else {
+        var highlighted_ids = this.state[this.state_id].highlighted.slice();
+        console.log(highlighted_ids);
+        highlighted_ids.forEach(function(id){
+            console.log("unhighlighting: ", id);
+            this.highlightElement(id, false);
+        }.bind(this));
+    }
+};
+LocusZoom.DataLayer.prototype.unhighlightAllElements = function(){
+    this.highlightAllElements(false);
+}
+
+// Toggle the selection status of an element
+LocusZoom.DataLayer.prototype.selectElement = function(id, toggle){
+    if (typeof toggle == "undefined"){ var toggle = true; }
+    // ...
+};
+// Toggle the selected status of all elements
+LocusZoom.DataLayer.prototype.selectAllElements = function(toggle){
+    if (typeof toggle == "undefined"){ var toggle = true; }
+    this.state[this.state_id].selected.forEach(function(id){
+        this.selectElement(id, toggle);
+    }.bind(this));
+};
+LocusZoom.DataLayer.prototype.unselectAllElements = function(){
+    this.selectAllElements(false);
+};
+
+// Apply element highlight behavior from directives in the layout
+LocusZoom.DataLayer.prototype.applyHighlight = function(selection){
+    
+    if (this.layout.highlight == "onmouseover"){
+        
+        // Sanity checks: valid d3 selection and defined ID field
+        if (typeof selection != "object"){
+            console.warn("Data layer " + this.id + " tried to apply highlight behavior but valid d3 selection not supplied");
+            return;
+        }
+        if (!this.layout.id_field){
+            console.warn("Data layer " + this.id + " tried to apply highlight behavior but valid id_field not defined in the layout");
+            return;
+        }
+        
+        // Bind mouse events
+        selection
+            .on("mouseover", function(){
+                var id = this.parent.id + "_" + d[this.layout.id_field].replace(/\W/g,"");
+                this.highlightElement(id, true);
+            }.bind(this))
+            .on("mouseout", function(){
+                var id = this.parent.id + "_" + d[this.layout.id_field].replace(/\W/g,"");
+                this.highlightElement(id, false);
+            }.bind(this));
+        
+    }
+    
+};
+
+// Apply element selectability behavior from directives in the layout
+LocusZoom.DataLayer.prototype.applySelectability = function(selection){
+};
+
+// Standard approach to applying unit-based selectability and general tooltip behavior (one and/or multiple)
+// on a selection of data elements
+LocusZoom.DataLayer.prototype.enableTooltips = function(selection){
+
+    if (typeof selection != "object"){ return; }
+    if (!this.layout.id_field){
+        console.warn("Data layer " + this.id + " tried to enable tooltips but does not have a valid id_field defined in the layout");
+        return;
+    }
+    
+    // Enable mouseover/mouseout tooltip show/hide behavior
+    selection.on("mouseover", function(d){
+        var id = this.parent.id + "_" + d[this.layout.id_field].replace(/\W/g,"");
+        var select_id = id;
+        var attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-hovered";
+        if (this.layout.hover_element){
+            select_id += "_" + this.layout.hover_element;
+            attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element + "-hovered";
+        }
+        if (this.state[this.state_id].selected.indexOf(id) == -1){
+            d3.select("#" + select_id).attr("class", attr_class);
+            if (this.layout.tooltip){ this.createTooltip(d, id); }
+        }
+    }.bind(this))
+        .on("mouseout", function(d){
+            var id = this.parent.id + "_" + d[this.layout.id_field].replace(/\W/g,"");
+            var select_id = id;
+            var attr_class = "lz-data_layer-" + this.layout.type;
+            if (this.layout.hover_element){
+                select_id += "_" + this.layout.hover_element;
+                attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element;
+            }
+            if (this.state[this.state_id].selected.indexOf(id) == -1){
+                d3.select("#" + select_id).attr("class", attr_class);
+                if (this.layout.tooltip){ this.destroyTooltip(id); }
+            }
+        }.bind(this));
+    
+    if (this.layout.selectable){
+
+        var select_id, attr_class;
+        
+        // Enable selectability
+        selection.on("click", function(d){
+            var id = this.parent.id + "_" + d[this.layout.id_field].replace(/\W/g,"");
+            var selected_idx = this.state[this.state_id].selected.indexOf(id);
+            // If this element IS currently selected...
+            if (selected_idx != -1){
+                // If in selectable:multiple mode and this tooltip was closed then unclose it and be done
+                if (this.layout.selectable == "multiple" && this.tooltips[id] && this.tooltips[id].closed){
+                    this.uncloseTooltip(id);
+                    // Otherwise unselect the element but leave the tool tip in place (to be destroyed on mouse out)
+                } else {
+                    this.state[this.state_id].selected.splice(selected_idx, 1);
+                    select_id = id;
+                    attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-hovered";
+                    if (this.layout.hover_element){
+                        select_id += "_" + this.layout.hover_element;
+                        attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element + "-hovered";
+                    }
+                    d3.select("#" + select_id).attr("class", attr_class);
+                }
+
+                // If this element IS NOT currently selected...
+            } else {
+                // If in selectable:one mode then deselect any current selection
+                if (this.layout.selectable == "one" && this.state[this.state_id].selected.length){
+                    this.destroyTooltip(this.state[this.state_id].selected[0]);
+                    select_id = this.state[this.state_id].selected[0];
+                    attr_class = "lz-data_layer-" + this.layout.type;
+                    if (this.layout.hover_element){
+                        select_id += "_" + this.layout.hover_element;
+                        attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element;
+                    }
+                    d3.select("#" + select_id).attr("class", attr_class);
+                    this.state[this.state_id].selected = [];
+                }
+                // Select the clicked element    
+                this.state[this.state_id].selected.push(id);
+                select_id = id;
+                attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-selected";
+                if (this.layout.hover_element){
+                    select_id += "_" + this.layout.hover_element;
+                    attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element + "-selected";
+                }
+                d3.select("#" + select_id).attr("class", attr_class);
+            }
+            this.onUpdate();
+        }.bind(this));
+
+        // Apply existing elements from state
+        if (Array.isArray(this.state[this.state_id].selected) && this.state[this.state_id].selected.length){
+            this.state[this.state_id].selected.forEach(function(selected_id, idx){
+                if (d3.select("#" + selected_id).empty()){
+                    console.warn("State elements for " + this.state_id + " contains an ID that is not or is no longer present on the plot: " + selected_id);
+                    this.state[this.state_id].selected.splice(idx, 1);
+                } else {
+                    if (this.tooltips[selected_id] && !this.tooltips[selected_id].closed){
+                        this.positionTooltip(selected_id);
+                    } else {
+                        this.state[this.state_id].selected.splice(idx, 1);
+                        var d = d3.select("#" + selected_id).datum();
+                        d3.select("#" + selected_id).on("mouseover")(d);
+                        d3.select("#" + selected_id).on("click")(d);
+                    }
+                }
+            }.bind(this));
+        }
+        
+    }
+};
+
+// Get an object with the x and y coordinates of the panel's origin in terms of the entire page
+// Necessary for positioning any HTML elements over the panel
+LocusZoom.DataLayer.prototype.getPageOrigin = function(){
+    var panel_origin = this.parent.getPageOrigin();
+    return {
+        x: panel_origin.x + this.parent.layout.margin.left,
+        y: panel_origin.y + this.parent.layout.margin.top
+    };
+};
+
 
 LocusZoom.DataLayer.prototype.draw = function(){
     this.svg.container.attr("transform", "translate(" + this.parent.layout.cliparea.origin.x +  "," + this.parent.layout.cliparea.origin.y + ")");
@@ -1671,7 +1868,7 @@ LocusZoom.DataLayers.add("scatter", function(id, layout){
         selection.enter()
             .append("path")
             .attr("class", "lz-data_layer-scatter")
-            .attr("id", function(d){ return this.parent.id + "_" + d[this.layout.id_field].replace(/\W/g,""); }.bind(this));
+            .attr("id", function(d){ return this.getElementId(d); }.bind(this));
 
         // Generate new values (or functions for them) for position, color, size, and shape
         var transform = function(d) {
@@ -2137,7 +2334,7 @@ LocusZoom.DataLayers.add("genes", function(id, layout){
         selection.enter().append("g")
             .attr("class", "lz-data_layer-genes");
         
-        selection.attr("id", function(d){ return this.parent.id + "_" + d[this.layout.id_field].replace(/\W/g,""); }.bind(this))
+        selection.attr("id", function(d){ return this.getElementId(d); }.bind(this))
             .each(function(gene){
 
                 var data_layer = gene.parent;
@@ -2151,7 +2348,7 @@ LocusZoom.DataLayers.add("genes", function(id, layout){
 
                 bboxes
                     .attr("id", function(d){
-                        return data_layer.parent.id + "_" + d[data_layer.layout.id_field].replace(/\W/g,"") + "_bounding_box";
+                        return data_layer.getElementId(d) + "_bounding_box";
                     })
                     .attr("x", function(d){
                         return d.display_range.start;
@@ -2266,7 +2463,7 @@ LocusZoom.DataLayers.add("genes", function(id, layout){
 
                 clickareas
                     .attr("id", function(d){
-                        return data_layer.parent.id + "_" + d[data_layer.layout.id_field].replace(/\W/g,"") + "_clickarea";
+                        return data_layer.getElementId(d) + "_clickarea";
                     })
                     .attr("x", function(d){
                         return d.display_range.start;
@@ -2313,7 +2510,7 @@ LocusZoom.DataLayers.add("genes", function(id, layout){
         var stroke_width = 1; // as defined in the default stylesheet
         var page_origin = this.getPageOrigin();
         var tooltip_box = tooltip.selector.node().getBoundingClientRect();
-        var gene_bbox_id = this.parent.id + "_" + tooltip.data[this.layout.id_field].replace(/\W/g,"") + "_bounding_box";
+        var gene_bbox_id = this.getElementId(tooltip.data) + "_bounding_box";
         var gene_bbox = d3.select("#" + gene_bbox_id).node().getBBox();
         var data_layer_height = this.parent.layout.height - (this.parent.layout.margin.top + this.parent.layout.margin.bottom);
         var data_layer_width = this.parent.layout.width - (this.parent.layout.margin.left + this.parent.layout.margin.right);

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -582,12 +582,22 @@ LocusZoom.DataLayer.prototype.getElementId = function(element){
     } else if (typeof element == "object"){
         var id_field = this.layout.id_field || "id";
         if (typeof element[id_field] == "undefined"){
+            console.log("here", id_field, element);
             throw("Unable to generate element ID");
         }
         element_id = element[id_field].replace(/\W/g,"");
     }
-    return (this.getBaseId() + "-" + element_id).replace(/\./g,"-");
+    return (this.getBaseId() + "-" + element_id).replace(/(:|\.|\[|\]|,)/g, "_");
 };
+
+LocusZoom.DataLayer.prototype.getElementById = function(id){
+    var selector = d3.select("#" + id.replace(/(:|\.|\[|\]|,)/g, "\\$1"));
+    if (!selector.empty() && selector.data() && selector.data().length){
+        return selector.data()[0];
+    } else {
+        return null;
+    }
+}
 
 LocusZoom.DataLayer.prototype.onUpdate = function(){
     this.parent.onUpdate();
@@ -693,11 +703,11 @@ LocusZoom.DataLayer.prototype.getAxisExtent = function(dimension){
 };
 
 // Generate a tool tip for a given element
-LocusZoom.DataLayer.prototype.createTooltip = function(d){
+LocusZoom.DataLayer.prototype.createTooltip = function(d, id){
     if (typeof this.layout.tooltip != "object"){
         throw ("DataLayer [" + this.id + "] layout does not define a tooltip");
     }
-    var id = this.getElementId(d);
+    if (typeof id == "undefined"){ var id = this.getElementId(d); }
     if (this.tooltips[id]){
         this.positionTooltip(id);
         return;
@@ -709,14 +719,12 @@ LocusZoom.DataLayer.prototype.createTooltip = function(d){
             .attr("class", "lz-data_layer-tooltip")
             .attr("id", id + "-tooltip")
     };
-    this.updateTooltip(d, id);
+    this.updateTooltip(d);
 };
 
 // Update a tool tip (generate its inner HTML)
 LocusZoom.DataLayer.prototype.updateTooltip = function(d, id){
-    if (typeof id == "undefined"){
-        var id = this.getElementId(d);
-    }
+    if (typeof id == "undefined"){ var id = this.getElementId(d); }
     // Empty the tooltip of all HTML (including its arrow!)
     this.tooltips[id].selector.html("");
     this.tooltips[id].arrow = null;
@@ -741,9 +749,11 @@ LocusZoom.DataLayer.prototype.updateTooltip = function(d, id){
 };
 
 // Destroy tool tip - remove the tool tip element from the DOM and delete the tool tip's record on the data layer
-LocusZoom.DataLayer.prototype.destroyTooltip = function(id){
-    if (typeof id != "string"){
-        throw ("Unable to destroy tooltip: id is not a string");
+LocusZoom.DataLayer.prototype.destroyTooltip = function(d, id){
+    if (typeof d == "string"){
+        id = d;
+    } else if (typeof id == "undefined"){
+        var id = this.getElementId(d);
     }
     if (this.tooltips[id]){
         if (typeof this.tooltips[id].selector == "object"){
@@ -789,23 +799,24 @@ LocusZoom.DataLayer.prototype.positionAllTooltips = function(){
 };
 
 // Show or hide a tool tip by ID depending on directives in the layout and state values relative to the ID
-LocusZoom.DataLayer.prototype.showOrHideTooltip = function(d, id){
+LocusZoom.DataLayer.prototype.showOrHideTooltip = function(element){
     
     if (typeof this.layout.tooltip != "object"){ return; }
+    var id = this.getElementId(element);
 
-    var resolveStatus = function(element, directive, operator){
+    var resolveStatus = function(statuses, directive, operator){
         var status = null;
-        if (typeof element != "object" || element == null){ return null; }
+        if (typeof statuses != "object" || statuses == null){ return null; }
         if (Array.isArray(directive)){
             if (typeof operator == "undefined"){ operator = "and"; }
             if (directive.length == 1){
-                status = element[directive[0]];
+                status = statuses[directive[0]];
             } else {
                 status = directive.reduce(function(previousValue, currentValue) {
                     if (operator == "and"){
-                        return element[previousValue] && element[currentValue];
+                        return statuses[previousValue] && statuses[currentValue];
                     } else if (operator == "or"){
-                        return element[previousValue] || element[currentValue];
+                        return statuses[previousValue] || statuses[currentValue];
                     }
                     return null;
                 });
@@ -813,7 +824,7 @@ LocusZoom.DataLayer.prototype.showOrHideTooltip = function(d, id){
         } else if (typeof directive == "object"){
             var sub_status;
             for (var sub_operator in directive){
-                sub_status = resolveStatus(element, directive[sub_operator], sub_operator);
+                sub_status = resolveStatus(statuses, directive[sub_operator], sub_operator);
                 if (status == null){
                     status = sub_status;
                 } else if (operator == "and"){
@@ -840,68 +851,72 @@ LocusZoom.DataLayer.prototype.showOrHideTooltip = function(d, id){
         hide_directive = this.layout.tooltip.hide;
     }
 
-    var element = {};
-    element.highlighted = this.state[this.state_id].highlighted.indexOf(id) != -1;
-    element.unhighlighted = !element.highlighted;
-    element.selected = this.state[this.state_id].selected.indexOf(id) != -1;
-    element.unselected = !element.selected;
+    var statuses = {};
+    statuses.highlighted = this.state[this.state_id].highlighted.indexOf(id) != -1;
+    statuses.unhighlighted = !statuses.highlighted;
+    statuses.selected = this.state[this.state_id].selected.indexOf(id) != -1;
+    statuses.unselected = !statuses.selected;
 
-    var show_resolved = resolveStatus(element, show_directive);
-    var hide_resolved = resolveStatus(element, hide_directive);
+    var show_resolved = resolveStatus(statuses, show_directive);
+    var hide_resolved = resolveStatus(statuses, hide_directive);
 
     // Only show tooltip if the resolved logic explicitly shows and explicitly not hides the tool tip
     // Otherwise ensure tooltip does not exist
     if (show_resolved && !hide_resolved){
-        this.createTooltip(d);
+        this.createTooltip(element);
     } else {
-        this.destroyTooltip(id);
+        this.destroyTooltip(element);
     }
     
 };
 
 // Toggle the highlighted status of an element
-LocusZoom.DataLayer.prototype.highlightElement = function(d, id, toggle){
-    if (typeof toggle == "undefined"){ var toggle = true; }
-    this.setElementStatus("highlighted", d, id, toggle);
+LocusZoom.DataLayer.prototype.highlightElement = function(element){
+    this.setElementStatus("highlighted", element, true);
 };
-LocusZoom.DataLayer.prototype.unhighlightElement = function(id){
-    this.highlightElement({}, id, false);
+LocusZoom.DataLayer.prototype.unhighlightElement = function(element){
+    this.setElementStatus("highlighted", element, false);
 };
 
 // Toggle the highlighted status of all elements
-LocusZoom.DataLayer.prototype.highlightAllElements = function(toggle){
-    if (typeof toggle == "undefined"){ var toggle = true; }
-    this.setAllElementStatus("highlighted", toggle);
+LocusZoom.DataLayer.prototype.highlightAllElements = function(){
+    this.setAllElementStatus("highlighted", true);
 };
 LocusZoom.DataLayer.prototype.unhighlightAllElements = function(){
-    this.highlightAllElements(false);
+    this.setAllElementStatus("highlighted", false);
 }
 
 // Toggle the selected status of an element
-LocusZoom.DataLayer.prototype.selectElement = function(d, id, toggle){
-    if (typeof toggle == "undefined"){ var toggle = true; }
-    this.setElementStatus("selected", d, id, toggle);
+LocusZoom.DataLayer.prototype.selectElement = function(element){
+    this.setElementStatus("selected", element, true);
 };
-LocusZoom.DataLayer.prototype.unselectElement = function(id){
-    this.selectElement({}, id, false);
+LocusZoom.DataLayer.prototype.unselectElement = function(element){
+    this.setElementStatus("selected", element, false);
 };
 
 // Toggle the selected status of all elements
-LocusZoom.DataLayer.prototype.selectAllElements = function(toggle){
-    if (typeof toggle == "undefined"){ var toggle = true; }
-    this.setAllElementStatus("selected", toggle);
+LocusZoom.DataLayer.prototype.selectAllElements = function(){
+    this.setAllElementStatus("selected", true);
 };
 LocusZoom.DataLayer.prototype.unselectAllElements = function(){
-    this.selectAllElements(false);
+    this.setAllElementStatus("selected", false);
 };
 
 // Toggle a status (e.g. highlighted, selected) on an element
-LocusZoom.DataLayer.prototype.setElementStatus = function(status, d, id, toggle){
+LocusZoom.DataLayer.prototype.setElementStatus = function(status, element, toggle){
     
     // Sanity checks
-    if (typeof status == "undefined" || ["highlighted","selected"].indexOf(status) == -1){ return; }
-    if (typeof id != "string"){ return; }
-    if (typeof toggle == "undefined"){ var toggle = true; }
+    if (typeof status == "undefined" || ["highlighted","selected"].indexOf(status) == -1){
+        throw("Invalid status passed to setElementStatus()");
+    }
+    if (typeof element == "undefined"){
+        throw("Invalid element passed to setElementStatus()");
+    }
+    if (typeof toggle == "undefined"){
+        var toggle = true;
+    }
+
+    var id = this.getElementId(element);
     
     // Set/unset the proper status class on the appropriate DOM element
     var element_id = id;
@@ -922,7 +937,7 @@ LocusZoom.DataLayer.prototype.setElementStatus = function(status, d, id, toggle)
     }
     
     // Trigger tool tip show/hide logic
-    this.showOrHideTooltip(d, id);
+    this.showOrHideTooltip(element);
 
     // Trigger generic onUpdate
     this.onUpdate();
@@ -933,21 +948,25 @@ LocusZoom.DataLayer.prototype.setElementStatus = function(status, d, id, toggle)
 LocusZoom.DataLayer.prototype.setAllElementStatus = function(status, toggle){
     
     // Sanity check
-    if (typeof status == "undefined" || ["highlighted","selected"].indexOf(status) == -1){ return; }
+    if (typeof status == "undefined" || ["highlighted","selected"].indexOf(status) == -1){
+        throw("Invalid status passed to setAllElementStatus()");
+    }
     if (typeof toggle == "undefined"){ var toggle = true; }
 
     // Apply statuses
     if (toggle){
         this.data.forEach(function(element){
-            var id = this.getElementId(element);
-            if (this.state[this.state_id][status].indexOf(id) == -1){
-                this.setElementStatus(status, element, id, true);
+            if (this.state[this.state_id][status].indexOf(this.getElementId(element)) == -1){
+                this.setElementStatus(status, element, true);
             }
         }.bind(this));
     } else {
         var status_ids = this.state[this.state_id][status].slice();
         status_ids.forEach(function(id){
-            this.setElementStatus(status, {}, id, false);
+            var element = this.getElementById(id);
+            if (typeof element == "object" && element != null){
+                this.setElementStatus(status, element, false);
+            }
         }.bind(this));
     }
     
@@ -974,7 +993,7 @@ LocusZoom.DataLayer.prototype.applyStatusBehavior = function(status, selection){
     };
 
     // General function to process mouse events and layout directives into discrete element status update calls
-    var handleElementStatusEvent = function(status, event, d){
+    var handleElementStatusEvent = function(status, event, element){
         var status_boolean = null;
         var ctrl = d3.event.ctrlKey;
         var shift = d3.event.shiftKey;
@@ -996,7 +1015,7 @@ LocusZoom.DataLayer.prototype.applyStatusBehavior = function(status, selection){
                 break;
             case "toggle":
             case "toggle_exclusive":
-                status_boolean = (this.state[this.state_id][status].indexOf(this.getElementId(d)) == -1);
+                status_boolean = (this.state[this.state_id][status].indexOf(this.getElementId(element)) == -1);
                 break;
         }
         if (status_boolean == null){ return; }
@@ -1006,7 +1025,7 @@ LocusZoom.DataLayer.prototype.applyStatusBehavior = function(status, selection){
             this.setAllElementStatus(status, false);
         }
         // Apply the new status
-        this.setElementStatus(status, d, this.getElementId(d), status_boolean);
+        this.setElementStatus(status, element, status_boolean);
     }.bind(this);
     
     // Determine which bindings to set up
@@ -1021,8 +1040,8 @@ LocusZoom.DataLayer.prototype.applyStatusBehavior = function(status, selection){
     // Set up the bindings
     Object.keys(events_to_bind).forEach(function(event){
         if (!events_to_bind[event]){ return; }
-        selection.on(event, function(d){
-            handleElementStatusEvent(status, event, d);
+        selection.on(event, function(element){
+            handleElementStatusEvent(status, event, element);
         }.bind(this));
     }.bind(this));
                     

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -448,10 +448,13 @@ LocusZoom.StandardLayout = {
                         upper_buffer: 0.05,
                         min_extent: [ 0, 10 ]
                     },
-                    highlighted: "onmouseover",
+                    highlighted: {
+                        onmouseover: "on",
+                        onmouseout: "off"
+                    },
                     selected: {
-                        toggle: "onclick",
-                        allow_multiple: "onshiftclick"
+                        onclick: "toggle_exclusive",
+                        onshiftclick: "toggle"
                     },
                     tooltip: {
                         show: { or: ["highlighted", "selected"] },
@@ -479,9 +482,13 @@ LocusZoom.StandardLayout = {
                     type: "genes",
                     fields: ["gene:gene", "constraint:constraint"],
                     id_field: "gene_id",
-                    highlighted: "onmouseover",
+                    highlighted: {
+                        onmouseover: "on",
+                        onmouseout: "off"
+                    },
                     selected: {
-                        toggle: "onclick"
+                        onclick: "toggle_exclusive",
+                        onshiftclick: "toggle"
                     },
                     tooltip: {
                         show: { or: ["highlighted", "selected"] },
@@ -534,10 +541,10 @@ LocusZoom.DataLayer = function(id, layout, parent) {
         this.state = this.parent.state;
         this.state_id = this.parent.id + "." + this.id;
         this.state[this.state_id] = this.state[this.state_id] || {};
-        if (this.layout.highlighted){
+        if (typeof this.layout.highlighted == "object"){
             this.state[this.state_id].highlighted = this.state[this.state_id].highlighted || [];
         }
-        if (this.layout.selected){
+        if (typeof this.layout.selected == "object"){
             this.state[this.state_id].selected = this.state[this.state_id].selected || [];
         }
     } else {
@@ -777,7 +784,21 @@ LocusZoom.DataLayer.prototype.showOrHideTooltip = function(d, id){
     var resolveStatus = function(element, directive, operator){
         var status = null;
         if (typeof element != "object" || element == null){ return null; }
-        if (typeof directive == "object"){
+        if (Array.isArray(directive)){
+            if (typeof operator == "undefined"){ operator = "and"; }
+            if (directive.length == 1){
+                status = element[directive[0]];
+            } else {
+                status = directive.reduce(function(previousValue, currentValue) {
+                    if (operator == "and"){
+                        return element[previousValue] && element[currentValue];
+                    } else if (operator == "or"){
+                        return element[previousValue] || element[currentValue];
+                    }
+                    return null;
+                });
+            }
+        } else if (typeof directive == "object"){
             var sub_status;
             for (var sub_operator in directive){
                 sub_status = resolveStatus(element, directive[sub_operator], sub_operator);
@@ -788,20 +809,6 @@ LocusZoom.DataLayer.prototype.showOrHideTooltip = function(d, id){
                 } else if (operator == "or"){
                     status = status || sub_status;
                 }
-            }
-        } else if (typeof directive == "array"){
-            if (typeof operator == "undefined"){ operator = "and"; }
-            if (directive.length == 1){
-                status = element[directive[0]];
-            } else {
-                status = directive.reduce(function(previousValue, currentValue) {
-                    if (operator == "and"){
-                        return previousValue && currentValue;
-                    } else if (operator == "or"){
-                        return previousValue || currentValue;
-                    }
-                    return null;
-                });
             }
         }
         return status;
@@ -831,16 +838,19 @@ LocusZoom.DataLayer.prototype.showOrHideTooltip = function(d, id){
     var hide_resolved = resolveStatus(element, hide_directive);
 
     // Only show tooltip if the resolved logic explicitly shows and explicitly not hides the tool tip
+    // Otherwise ensure tooltip does not exist
     if (show_resolved && !hide_resolved){
         this.createTooltip(d, id);
-    }   
+    } else {
+        this.destroyTooltip(id);
+    }
     
 };
 
 // Toggle the highlighted status of an element
 LocusZoom.DataLayer.prototype.highlightElement = function(d, id, toggle){
     if (typeof toggle == "undefined"){ var toggle = true; }
-    this.toggleElementStatus("highlighted", d, id, toggle);
+    this.setElementStatus("highlighted", d, id, toggle);
 };
 LocusZoom.DataLayer.prototype.unhighlightElement = function(id){
     this.highlightElement({}, id, false);
@@ -849,7 +859,7 @@ LocusZoom.DataLayer.prototype.unhighlightElement = function(id){
 // Toggle the highlighted status of all elements
 LocusZoom.DataLayer.prototype.highlightAllElements = function(toggle){
     if (typeof toggle == "undefined"){ var toggle = true; }
-    this.toggleAllElementStatus("highlighted", toggle);
+    this.setAllElementStatus("highlighted", toggle);
 };
 LocusZoom.DataLayer.prototype.unhighlightAllElements = function(){
     this.highlightAllElements(false);
@@ -858,7 +868,7 @@ LocusZoom.DataLayer.prototype.unhighlightAllElements = function(){
 // Toggle the selected status of an element
 LocusZoom.DataLayer.prototype.selectElement = function(d, id, toggle){
     if (typeof toggle == "undefined"){ var toggle = true; }
-    this.toggleElementStatus("selected", d, id, toggle);
+    this.setElementStatus("selected", d, id, toggle);
 };
 LocusZoom.DataLayer.prototype.unselectElement = function(id){
     this.selectElement({}, id, false);
@@ -867,14 +877,14 @@ LocusZoom.DataLayer.prototype.unselectElement = function(id){
 // Toggle the selected status of all elements
 LocusZoom.DataLayer.prototype.selectAllElements = function(toggle){
     if (typeof toggle == "undefined"){ var toggle = true; }
-    this.toggleAllElementStatus("selected", toggle);
+    this.setAllElementStatus("selected", toggle);
 };
 LocusZoom.DataLayer.prototype.unselectAllElements = function(){
     this.selectAllElements(false);
 };
 
 // Toggle a status (e.g. highlighted, selected) on an element
-LocusZoom.DataLayer.prototype.toggleElementStatus = function(status, d, id, toggle){
+LocusZoom.DataLayer.prototype.setElementStatus = function(status, d, id, toggle){
     
     // Sanity checks
     if (typeof status == "undefined" || ["highlighted","selected"].indexOf(status) == -1){ return; }
@@ -908,7 +918,7 @@ LocusZoom.DataLayer.prototype.toggleElementStatus = function(status, d, id, togg
 };
 
 // Toggle a status on an all elements in the data layer
-LocusZoom.DataLayer.prototype.toggleAllElementStatus = function(status, toggle){
+LocusZoom.DataLayer.prototype.setAllElementStatus = function(status, toggle){
     
     // Sanity check
     if (typeof status == "undefined" || ["highlighted","selected"].indexOf(status) == -1){ return; }
@@ -919,13 +929,13 @@ LocusZoom.DataLayer.prototype.toggleAllElementStatus = function(status, toggle){
         this.data.forEach(function(element){
             var id = this.getElementId(element);
             if (this.state[this.state_id][status].indexOf(id) == -1){
-                this.toggleElementStatus(status, element, id, true);
+                this.setElementStatus(status, element, id, true);
             }
         }.bind(this));
     } else {
         var status_ids = this.state[this.state_id][status].slice();
         status_ids.forEach(function(id){
-            this.toggleElementStatus(status, {}, id, false);
+            this.setElementStatus(status, {}, id, false);
         }.bind(this));
     }
     
@@ -934,21 +944,76 @@ LocusZoom.DataLayer.prototype.toggleAllElementStatus = function(status, toggle){
 // Apply mouse event bindings to create status-related behavior (e.g. highlighted, selected)
 LocusZoom.DataLayer.prototype.applyStatusBehavior = function(status, selection){
 
+    // Glossary for this function:
+    // status - an element property that can be tied to mouse behavior (e.g. highighted, selected)
+    // event - a mouse event that can be bound to a watch function (e.g. "mouseover", "click")
+    // action - a more verbose locuszoom-layout-specific form of an event (e.g. "onmouseover", "onshiftclick")
+
     // Sanity checks
     if (typeof status == "undefined" || ["highlighted","selected"].indexOf(status) == -1){ return; }
     if (typeof selection != "object"){ return; }
-    if (!this.layout[status]){ return; }
+    if (typeof this.layout[status] != "object" || !this.layout[status]){ return; }
+
+    // Map of supported d3 events and the locuszoom layout events they map to
+    var event_directive_map = {
+        "mouseover": ["onmouseover", "onctrlmouseover", "onshiftmouseover", "onctrlshiftmouseover"],
+        "mouseout": ["onmouseout"],
+        "click": ["onclick", "onctrlclick", "onshiftclick", "onctrlshiftclick"]
+    };
+
+    // General function to process mouse events and layout directives into discrete element status update calls
+    var handleElementStatusEvent = function(status, event, d){
+        var status_boolean = null;
+        var ctrl = d3.event.ctrlKey;
+        var shift = d3.event.shiftKey;
+        if (!event_directive_map[event]){ return; }
+        // Determine the directive by building the action string to use. Default down to basic actions
+        // if more precise actions are not defined (e.g. if onclick is defined and onshiftclick is not,
+        // but this click event happened with the shift key pressed, just treat it as a regular click)
+        var base_action = "on" + event;
+        var precise_action = "on" + (ctrl ? "ctrl" : "") + (shift ? "shift" : "") + event;
+        var directive = this.layout[status][precise_action] || this.layout[status][base_action] || null;
+        if (!directive){ return; }
+        // Resolve the value of the status boolean from the directive and the element's current status
+        switch (directive){
+            case "on":
+                status_boolean = true;
+                break;
+            case "off":
+                status_boolean = false;
+                break;
+            case "toggle":
+            case "toggle_exclusive":
+                status_boolean = (this.state[this.state_id][status].indexOf(this.getElementId(d)) == -1);
+                break;
+        }
+        if (status_boolean == null){ return; }
+        // Special handling for toggle_exclusive - if the new status_boolean is true then first set the
+        // status to off for all other elements
+        if (status_boolean && directive == "toggle_exclusive"){
+            this.setAllElementStatus(status, false);
+        }
+        // Apply the new status
+        this.setElementStatus(status, d, this.getElementId(d), status_boolean);
+    }.bind(this);
     
-    if (this.layout[status] == "onmouseover"){
-        selection
-            .on("mouseover", function(d){
-                this.toggleElementStatus(status, d, this.getElementId(d), true);
-            }.bind(this))
-            .on("mouseout", function(d){
-                this.toggleElementStatus(status, d, this.getElementId(d), false);
-            }.bind(this));
-    }
-    
+    // Determine which bindings to set up
+    var events_to_bind = {};
+    Object.keys(event_directive_map).forEach(function(event){ events_to_bind[event] = false; });
+    Object.keys(this.layout[status]).forEach(function(action){
+        Object.keys(event_directive_map).forEach(function(event){
+            if (event_directive_map[event].indexOf(action) != -1){ events_to_bind[event] = true; }
+        });
+    });
+
+    // Set up the bindings
+    Object.keys(events_to_bind).forEach(function(event){
+        if (!events_to_bind[event]){ return; }
+        selection.on(event, function(d){
+            handleElementStatusEvent(status, event, d);
+        }.bind(this));
+    }.bind(this));
+                    
 };
 
 // Apply all supported status behaviors to a selection of objects
@@ -958,118 +1023,6 @@ LocusZoom.DataLayer.prototype.applyAllStatusBehaviors = function(selection){
         this.applyStatusBehavior(status, selection);
     }.bind(this));
 }
-
-// Standard approach to applying unit-based selectability and general tooltip behavior (one and/or multiple)
-// on a selection of data elements
-LocusZoom.DataLayer.prototype.enableTooltips = function(selection){
-
-    if (typeof selection != "object"){ return; }
-    if (!this.layout.id_field){
-        console.warn("Data layer " + this.id + " tried to enable tooltips but does not have a valid id_field defined in the layout");
-        return;
-    }
-    
-    // Enable mouseover/mouseout tooltip show/hide behavior
-    selection.on("mouseover", function(d){
-        var id = this.parent.id + "_" + d[this.layout.id_field].replace(/\W/g,"");
-        var select_id = id;
-        var attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-hovered";
-        if (this.layout.hover_element){
-            select_id += "_" + this.layout.hover_element;
-            attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element + "-hovered";
-        }
-        if (this.state[this.state_id].selected.indexOf(id) == -1){
-            d3.select("#" + select_id).attr("class", attr_class);
-            if (this.layout.tooltip){ this.createTooltip(d, id); }
-        }
-    }.bind(this))
-        .on("mouseout", function(d){
-            var id = this.parent.id + "_" + d[this.layout.id_field].replace(/\W/g,"");
-            var select_id = id;
-            var attr_class = "lz-data_layer-" + this.layout.type;
-            if (this.layout.hover_element){
-                select_id += "_" + this.layout.hover_element;
-                attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element;
-            }
-            if (this.state[this.state_id].selected.indexOf(id) == -1){
-                d3.select("#" + select_id).attr("class", attr_class);
-                if (this.layout.tooltip){ this.destroyTooltip(id); }
-            }
-        }.bind(this));
-    
-    if (this.layout.selectable){
-
-        var select_id, attr_class;
-        
-        // Enable selectability
-        selection.on("click", function(d){
-            var id = this.parent.id + "_" + d[this.layout.id_field].replace(/\W/g,"");
-            var selected_idx = this.state[this.state_id].selected.indexOf(id);
-            // If this element IS currently selected...
-            if (selected_idx != -1){
-                // If in selectable:multiple mode and this tooltip was closed then unclose it and be done
-                if (this.layout.selectable == "multiple" && this.tooltips[id] && this.tooltips[id].closed){
-                    this.uncloseTooltip(id);
-                    // Otherwise unselect the element but leave the tool tip in place (to be destroyed on mouse out)
-                } else {
-                    this.state[this.state_id].selected.splice(selected_idx, 1);
-                    select_id = id;
-                    attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-hovered";
-                    if (this.layout.hover_element){
-                        select_id += "_" + this.layout.hover_element;
-                        attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element + "-hovered";
-                    }
-                    d3.select("#" + select_id).attr("class", attr_class);
-                }
-
-                // If this element IS NOT currently selected...
-            } else {
-                // If in selectable:one mode then deselect any current selection
-                if (this.layout.selectable == "one" && this.state[this.state_id].selected.length){
-                    this.destroyTooltip(this.state[this.state_id].selected[0]);
-                    select_id = this.state[this.state_id].selected[0];
-                    attr_class = "lz-data_layer-" + this.layout.type;
-                    if (this.layout.hover_element){
-                        select_id += "_" + this.layout.hover_element;
-                        attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element;
-                    }
-                    d3.select("#" + select_id).attr("class", attr_class);
-                    this.state[this.state_id].selected = [];
-                }
-                // Select the clicked element    
-                this.state[this.state_id].selected.push(id);
-                select_id = id;
-                attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-selected";
-                if (this.layout.hover_element){
-                    select_id += "_" + this.layout.hover_element;
-                    attr_class = "lz-data_layer-" + this.layout.type + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element + " lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element + "-selected";
-                }
-                d3.select("#" + select_id).attr("class", attr_class);
-            }
-            this.onUpdate();
-        }.bind(this));
-
-        // Apply existing elements from state
-        if (Array.isArray(this.state[this.state_id].selected) && this.state[this.state_id].selected.length){
-            this.state[this.state_id].selected.forEach(function(selected_id, idx){
-                if (d3.select("#" + selected_id).empty()){
-                    console.warn("State elements for " + this.state_id + " contains an ID that is not or is no longer present on the plot: " + selected_id);
-                    this.state[this.state_id].selected.splice(idx, 1);
-                } else {
-                    if (this.tooltips[selected_id] && !this.tooltips[selected_id].closed){
-                        this.positionTooltip(selected_id);
-                    } else {
-                        this.state[this.state_id].selected.splice(idx, 1);
-                        var d = d3.select("#" + selected_id).datum();
-                        d3.select("#" + selected_id).on("mouseover")(d);
-                        d3.select("#" + selected_id).on("click")(d);
-                    }
-                }
-            }.bind(this));
-        }
-        
-    }
-};
 
 // Get an object with the x and y coordinates of the panel's origin in terms of the entire page
 // Necessary for positioning any HTML elements over the panel

--- a/locuszoom.css
+++ b/locuszoom.css
@@ -70,7 +70,7 @@ svg.lz-locuszoom {
     stroke: rgba(24, 24, 24, 0.4);
     stroke-width: 1;
     cursor: pointer; }
-  svg.lz-locuszoom path.lz-data_layer-scatter-hovered {
+  svg.lz-locuszoom path.lz-data_layer-scatter-highlighted {
     stroke: rgba(24, 24, 24, 0.4);
     stroke-width: 4; }
   svg.lz-locuszoom path.lz-data_layer-scatter-selected {
@@ -98,7 +98,7 @@ svg.lz-locuszoom {
     fill: #363696;
     fill-opacity: 0;
     stroke-width: 0; }
-  svg.lz-locuszoom rect.lz-data_layer-genes.lz-data_layer-genes-bounding_box-hovered {
+  svg.lz-locuszoom rect.lz-data_layer-genes.lz-data_layer-genes-bounding_box-highlighted {
     fill: #363696;
     fill-opacity: 0.1;
     stroke-width: 0; }

--- a/test/DataLayer.js
+++ b/test/DataLayer.js
@@ -62,9 +62,6 @@ describe('LocusZoom.DataLayer', function(){
         it('should have a state object', function(){
             this.datalayer.should.have.property('state').which.is.an.Object;
         });
-        it('should have a tooltips object', function(){
-            this.datalayer.should.have.property('tooltips').which.is.an.Object;
-        });
     });
 
     describe("Scalable parameter resolution", function() {
@@ -332,35 +329,44 @@ describe('LocusZoom.DataLayer', function(){
             delete this.plot;
         });
         it('should allow for highlighting and unhighlighting a single element', function(){
-            this.plot.panels.p.addDataLayer("d", { type: "scatter", highlightable: "onmouseover" });
+            this.plot.panels.p.addDataLayer("d", { type: "scatter", highlighted: "onmouseover" });
             var state_id = this.plot.panels.p.data_layers.d.state_id;
             var d = this.plot.panels.p.data_layers.d;
             this.plot.panels.p.data_layers.d.data = [{ id: "a" }, { id: "b" },{ id: "c" },];
+            var a = d.data[0];
+            var a_id = d.getElementId(a);
+            var b = d.data[1];
+            var b_id = d.getElementId(b);
+            var c = d.data[2];
+            var c_id = d.getElementId(c);
             this.plot.state[state_id].highlighted.should.be.an.Array;
             this.plot.state[state_id].highlighted.length.should.be.exactly(0);
-            this.plot.panels.p.data_layers.d.highlightElement(d.getElementId(d.data[0]), true);
+            this.plot.panels.p.data_layers.d.highlightElement(a, a_id, true);
             this.plot.state[state_id].highlighted.length.should.be.exactly(1);
-            this.plot.state[state_id].highlighted[0].should.be.exactly(d.getElementId(d.data[0]));
-            this.plot.panels.p.data_layers.d.highlightElement(d.getElementId(d.data[0]), false);
+            this.plot.state[state_id].highlighted[0].should.be.exactly(a_id);
+            this.plot.panels.p.data_layers.d.highlightElement(a, a_id, false);
             this.plot.state[state_id].highlighted.length.should.be.exactly(0);
-            this.plot.panels.p.data_layers.d.highlightElement(d.getElementId(d.data[2]));
+            this.plot.panels.p.data_layers.d.highlightElement(c, c_id);
             this.plot.state[state_id].highlighted.length.should.be.exactly(1);
-            this.plot.state[state_id].highlighted[0].should.be.exactly(d.getElementId(d.data[2]));
-            this.plot.panels.p.data_layers.d.unhighlightElement(d.getElementId(d.data[1]));
+            this.plot.state[state_id].highlighted[0].should.be.exactly(c_id);
+            this.plot.panels.p.data_layers.d.unhighlightElement(b_id);
             this.plot.state[state_id].highlighted.length.should.be.exactly(1);
-            this.plot.panels.p.data_layers.d.unhighlightElement(d.getElementId(d.data[2]));
+            this.plot.panels.p.data_layers.d.unhighlightElement(c_id);
             this.plot.state[state_id].highlighted.length.should.be.exactly(0);
         });
         it('should allow for highlighting and unhighlighting all elements', function(){
-            this.plot.panels.p.addDataLayer("d", { type: "scatter", highlightable: "onmouseover" });
+            this.plot.panels.p.addDataLayer("d", { type: "scatter", highlighted: "onmouseover" });
             var state_id = this.plot.panels.p.data_layers.d.state_id;
             var d = this.plot.panels.p.data_layers.d;
             this.plot.panels.p.data_layers.d.data = [{ id: "a" }, { id: "b" },{ id: "c" },];
+            var a_id = d.getElementId(d.data[0]);
+            var b_id = d.getElementId(d.data[1]);
+            var c_id = d.getElementId(d.data[2]);
             this.plot.panels.p.data_layers.d.highlightAllElements(true);
             this.plot.state[state_id].highlighted.length.should.be.exactly(3);
-            this.plot.state[state_id].highlighted[0].should.be.exactly(d.getElementId(d.data[0]));
-            this.plot.state[state_id].highlighted[1].should.be.exactly(d.getElementId(d.data[1]));
-            this.plot.state[state_id].highlighted[2].should.be.exactly(d.getElementId(d.data[2]));
+            this.plot.state[state_id].highlighted[0].should.be.exactly(a_id);
+            this.plot.state[state_id].highlighted[1].should.be.exactly(b_id);
+            this.plot.state[state_id].highlighted[2].should.be.exactly(c_id);
             this.plot.panels.p.data_layers.d.highlightAllElements(false);
             this.plot.state[state_id].highlighted.length.should.be.exactly(0);
             this.plot.panels.p.data_layers.d.highlightAllElements();
@@ -382,35 +388,44 @@ describe('LocusZoom.DataLayer', function(){
             delete this.plot;
         });
         it('should allow for selecting and unselecting a single element', function(){
-            this.plot.panels.p.addDataLayer("d", { type: "scatter", selectable: { toggle: "onclick" } });
+            this.plot.panels.p.addDataLayer("d", { type: "scatter", selected: { toggle: "onclick" } });
             var state_id = this.plot.panels.p.data_layers.d.state_id;
             var d = this.plot.panels.p.data_layers.d;
             this.plot.panels.p.data_layers.d.data = [{ id: "a" }, { id: "b" },{ id: "c" },];
+            var a = d.data[0];
+            var a_id = d.getElementId(a);
+            var b = d.data[1];
+            var b_id = d.getElementId(b);
+            var c = d.data[2];
+            var c_id = d.getElementId(c);
             this.plot.state[state_id].selected.should.be.an.Array;
             this.plot.state[state_id].selected.length.should.be.exactly(0);
-            this.plot.panels.p.data_layers.d.selectElement(d.getElementId(d.data[0]), true);
+            this.plot.panels.p.data_layers.d.selectElement(a, a_id, true);
             this.plot.state[state_id].selected.length.should.be.exactly(1);
-            this.plot.state[state_id].selected[0].should.be.exactly(d.getElementId(d.data[0]));
-            this.plot.panels.p.data_layers.d.selectElement(d.getElementId(d.data[0]), false);
+            this.plot.state[state_id].selected[0].should.be.exactly(a_id);
+            this.plot.panels.p.data_layers.d.selectElement(a, a_id, false);
             this.plot.state[state_id].selected.length.should.be.exactly(0);
-            this.plot.panels.p.data_layers.d.selectElement(d.getElementId(d.data[2]));
+            this.plot.panels.p.data_layers.d.selectElement(c, c_id);
             this.plot.state[state_id].selected.length.should.be.exactly(1);
-            this.plot.state[state_id].selected[0].should.be.exactly(d.getElementId(d.data[2]));
-            this.plot.panels.p.data_layers.d.unselectElement(d.getElementId(d.data[1]));
+            this.plot.state[state_id].selected[0].should.be.exactly(c_id);
+            this.plot.panels.p.data_layers.d.unselectElement(b_id);
             this.plot.state[state_id].selected.length.should.be.exactly(1);
-            this.plot.panels.p.data_layers.d.unselectElement(d.getElementId(d.data[2]));
+            this.plot.panels.p.data_layers.d.unselectElement(c_id);
             this.plot.state[state_id].selected.length.should.be.exactly(0);
         });
         it('should allow for selecting and unselecting all elements', function(){
-            this.plot.panels.p.addDataLayer("d", { type: "scatter", selectable: "onmouseover" });
+            this.plot.panels.p.addDataLayer("d", { type: "scatter", selected: "onmouseover" });
             var state_id = this.plot.panels.p.data_layers.d.state_id;
             var d = this.plot.panels.p.data_layers.d;
             this.plot.panels.p.data_layers.d.data = [{ id: "a" }, { id: "b" },{ id: "c" },];
+            var a_id = d.getElementId(d.data[0]);
+            var b_id = d.getElementId(d.data[1]);
+            var c_id = d.getElementId(d.data[2]);
             this.plot.panels.p.data_layers.d.selectAllElements(true);
             this.plot.state[state_id].selected.length.should.be.exactly(3);
-            this.plot.state[state_id].selected[0].should.be.exactly(d.getElementId(d.data[0]));
-            this.plot.state[state_id].selected[1].should.be.exactly(d.getElementId(d.data[1]));
-            this.plot.state[state_id].selected[2].should.be.exactly(d.getElementId(d.data[2]));
+            this.plot.state[state_id].selected[0].should.be.exactly(a_id);
+            this.plot.state[state_id].selected[1].should.be.exactly(b_id);
+            this.plot.state[state_id].selected[2].should.be.exactly(c_id);
             this.plot.panels.p.data_layers.d.selectAllElements(false);
             this.plot.state[state_id].selected.length.should.be.exactly(0);
             this.plot.panels.p.data_layers.d.selectAllElements();
@@ -434,8 +449,8 @@ describe('LocusZoom.DataLayer', function(){
         it('should allow for showing or hiding a tool tip based on layout directives and element status', function(){
             this.plot.panels.p.addDataLayer("d", {
                 type: "scatter",
-                highlightable: "onmouseover",
-                selectable: "onmouseover",
+                highlighted: "onmouseover",
+                selected: "onmouseover",
                 tooltip: {
                     show: { or: ["highlighted", "selected"] },
                     hide: { and: ["unhighlighted", "unselected"] },
@@ -443,29 +458,32 @@ describe('LocusZoom.DataLayer', function(){
                 }
             });
             var state_id = this.plot.panels.p.data_layers.d.state_id;
-            var d = this.plot.panels.p.data_layers.d;
             this.plot.panels.p.data_layers.d.data = [{ id: "a" }, { id: "b" },{ id: "c" },];
-            d.should.be.an.Object;
-            var a_id = d.getElementId(d.data[0]);
-            var b_id = d.getElementId(d.data[1]);
+            var d = this.plot.panels.p.data_layers.d;
+            var a = d.data[0];
+            var a_id = d.getElementId(a);
+            var b = d.data[1];
+            var b_id = d.getElementId(b);
+            // Make sure the tooltips object is there
+            d.should.have.property('tooltips').which.is.an.Object;
             // Test highlighted OR selected
-            should(d[a_id]).be.type("undefined");
-            this.plot.panels.p.data_layers.d.highlightElement(a_id, true);
-            should(d[a_id]).be.an.Object;
-            this.plot.panels.p.data_layers.d.highlightElement(a_id, false);
-            should(d[a_id]).be.type("undefined");
-            this.plot.panels.p.data_layers.d.selectElement(a_id, true);
-            should(d[a_id]).be.an.Object;
-            this.plot.panels.p.data_layers.d.selectElement(a_id, false);
-            should(d[a_id]).be.type("undefined");
+            should(d.tooltips[a_id]).be.type("undefined");
+            d.highlightElement(a, a_id, true);
+            should(d.tooltips[a_id]).be.an.Object;
+            d.highlightElement(a, a_id, false);
+            should(d.tooltips[a_id]).be.type("undefined");
+            d.selectElement(a, a_id, true);
+            should(d.tooltips[a_id]).be.an.Object;
+            d.selectElement(a, a_id, false);
+            should(d.tooltips[a_id]).be.type("undefined");
             // Test highlight AND selected
-            should(d[b_id]).be.type("undefined");
-            this.plot.panels.p.data_layers.d.highlightElement(b_id, true);
-            this.plot.panels.p.data_layers.d.selectElement(b_id, true);
-            should(d[a_id]).be.an.Object;
-            this.plot.panels.p.data_layers.d.highlightElement(b_id, false);
-            this.plot.panels.p.data_layers.d.selectElement(b_id, false);
-            should(d[b_id]).be.type("undefined");
+            should(d.tooltips[b_id]).be.type("undefined");
+            d.highlightElement(b, b_id, true);
+            d.selectElement(b, b_id, true);
+            should(d.tooltips[a_id]).be.an.Object;
+            d.highlightElement(b, b_id, false);
+            d.selectElement(b, b_id, false);
+            should(d.tooltips[b_id]).be.type("undefined");
         });
     });
 

--- a/test/DataLayer.js
+++ b/test/DataLayer.js
@@ -329,7 +329,7 @@ describe('LocusZoom.DataLayer', function(){
             delete this.plot;
         });
         it('should allow for highlighting and unhighlighting a single element', function(){
-            this.plot.panels.p.addDataLayer("d", { type: "scatter", highlighted: "onmouseover" });
+            this.plot.panels.p.addDataLayer("d", { type: "scatter", highlighted: { onmouseover: "toggle" } });
             var state_id = this.plot.panels.p.data_layers.d.state_id;
             var d = this.plot.panels.p.data_layers.d;
             this.plot.panels.p.data_layers.d.data = [{ id: "a" }, { id: "b" },{ id: "c" },];
@@ -355,7 +355,7 @@ describe('LocusZoom.DataLayer', function(){
             this.plot.state[state_id].highlighted.length.should.be.exactly(0);
         });
         it('should allow for highlighting and unhighlighting all elements', function(){
-            this.plot.panels.p.addDataLayer("d", { type: "scatter", highlighted: "onmouseover" });
+            this.plot.panels.p.addDataLayer("d", { type: "scatter", highlighted: { onmouseover: "toggle" } });
             var state_id = this.plot.panels.p.data_layers.d.state_id;
             var d = this.plot.panels.p.data_layers.d;
             this.plot.panels.p.data_layers.d.data = [{ id: "a" }, { id: "b" },{ id: "c" },];
@@ -388,7 +388,7 @@ describe('LocusZoom.DataLayer', function(){
             delete this.plot;
         });
         it('should allow for selecting and unselecting a single element', function(){
-            this.plot.panels.p.addDataLayer("d", { type: "scatter", selected: { toggle: "onclick" } });
+            this.plot.panels.p.addDataLayer("d", { type: "scatter", selected: { onclick: "toggle" } });
             var state_id = this.plot.panels.p.data_layers.d.state_id;
             var d = this.plot.panels.p.data_layers.d;
             this.plot.panels.p.data_layers.d.data = [{ id: "a" }, { id: "b" },{ id: "c" },];
@@ -414,7 +414,7 @@ describe('LocusZoom.DataLayer', function(){
             this.plot.state[state_id].selected.length.should.be.exactly(0);
         });
         it('should allow for selecting and unselecting all elements', function(){
-            this.plot.panels.p.addDataLayer("d", { type: "scatter", selected: "onmouseover" });
+            this.plot.panels.p.addDataLayer("d", { type: "scatter", selected: { onclick: "toggle" } });
             var state_id = this.plot.panels.p.data_layers.d.state_id;
             var d = this.plot.panels.p.data_layers.d;
             this.plot.panels.p.data_layers.d.data = [{ id: "a" }, { id: "b" },{ id: "c" },];
@@ -449,8 +449,8 @@ describe('LocusZoom.DataLayer', function(){
         it('should allow for showing or hiding a tool tip based on layout directives and element status', function(){
             this.plot.panels.p.addDataLayer("d", {
                 type: "scatter",
-                highlighted: "onmouseover",
-                selected: "onmouseover",
+                highlighted: { onmouseover: "toggle" },
+                selected: { onclick: "toggle" },
                 tooltip: {
                     show: { or: ["highlighted", "selected"] },
                     hide: { and: ["unhighlighted", "unselected"] },
@@ -459,6 +459,7 @@ describe('LocusZoom.DataLayer', function(){
             });
             var state_id = this.plot.panels.p.data_layers.d.state_id;
             this.plot.panels.p.data_layers.d.data = [{ id: "a" }, { id: "b" },{ id: "c" },];
+            this.plot.panels.p.data_layers.d.positionTooltip = function(){ return 0; };
             var d = this.plot.panels.p.data_layers.d;
             var a = d.data[0];
             var a_id = d.getElementId(a);

--- a/test/DataLayer.js
+++ b/test/DataLayer.js
@@ -446,6 +446,29 @@ describe('LocusZoom.DataLayer', function(){
             d3.select("#plot").remove();
             delete this.plot;
         });
+        it('should allow for creating and destroying tool tips', function(){
+            this.plot.panels.p.addDataLayer("d", {
+                type: "scatter",
+                tooltip: {
+                    html: "foo"
+                }
+            });
+            this.plot.panels.p.data_layers.d.data = [{ id: "a" }, { id: "b" },{ id: "c" },];
+            this.plot.panels.p.data_layers.d.positionTooltip = function(){ return 0; };
+            var a = this.plot.panels.p.data_layers.d.data[0];
+            var a_id = this.plot.panels.p.data_layers.d.getElementId(a);
+            var a_id_q = "#" + (a_id+"-tooltip").replace(/(:|\.|\[|\]|,)/g, "\\$1");
+            this.plot.panels.p.data_layers.d.tooltips.should.be.an.Object;
+            Object.keys(this.plot.panels.p.data_layers.d.tooltips).length.should.be.exactly(0);
+            this.plot.panels.p.data_layers.d.createTooltip(a);
+            this.plot.panels.p.data_layers.d.tooltips[a_id].should.be.an.Object;
+            Object.keys(this.plot.panels.p.data_layers.d.tooltips).length.should.be.exactly(1);
+            assert.equal(d3.select(a_id_q).empty(), false);
+            this.plot.panels.p.data_layers.d.destroyTooltip(a_id);
+            Object.keys(this.plot.panels.p.data_layers.d.tooltips).length.should.be.exactly(0);
+            assert.equal(typeof this.plot.panels.p.data_layers.d.tooltips[a_id], "undefined");
+            assert.equal(d3.select(a_id_q).empty(), true);
+        });
         it('should allow for showing or hiding a tool tip based on layout directives and element status', function(){
             this.plot.panels.p.addDataLayer("d", {
                 type: "scatter",

--- a/test/DataLayer.js
+++ b/test/DataLayer.js
@@ -320,4 +320,153 @@ describe('LocusZoom.DataLayer', function(){
         });
     });
 
+    describe("Highlight functions", function() {
+        beforeEach(function(){
+            this.plot = null;
+            this.layout = { panels: { p: { data_layers: {} } }, controls: false };
+            d3.select("body").append("div").attr("id", "plot");
+            this.plot = LocusZoom.populate("#plot", {}, this.layout);
+        });
+        afterEach(function(){
+            d3.select("#plot").remove();
+            delete this.plot;
+        });
+        it('should allow for highlighting and unhighlighting a single element', function(){
+            this.plot.panels.p.addDataLayer("d", { type: "scatter", highlightable: "onmouseover" });
+            var state_id = this.plot.panels.p.data_layers.d.state_id;
+            var d = this.plot.panels.p.data_layers.d;
+            this.plot.panels.p.data_layers.d.data = [{ id: "a" }, { id: "b" },{ id: "c" },];
+            this.plot.state[state_id].highlighted.should.be.an.Array;
+            this.plot.state[state_id].highlighted.length.should.be.exactly(0);
+            this.plot.panels.p.data_layers.d.highlightElement(d.getElementId(d.data[0]), true);
+            this.plot.state[state_id].highlighted.length.should.be.exactly(1);
+            this.plot.state[state_id].highlighted[0].should.be.exactly(d.getElementId(d.data[0]));
+            this.plot.panels.p.data_layers.d.highlightElement(d.getElementId(d.data[0]), false);
+            this.plot.state[state_id].highlighted.length.should.be.exactly(0);
+            this.plot.panels.p.data_layers.d.highlightElement(d.getElementId(d.data[2]));
+            this.plot.state[state_id].highlighted.length.should.be.exactly(1);
+            this.plot.state[state_id].highlighted[0].should.be.exactly(d.getElementId(d.data[2]));
+            this.plot.panels.p.data_layers.d.unhighlightElement(d.getElementId(d.data[1]));
+            this.plot.state[state_id].highlighted.length.should.be.exactly(1);
+            this.plot.panels.p.data_layers.d.unhighlightElement(d.getElementId(d.data[2]));
+            this.plot.state[state_id].highlighted.length.should.be.exactly(0);
+        });
+        it('should allow for highlighting and unhighlighting all elements', function(){
+            this.plot.panels.p.addDataLayer("d", { type: "scatter", highlightable: "onmouseover" });
+            var state_id = this.plot.panels.p.data_layers.d.state_id;
+            var d = this.plot.panels.p.data_layers.d;
+            this.plot.panels.p.data_layers.d.data = [{ id: "a" }, { id: "b" },{ id: "c" },];
+            this.plot.panels.p.data_layers.d.highlightAllElements(true);
+            this.plot.state[state_id].highlighted.length.should.be.exactly(3);
+            this.plot.state[state_id].highlighted[0].should.be.exactly(d.getElementId(d.data[0]));
+            this.plot.state[state_id].highlighted[1].should.be.exactly(d.getElementId(d.data[1]));
+            this.plot.state[state_id].highlighted[2].should.be.exactly(d.getElementId(d.data[2]));
+            this.plot.panels.p.data_layers.d.highlightAllElements(false);
+            this.plot.state[state_id].highlighted.length.should.be.exactly(0);
+            this.plot.panels.p.data_layers.d.highlightAllElements();
+            this.plot.state[state_id].highlighted.length.should.be.exactly(3);
+            this.plot.panels.p.data_layers.d.unhighlightAllElements();
+            this.plot.state[state_id].highlighted.length.should.be.exactly(0);
+        });
+    });
+
+    describe("Select functions", function() {
+        beforeEach(function(){
+            this.plot = null;
+            this.layout = { panels: { p: { data_layers: {} } }, controls: false };
+            d3.select("body").append("div").attr("id", "plot");
+            this.plot = LocusZoom.populate("#plot", {}, this.layout);
+        });
+        afterEach(function(){
+            d3.select("#plot").remove();
+            delete this.plot;
+        });
+        it('should allow for selecting and unselecting a single element', function(){
+            this.plot.panels.p.addDataLayer("d", { type: "scatter", selectable: { toggle: "onclick" } });
+            var state_id = this.plot.panels.p.data_layers.d.state_id;
+            var d = this.plot.panels.p.data_layers.d;
+            this.plot.panels.p.data_layers.d.data = [{ id: "a" }, { id: "b" },{ id: "c" },];
+            this.plot.state[state_id].selected.should.be.an.Array;
+            this.plot.state[state_id].selected.length.should.be.exactly(0);
+            this.plot.panels.p.data_layers.d.selectElement(d.getElementId(d.data[0]), true);
+            this.plot.state[state_id].selected.length.should.be.exactly(1);
+            this.plot.state[state_id].selected[0].should.be.exactly(d.getElementId(d.data[0]));
+            this.plot.panels.p.data_layers.d.selectElement(d.getElementId(d.data[0]), false);
+            this.plot.state[state_id].selected.length.should.be.exactly(0);
+            this.plot.panels.p.data_layers.d.selectElement(d.getElementId(d.data[2]));
+            this.plot.state[state_id].selected.length.should.be.exactly(1);
+            this.plot.state[state_id].selected[0].should.be.exactly(d.getElementId(d.data[2]));
+            this.plot.panels.p.data_layers.d.unselectElement(d.getElementId(d.data[1]));
+            this.plot.state[state_id].selected.length.should.be.exactly(1);
+            this.plot.panels.p.data_layers.d.unselectElement(d.getElementId(d.data[2]));
+            this.plot.state[state_id].selected.length.should.be.exactly(0);
+        });
+        it('should allow for selecting and unselecting all elements', function(){
+            this.plot.panels.p.addDataLayer("d", { type: "scatter", selectable: "onmouseover" });
+            var state_id = this.plot.panels.p.data_layers.d.state_id;
+            var d = this.plot.panels.p.data_layers.d;
+            this.plot.panels.p.data_layers.d.data = [{ id: "a" }, { id: "b" },{ id: "c" },];
+            this.plot.panels.p.data_layers.d.selectAllElements(true);
+            this.plot.state[state_id].selected.length.should.be.exactly(3);
+            this.plot.state[state_id].selected[0].should.be.exactly(d.getElementId(d.data[0]));
+            this.plot.state[state_id].selected[1].should.be.exactly(d.getElementId(d.data[1]));
+            this.plot.state[state_id].selected[2].should.be.exactly(d.getElementId(d.data[2]));
+            this.plot.panels.p.data_layers.d.selectAllElements(false);
+            this.plot.state[state_id].selected.length.should.be.exactly(0);
+            this.plot.panels.p.data_layers.d.selectAllElements();
+            this.plot.state[state_id].selected.length.should.be.exactly(3);
+            this.plot.panels.p.data_layers.d.unselectAllElements();
+            this.plot.state[state_id].selected.length.should.be.exactly(0);
+        });
+    });
+
+    describe("Tool tip functions", function() {
+        beforeEach(function(){
+            this.plot = null;
+            this.layout = { panels: { p: { data_layers: {} } }, controls: false };
+            d3.select("body").append("div").attr("id", "plot");
+            this.plot = LocusZoom.populate("#plot", {}, this.layout);
+        });
+        afterEach(function(){
+            d3.select("#plot").remove();
+            delete this.plot;
+        });
+        it('should allow for showing or hiding a tool tip based on layout directives and element status', function(){
+            this.plot.panels.p.addDataLayer("d", {
+                type: "scatter",
+                highlightable: "onmouseover",
+                selectable: "onmouseover",
+                tooltip: {
+                    show: { or: ["highlighted", "selected"] },
+                    hide: { and: ["unhighlighted", "unselected"] },
+                    html: ""
+                }
+            });
+            var state_id = this.plot.panels.p.data_layers.d.state_id;
+            var d = this.plot.panels.p.data_layers.d;
+            this.plot.panels.p.data_layers.d.data = [{ id: "a" }, { id: "b" },{ id: "c" },];
+            d.should.be.an.Object;
+            var a_id = d.getElementId(d.data[0]);
+            var b_id = d.getElementId(d.data[1]);
+            // Test highlighted OR selected
+            should(d[a_id]).be.type("undefined");
+            this.plot.panels.p.data_layers.d.highlightElement(a_id, true);
+            should(d[a_id]).be.an.Object;
+            this.plot.panels.p.data_layers.d.highlightElement(a_id, false);
+            should(d[a_id]).be.type("undefined");
+            this.plot.panels.p.data_layers.d.selectElement(a_id, true);
+            should(d[a_id]).be.an.Object;
+            this.plot.panels.p.data_layers.d.selectElement(a_id, false);
+            should(d[a_id]).be.type("undefined");
+            // Test highlight AND selected
+            should(d[b_id]).be.type("undefined");
+            this.plot.panels.p.data_layers.d.highlightElement(b_id, true);
+            this.plot.panels.p.data_layers.d.selectElement(b_id, true);
+            should(d[a_id]).be.an.Object;
+            this.plot.panels.p.data_layers.d.highlightElement(b_id, false);
+            this.plot.panels.p.data_layers.d.selectElement(b_id, false);
+            should(d[b_id]).be.type("undefined");
+        });
+    });
+
 });


### PR DESCRIPTION
# Overview

This branch began when encountering a complication presented by conditional analysis on a variant: the variant disappears from view. It is still, however, tracked as a "selected" variant and therefore the selection must be cleared, making sure the tool tip goes with it.

Looking to provide functions to easily clear selections to an implementer I ended up organizing the code for highlighting, selecting, and showing tool tips for data elements. In the process I expanded the supported layout directives to allow more control over how highlighting, selecting, and tool tips should behave.

## New Methods

The `DataLayer` class has several new methods that will need to be documented for implementers to use when setting up custom interactivity:

* `highlightElement(element)`
* `unhighlightElement(element)`
* `highlightAllElements()`
* `unhighlightAllElements()`
* `selectElement(element)`
* `unselectElement(element)`
* `selectAllElements()`
* `unselectAllElements()`

The above should be more or less self explanatory. The `element` passed to the singular methods is a discrete element from the `data` array of the data layer.

## New layout syntax

The new layout syntax allows for defining select, highlight, and tool tip behavior independently:

```javascript
data_layer: {
    ...
    highlighted: {
        onmouseover: "on",
        onmouseout: "off"
    },
    selected: {
        onclick: "toggle_exclusive",
        onshiftclick: "toggle"
    },
    tooltip: {
        closable: true,
        show: { or: ["highlighted", "selected"] },
        hide: { and: ["unhighlighted", "unselected"] },
        html: ""
    }
```

In this example, a mouse over event will highlight an element and a mouse out event will unhighlight it. A click will toggle the selection of an element exclusively (if selected deselect it, if not selected select it and deselect all the other elements). A shift click will just toggle with no exclusivity.

The tool tip also has syntax to dictate when it should be shown or hidden based on the selected and highlighted statuses together. Combined these new layout directive provide independent definitions for selection and highlighting, and tool tip display logic that is explicitly coupled to those statuses by the implementer to the behavior of their choosing.

In the process of setting this up it was little extra effort to include support for control-clicking, shift-clicking, and control-shift-clicking so that is included too.