### PR TITLE
Event Hooks

### DIFF
--- a/assets/js/app/DataLayer.js
+++ b/assets/js/app/DataLayer.js
@@ -510,6 +510,11 @@ LocusZoom.DataLayer.prototype.applyStatusBehavior = function(status, selection){
         }
         // Apply the new status
         this.setElementStatus(status, element, status_boolean);
+        // Trigger event emitters as needed
+        if (event == "click"){
+            this.parent.emit("element_clicked", element);
+            this.parent.parent.emit("element_clicked", element);
+        }
     }.bind(this);
     
     // Determine which bindings to set up

--- a/assets/js/app/DataLayer.js
+++ b/assets/js/app/DataLayer.js
@@ -423,8 +423,8 @@ LocusZoom.DataLayer.prototype.setElementStatus = function(status, element, toggl
     this.showOrHideTooltip(element);
 
     // Trigger layout changed event hook
-    this.parent.on("layout_changed");
-    this.parent.parent.on("layout_changed");
+    this.parent.emit("layout_changed");
+    this.parent.parent.emit("layout_changed");
     
 };
 

--- a/assets/js/app/DataLayer.js
+++ b/assets/js/app/DataLayer.js
@@ -86,10 +86,6 @@ LocusZoom.DataLayer.prototype.getElementById = function(id){
     }
 };
 
-LocusZoom.DataLayer.prototype.onUpdate = function(){
-    this.parent.onUpdate();
-};
-
 // Initialize a data layer
 LocusZoom.DataLayer.prototype.initialize = function(){
 
@@ -426,8 +422,9 @@ LocusZoom.DataLayer.prototype.setElementStatus = function(status, element, toggl
     // Trigger tool tip show/hide logic
     this.showOrHideTooltip(element);
 
-    // Trigger generic onUpdate
-    this.onUpdate();
+    // Trigger layout changed event hook
+    this.parent.on("layout_changed");
+    this.parent.parent.on("layout_changed");
     
 };
 

--- a/assets/js/app/Instance.js
+++ b/assets/js/app/Instance.js
@@ -55,14 +55,21 @@ LocusZoom.Instance = function(id, datasource, layout) {
         "data_rendered": []
     };
     this.on = function(event, hook){
-        if (typeof "event" != "string" || !Array.isArray(this.event_hooks[event])){ return; }
-        if (typeof hook == "undefined"){
-            this.event_hooks[event].forEach(function(hookToRun) {
-                hookToRun();
-            });
-        } else if (typeof hook == "function") {
-            this.event_hooks[event].push(hook);
+        if (typeof "event" != "string" || !Array.isArray(this.event_hooks[event])){
+            throw("Unable to register event hook, invalid event: " + event.toString());
         }
+        if (typeof hook != "function"){
+            throw("Unable to register event hook, invalid hook function passed");
+        }
+        this.event_hooks[event].push(hook.bind(this));
+    };
+    this.emit = function(event){
+        if (typeof "event" != "string" || !Array.isArray(this.event_hooks[event])){
+            throw("LocusZoom attempted to throw an invalid event: " + event.toString());
+        }
+        this.event_hooks[event].forEach(function(hookToRun) {
+            hookToRun();
+        });
     };
 
     // Get an object with the x and y coordinates of the instance's origin in terms of the entire page
@@ -254,7 +261,7 @@ LocusZoom.Instance.prototype.setDimensions = function(width, height){
         this.ui.render();
     }
 
-    this.on("layout_changed");
+    this.emit("layout_changed");
     return this;
 };
 
@@ -771,8 +778,8 @@ LocusZoom.Instance.prototype.mapTo = function(chr, start, end){
             this.curtain.drop(error);
         }.bind(this))
         .done(function(){
-            this.on("layout_changed");
-            this.on("data_rendered");
+            this.emit("layout_changed");
+            this.emit("data_rendered");
         }.bind(this));
 
     return this;
@@ -806,8 +813,8 @@ LocusZoom.Instance.prototype.applyState = function(new_state){
             this.curtain.drop(error);
         }.bind(this))
         .done(function(){
-            this.on("layout_changed");
-            this.on("data_rendered");
+            this.emit("layout_changed");
+            this.emit("data_rendered");
         }.bind(this));
 
     return this;

--- a/assets/js/app/Instance.js
+++ b/assets/js/app/Instance.js
@@ -52,7 +52,8 @@ LocusZoom.Instance = function(id, datasource, layout) {
     // Event hooks
     this.event_hooks = {
         "layout_changed": [],
-        "data_rendered": []
+        "data_rendered": [],
+        "element_clicked": []
     };
     this.on = function(event, hook){
         if (typeof "event" != "string" || !Array.isArray(this.event_hooks[event])){
@@ -61,14 +62,15 @@ LocusZoom.Instance = function(id, datasource, layout) {
         if (typeof hook != "function"){
             throw("Unable to register event hook, invalid hook function passed");
         }
-        this.event_hooks[event].push(hook.bind(this));
+        this.event_hooks[event].push(hook);
     };
-    this.emit = function(event){
+    this.emit = function(event, context){
         if (typeof "event" != "string" || !Array.isArray(this.event_hooks[event])){
             throw("LocusZoom attempted to throw an invalid event: " + event.toString());
         }
+        context = context || this;
         this.event_hooks[event].forEach(function(hookToRun) {
-            hookToRun();
+            hookToRun.call(context);
         });
     };
 

--- a/assets/js/app/Panel.js
+++ b/assets/js/app/Panel.js
@@ -56,8 +56,20 @@ LocusZoom.Panel = function(layout, parent) {
         return this.parent.id + "." + this.id;
     };
 
-    this.onUpdate = function(){
-        this.parent.onUpdate();
+    // Event hooks
+    this.event_hooks = {
+        "layout_changed": [],
+        "data_rendered": []
+    };
+    this.on = function(event, hook){
+        if (typeof "event" != "string" || !Array.isArray(this.event_hooks[event])){ return; }
+        if (typeof hook == "undefined"){
+            this.event_hooks[event].forEach(function(hookToRun) {
+                hookToRun();
+            });
+        } else if (typeof hook == "function") {
+            this.event_hooks[event].push(hook);
+        }
     };
     
     // Get an object with the x and y coordinates of the panel's origin in terms of the entire page
@@ -217,7 +229,7 @@ LocusZoom.Panel.prototype.initialize = function(){
     // Position with initial layout parameters
     this.svg.container = this.parent.svg.insert("svg:g", "#" + this.parent.id + "\\.ui")
         .attr("id", this.getBaseId() + ".panel_container")
-        .attr("transform", "translate(" + this.layout.origin.x +  "," + this.layout.origin.y + ")");
+        .attr("transform", "translate(" + this.layout.origin.x + "," + this.layout.origin.y + ")");
 
     // Append clip path to the parent svg element, size with initial layout parameters
     var clipPath = this.svg.container.append("clipPath")
@@ -542,6 +554,9 @@ LocusZoom.Panel.prototype.reMap = function(){
         .then(function(){
             this.initialized = true;
             this.render();
+            this.on("layout_changed");
+            this.parent.on("layout_changed");
+            this.on("data_rendered");
         }.bind(this))
         .catch(function(error){
             console.log(error);

--- a/assets/js/app/Panel.js
+++ b/assets/js/app/Panel.js
@@ -81,14 +81,21 @@ LocusZoom.Panel = function(layout, parent) {
         "data_rendered": []
     };
     this.on = function(event, hook){
-        if (typeof "event" != "string" || !Array.isArray(this.event_hooks[event])){ return; }
-        if (typeof hook == "undefined"){
-            this.event_hooks[event].forEach(function(hookToRun) {
-                hookToRun();
-            });
-        } else if (typeof hook == "function") {
-            this.event_hooks[event].push(hook);
+        if (typeof "event" != "string" || !Array.isArray(this.event_hooks[event])){
+            throw("Unable to register event hook, invalid event: " + event.toString());
         }
+        if (typeof hook != "function"){
+            throw("Unable to register event hook, invalid hook function passed");
+        }
+        this.event_hooks[event].push(hook.bind(this));
+    };
+    this.emit = function(event){
+        if (typeof "event" != "string" || !Array.isArray(this.event_hooks[event])){
+            throw("LocusZoom attempted to throw an invalid event: " + event.toString());
+        }
+        this.event_hooks[event].forEach(function(hookToRun) {
+            hookToRun();
+        });
     };
     
     // Get an object with the x and y coordinates of the panel's origin in terms of the entire page
@@ -573,9 +580,9 @@ LocusZoom.Panel.prototype.reMap = function(){
         .then(function(){
             this.initialized = true;
             this.render();
-            this.on("layout_changed");
-            this.parent.on("layout_changed");
-            this.on("data_rendered");
+            this.emit("layout_changed");
+            this.parent.emit("layout_changed");
+            this.emit("data_rendered");
         }.bind(this))
         .catch(function(error){
             console.log(error);

--- a/assets/js/app/Panel.js
+++ b/assets/js/app/Panel.js
@@ -78,7 +78,8 @@ LocusZoom.Panel = function(layout, parent) {
     // Event hooks
     this.event_hooks = {
         "layout_changed": [],
-        "data_rendered": []
+        "data_rendered": [],
+        "element_clicked": []
     };
     this.on = function(event, hook){
         if (typeof "event" != "string" || !Array.isArray(this.event_hooks[event])){
@@ -87,14 +88,15 @@ LocusZoom.Panel = function(layout, parent) {
         if (typeof hook != "function"){
             throw("Unable to register event hook, invalid hook function passed");
         }
-        this.event_hooks[event].push(hook.bind(this));
+        this.event_hooks[event].push(hook);
     };
-    this.emit = function(event){
+    this.emit = function(event, context){
         if (typeof "event" != "string" || !Array.isArray(this.event_hooks[event])){
             throw("LocusZoom attempted to throw an invalid event: " + event.toString());
         }
+        context = context || this;
         this.event_hooks[event].forEach(function(hookToRun) {
-            hookToRun();
+            hookToRun.call(context);
         });
     };
     

--- a/assets/js/app/Singletons.js
+++ b/assets/js/app/Singletons.js
@@ -789,11 +789,17 @@ LocusZoom.DataLayers.add("scatter", function(layout){
                 .attr("d", shape);
         }
 
-        // Apply selectable, tooltip, etc
-        this.applyAllStatusBehaviors(selection);
-
         // Remove old elements as needed
         selection.exit().remove();
+
+        // Apply default event emitters to selection
+        selection.on("click", function(element){
+            this.parent.emit("element_clicked", element);
+            this.parent.parent.emit("element_clicked", element);
+        }.bind(this));
+       
+        // Apply selectable, tooltip, etc
+        this.applyAllStatusBehaviors(selection);
 
         // Apply method to keep labels from overlapping each other
         if (this.layout.label){
@@ -1374,6 +1380,12 @@ LocusZoom.DataLayers.add("genes", function(layout){
 
                 // Remove old clickareas as needed
                 clickareas.exit().remove();
+
+                // Apply default event emitters to clickareas
+                clickareas.on("click", function(element){
+                    this.parent.emit("element_clicked", element);
+                    this.parent.parent.emit("element_clicked", element);
+                }.bind(this));
 
                 // Apply selectable, tooltip, etc to clickareas
                 data_layer.applyAllStatusBehaviors(clickareas);

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -944,8 +944,8 @@ LocusZoom.DataLayer.prototype.setElementStatus = function(status, element, toggl
     this.showOrHideTooltip(element);
 
     // Trigger layout changed event hook
-    this.parent.on("layout_changed");
-    this.parent.parent.on("layout_changed");
+    this.parent.emit("layout_changed");
+    this.parent.parent.emit("layout_changed");
     
 };
 
@@ -3153,14 +3153,21 @@ LocusZoom.Instance = function(id, datasource, layout) {
         "data_rendered": []
     };
     this.on = function(event, hook){
-        if (typeof "event" != "string" || !Array.isArray(this.event_hooks[event])){ return; }
-        if (typeof hook == "undefined"){
-            this.event_hooks[event].forEach(function(hookToRun) {
-                hookToRun();
-            });
-        } else if (typeof hook == "function") {
-            this.event_hooks[event].push(hook);
+        if (typeof "event" != "string" || !Array.isArray(this.event_hooks[event])){
+            throw("Unable to register event hook, invalid event: " + event.toString());
         }
+        if (typeof hook != "function"){
+            throw("Unable to register event hook, invalid hook function passed");
+        }
+        this.event_hooks[event].push(hook.bind(this));
+    };
+    this.emit = function(event){
+        if (typeof "event" != "string" || !Array.isArray(this.event_hooks[event])){
+            throw("LocusZoom attempted to throw an invalid event: " + event.toString());
+        }
+        this.event_hooks[event].forEach(function(hookToRun) {
+            hookToRun();
+        });
     };
 
     // Get an object with the x and y coordinates of the instance's origin in terms of the entire page
@@ -3352,7 +3359,7 @@ LocusZoom.Instance.prototype.setDimensions = function(width, height){
         this.ui.render();
     }
 
-    this.on("layout_changed");
+    this.emit("layout_changed");
     return this;
 };
 
@@ -3869,8 +3876,8 @@ LocusZoom.Instance.prototype.mapTo = function(chr, start, end){
             this.curtain.drop(error);
         }.bind(this))
         .done(function(){
-            this.on("layout_changed");
-            this.on("data_rendered");
+            this.emit("layout_changed");
+            this.emit("data_rendered");
         }.bind(this));
 
     return this;
@@ -3904,8 +3911,8 @@ LocusZoom.Instance.prototype.applyState = function(new_state){
             this.curtain.drop(error);
         }.bind(this))
         .done(function(){
-            this.on("layout_changed");
-            this.on("data_rendered");
+            this.emit("layout_changed");
+            this.emit("data_rendered");
         }.bind(this));
 
     return this;
@@ -3995,14 +4002,21 @@ LocusZoom.Panel = function(layout, parent) {
         "data_rendered": []
     };
     this.on = function(event, hook){
-        if (typeof "event" != "string" || !Array.isArray(this.event_hooks[event])){ return; }
-        if (typeof hook == "undefined"){
-            this.event_hooks[event].forEach(function(hookToRun) {
-                hookToRun();
-            });
-        } else if (typeof hook == "function") {
-            this.event_hooks[event].push(hook);
+        if (typeof "event" != "string" || !Array.isArray(this.event_hooks[event])){
+            throw("Unable to register event hook, invalid event: " + event.toString());
         }
+        if (typeof hook != "function"){
+            throw("Unable to register event hook, invalid hook function passed");
+        }
+        this.event_hooks[event].push(hook.bind(this));
+    };
+    this.emit = function(event){
+        if (typeof "event" != "string" || !Array.isArray(this.event_hooks[event])){
+            throw("LocusZoom attempted to throw an invalid event: " + event.toString());
+        }
+        this.event_hooks[event].forEach(function(hookToRun) {
+            hookToRun();
+        });
     };
     
     // Get an object with the x and y coordinates of the panel's origin in terms of the entire page
@@ -4487,9 +4501,9 @@ LocusZoom.Panel.prototype.reMap = function(){
         .then(function(){
             this.initialized = true;
             this.render();
-            this.on("layout_changed");
-            this.parent.on("layout_changed");
-            this.on("data_rendered");
+            this.emit("layout_changed");
+            this.parent.emit("layout_changed");
+            this.emit("data_rendered");
         }.bind(this))
         .catch(function(error){
             console.log(error);

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -1031,6 +1031,11 @@ LocusZoom.DataLayer.prototype.applyStatusBehavior = function(status, selection){
         }
         // Apply the new status
         this.setElementStatus(status, element, status_boolean);
+        // Trigger event emitters as needed
+        if (event == "click"){
+            this.parent.emit("element_clicked", element);
+            this.parent.parent.emit("element_clicked", element);
+        }
     }.bind(this);
     
     // Determine which bindings to set up
@@ -1887,11 +1892,17 @@ LocusZoom.DataLayers.add("scatter", function(layout){
                 .attr("d", shape);
         }
 
-        // Apply selectable, tooltip, etc
-        this.applyAllStatusBehaviors(selection);
-
         // Remove old elements as needed
         selection.exit().remove();
+
+        // Apply default event emitters to selection
+        selection.on("click", function(element){
+            this.parent.emit("element_clicked", element);
+            this.parent.parent.emit("element_clicked", element);
+        }.bind(this));
+       
+        // Apply selectable, tooltip, etc
+        this.applyAllStatusBehaviors(selection);
 
         // Apply method to keep labels from overlapping each other
         if (this.layout.label){
@@ -2472,6 +2483,12 @@ LocusZoom.DataLayers.add("genes", function(layout){
 
                 // Remove old clickareas as needed
                 clickareas.exit().remove();
+
+                // Apply default event emitters to clickareas
+                clickareas.on("click", function(element){
+                    this.parent.emit("element_clicked", element);
+                    this.parent.parent.emit("element_clicked", element);
+                }.bind(this));
 
                 // Apply selectable, tooltip, etc to clickareas
                 data_layer.applyAllStatusBehaviors(clickareas);
@@ -3150,7 +3167,8 @@ LocusZoom.Instance = function(id, datasource, layout) {
     // Event hooks
     this.event_hooks = {
         "layout_changed": [],
-        "data_rendered": []
+        "data_rendered": [],
+        "element_clicked": []
     };
     this.on = function(event, hook){
         if (typeof "event" != "string" || !Array.isArray(this.event_hooks[event])){
@@ -3159,14 +3177,15 @@ LocusZoom.Instance = function(id, datasource, layout) {
         if (typeof hook != "function"){
             throw("Unable to register event hook, invalid hook function passed");
         }
-        this.event_hooks[event].push(hook.bind(this));
+        this.event_hooks[event].push(hook);
     };
-    this.emit = function(event){
+    this.emit = function(event, context){
         if (typeof "event" != "string" || !Array.isArray(this.event_hooks[event])){
             throw("LocusZoom attempted to throw an invalid event: " + event.toString());
         }
+        context = context || this;
         this.event_hooks[event].forEach(function(hookToRun) {
-            hookToRun();
+            hookToRun.call(context);
         });
     };
 
@@ -3999,7 +4018,8 @@ LocusZoom.Panel = function(layout, parent) {
     // Event hooks
     this.event_hooks = {
         "layout_changed": [],
-        "data_rendered": []
+        "data_rendered": [],
+        "element_clicked": []
     };
     this.on = function(event, hook){
         if (typeof "event" != "string" || !Array.isArray(this.event_hooks[event])){
@@ -4008,14 +4028,15 @@ LocusZoom.Panel = function(layout, parent) {
         if (typeof hook != "function"){
             throw("Unable to register event hook, invalid hook function passed");
         }
-        this.event_hooks[event].push(hook.bind(this));
+        this.event_hooks[event].push(hook);
     };
-    this.emit = function(event){
+    this.emit = function(event, context){
         if (typeof "event" != "string" || !Array.isArray(this.event_hooks[event])){
             throw("LocusZoom attempted to throw an invalid event: " + event.toString());
         }
+        context = context || this;
         this.event_hooks[event].forEach(function(hookToRun) {
-            hookToRun();
+            hookToRun.call(context);
         });
     };
     

--- a/plot_builder.html
+++ b/plot_builder.html
@@ -222,7 +222,11 @@
               }
           ]
       };
-      plot.addPanel(layout);
+      var panel = plot.addPanel(layout);
+      panel.curtain.drop("loading...");
+      panel.on("data_rendered", function(){
+        this.curtain.raise(500);
+      }.bind(panel));
     }
 
     var plot;
@@ -241,7 +245,7 @@
     }
 
     function applyOnUpdate(){
-      plot.onUpdate(function(){
+      plot.on("layout_changed", function(){
         $("#layout").val(JSON.stringify(plot.layout, null, "  "));
       });
     }

--- a/plot_builder.html
+++ b/plot_builder.html
@@ -225,7 +225,7 @@
       var panel = plot.addPanel(layout);
       panel.curtain.drop("loading...");
       panel.on("data_rendered", function(){
-        this.curtain.raise(500);
+        this.curtain.raise();
       }.bind(panel));
     }
 
@@ -241,10 +241,10 @@
                           };
       var base_layout = LocusZoom.mergeLayouts(initial_state, LocusZoom.StandardLayout);
       plot = LocusZoom.populate("#plot", data_sources, base_layout);
-      applyOnUpdate();
+      applyOnLayoutChanged();
     }
 
-    function applyOnUpdate(){
+    function applyOnLayoutChanged(){
       plot.on("layout_changed", function(){
         $("#layout").val(JSON.stringify(plot.layout, null, "  "));
       });
@@ -263,7 +263,11 @@
         return;
       }
       plot = LocusZoom.populate("#plot", data_sources, layout);
-      applyOnUpdate();
+      plot.curtain.drop("applying layout...");
+      plot.on("data_rendered", function(){
+        this.curtain.raise();
+      }.bind(plot));
+      applyOnLayoutChanged();
     }
 
     resetPlot();

--- a/plot_builder.html
+++ b/plot_builder.html
@@ -241,6 +241,9 @@
                           };
       var base_layout = LocusZoom.mergeLayouts(initial_state, LocusZoom.StandardLayout);
       plot = LocusZoom.populate("#plot", data_sources, base_layout);
+      plot.on("element_clicked", function(){
+        console.log("element clicked: ", this);
+      });
       applyOnLayoutChanged();
     }
 


### PR DESCRIPTION
This small branch expands the "onUpdate" functionality on plots to named "event hooks" that live on both plots and panels.

## The old way

Before, an implementer would register an onUpdate function like this:

```javascript
plot.onUpdate(function(){
  ...
});
```

And all registered onUpdate functions would fire whenever the layout changed. The layout changes every time state changes, or the geometry of the plot changes. This was needed to make the plot builder show the layout contents change in real time, but is too noisy for implementers wanting to hook to less frequent events.

## The new way

Now an implementer does this:

```javascript
plot.on("layout_changed", function(){
  ...
});
```

And can register many functions to named events.

## Supported events

Two named events are supported in this branch:

* `layout_changed`
* `data_rendered`

The `on(event , hook)` method will do nothing if passed an event that is not present in the object's internal `event_hooks` object. Adding support for new event types would consist of adding an array to track registered functions in the `event_hooks` object and adding triggers to that event where appropriate in the core library.

The plot builder demo has been updated to demonstrate hooks to both supported events at the instance level.

## Plots and Panels

The same event hooks framework with the accompanying `on(event, hook)` function has been applied to instances/plots as well as to panels. The plot builder demonstrates panel-level event hooking by showing a "loading" overlay on the new panel when adding an analysis.