### PR TITLE
Data Filtering

### DIFF
--- a/assets/css/locuszoom.scss
+++ b/assets/css/locuszoom.scss
@@ -87,8 +87,8 @@ svg.#{$namespace}-locuszoom {
   }
 
   path.#{$namespace}-data_layer-scatter-identified {
-    stroke: #{$default_black_shadow_svg_color};
-    stroke-opacity: #{$default_black_shadow_svg_opacity};
+    stroke: rgb(66,66,66);
+    stroke-opacity: 0.8;
     stroke-width: 4px;
   }
 

--- a/assets/css/locuszoom.scss
+++ b/assets/css/locuszoom.scss
@@ -91,15 +91,9 @@ svg.#{$namespace}-locuszoom {
     stroke-width: 4px;
   }
 
-  path.#{$namespace}-data_layer-scatter-identified {
-    stroke: rgb(66,66,66);
-    stroke-opacity: 0.8;
-    stroke-width: 4px;
-  }
-
   path.#{$namespace}-data_layer-scatter-dimmed {
-    fill-opacity: 0.2;
-    stroke-opacity: 0.2;
+    fill-opacity: 0.1;
+    stroke-opacity: 0.1;
   }
 
   path.#{$namespace}-data_layer-scatter-hidden {
@@ -128,8 +122,16 @@ svg.#{$namespace}-locuszoom {
     cursor: pointer;
   }
 
-  g.#{$namespace}-data_layer-gene {
+  g.#{$namespace}-data_layer-genes {
     cursor: pointer;
+  }
+
+  g.#{$namespace}-data_layer-genes-dimmed {
+    opacity: 0.1;
+  }
+
+  g.#{$namespace}-data_layer-genes-hidden {
+    display: none;
   }
 
   text.#{$namespace}-data_layer-genes.#{$namespace}-label {
@@ -143,12 +145,6 @@ svg.#{$namespace}-locuszoom {
   }
 
   rect.#{$namespace}-data_layer-genes.#{$namespace}-data_layer-genes-bounding_box-highlighted {
-    fill: rgb(54, 54, 150);
-    fill-opacity: 0.1;
-    stroke-width: 0px;
-  }
-
-  rect.#{$namespace}-data_layer-genes.#{$namespace}-data_layer-genes-bounding_box-identified {
     fill: rgb(54, 54, 150);
     fill-opacity: 0.1;
     stroke-width: 0px;

--- a/assets/css/locuszoom.scss
+++ b/assets/css/locuszoom.scss
@@ -86,6 +86,12 @@ svg.#{$namespace}-locuszoom {
     stroke-width: 4px;
   }
 
+  path.#{$namespace}-data_layer-scatter-identified {
+    stroke: #{$default_black_shadow_svg_color};
+    stroke-opacity: #{$default_black_shadow_svg_opacity};
+    stroke-width: 4px;
+  }
+
   path.#{$namespace}-data_layer-scatter-selected {
     stroke: #{$default_black};
     stroke-width: 4px;
@@ -128,6 +134,12 @@ svg.#{$namespace}-locuszoom {
   }
 
   rect.#{$namespace}-data_layer-genes.#{$namespace}-data_layer-genes-bounding_box-highlighted {
+    fill: rgb(54, 54, 150);
+    fill-opacity: 0.1;
+    stroke-width: 0px;
+  }
+
+  rect.#{$namespace}-data_layer-genes.#{$namespace}-data_layer-genes-bounding_box-identified {
     fill: rgb(54, 54, 150);
     fill-opacity: 0.1;
     stroke-width: 0px;

--- a/assets/css/locuszoom.scss
+++ b/assets/css/locuszoom.scss
@@ -86,15 +86,24 @@ svg.#{$namespace}-locuszoom {
     stroke-width: 4px;
   }
 
+  path.#{$namespace}-data_layer-scatter-selected {
+    stroke: #{$default_black};
+    stroke-width: 4px;
+  }
+
   path.#{$namespace}-data_layer-scatter-identified {
     stroke: rgb(66,66,66);
     stroke-opacity: 0.8;
     stroke-width: 4px;
   }
 
-  path.#{$namespace}-data_layer-scatter-selected {
-    stroke: #{$default_black};
-    stroke-width: 4px;
+  path.#{$namespace}-data_layer-scatter-dimmed {
+    fill-opacity: 0.2;
+    stroke-opacity: 0.2;
+  }
+
+  path.#{$namespace}-data_layer-scatter-hidden {
+    display: none;
   }
 
   text.#{$namespace}-data_layer-scatter-label {

--- a/assets/js/app/DataLayer.js
+++ b/assets/js/app/DataLayer.js
@@ -585,16 +585,22 @@ LocusZoom.DataLayer.prototype.setAllElementStatus = function(status, toggle){
 };
 
 // Toggle a status on elements in the data layer based on a set of filters
-LocusZoom.DataLayer.prototype.setElementStatusByFilters = function(status, toggle, filters){
+LocusZoom.DataLayer.prototype.setElementStatusByFilters = function(status, toggle, filters, exclusive){
     
     // Sanity check
     if (typeof status == "undefined" || ["highlighted","selected","identified"].indexOf(status) == -1){
         throw("Invalid status passed to setElementStatusByFilters()");
     }
     if (typeof this.state[this.state_id][status] == "undefined"){ return this; }
-    if (typeof toggle == "undefined"){ toggle = true; }
+    if (typeof toggle == "undefined"){ toggle = true; } else { toggle = !!toggle; }
+    if (typeof exclusive == "undefined"){ exclusive = false; } else { exclusive = !!exclusive; }
     if (!Array.isArray(filters)){ filters = []; }
 
+    // Enforce exlcusivity (force all elements to have the opposite of toggle first)
+    if (exclusive){
+        this.setAllElementStatus(status, !toggle);
+    }
+    
     // Apply statuses
     this.filterElements(filters).forEach(function(element){
         if (this.state[this.state_id][status].indexOf(this.getElementId(element)) == -1){
@@ -604,23 +610,29 @@ LocusZoom.DataLayer.prototype.setElementStatusByFilters = function(status, toggl
     
     return this;
 };
-LocusZoom.DataLayer.prototype.highlightElementsByFilters = function(filters){
-    return this.setElementStatusByFilters("highlighted", true, filters);
+LocusZoom.DataLayer.prototype.highlightElementsByFilters = function(filters, exclusive){
+    if (typeof exclusive == "undefined"){ exclusive = false; } else { exclusive = !!exclusive; }
+    return this.setElementStatusByFilters("highlighted", true, filters, exclusive);
 };
-LocusZoom.DataLayer.prototype.unhighlightElementsByFilters = function(filters){
-    return this.setElementStatusByFilters("highlighted", false, filters);
+LocusZoom.DataLayer.prototype.unhighlightElementsByFilters = function(filters, exclusive){
+    if (typeof exclusive == "undefined"){ exclusive = false; } else { exclusive = !!exclusive; }
+    return this.setElementStatusByFilters("highlighted", false, filters, exclusive);
 };
-LocusZoom.DataLayer.prototype.selectElementsByFilters = function(filters){
-    return this.setElementStatusByFilters("selected", true, filters);
+LocusZoom.DataLayer.prototype.selectElementsByFilters = function(filters, exclusive){
+    if (typeof exclusive == "undefined"){ exclusive = false; } else { exclusive = !!exclusive; }
+    return this.setElementStatusByFilters("selected", true, filters, exclusive);
 };
-LocusZoom.DataLayer.prototype.unselectElementsByFilters = function(filters){
-    return this.setElementStatusByFilters("selected", false, filters);
+LocusZoom.DataLayer.prototype.unselectElementsByFilters = function(filters, exclusive){
+    if (typeof exclusive == "undefined"){ exclusive = false; } else { exclusive = !!exclusive; }
+    return this.setElementStatusByFilters("selected", false, filters, exclusive);
 };
-LocusZoom.DataLayer.prototype.identifyElementsByFilters = function(filters){
-    return this.setElementStatusByFilters("identified", true, filters);
+LocusZoom.DataLayer.prototype.identifyElementsByFilters = function(filters, exclusive){
+    if (typeof exclusive == "undefined"){ exclusive = false; } else { exclusive = !!exclusive; }
+    return this.setElementStatusByFilters("identified", true, filters, exclusive);
 };
-LocusZoom.DataLayer.prototype.unidentifyElementsByFilters = function(filters){
-    return this.setElementStatusByFilters("identified", false, filters);
+LocusZoom.DataLayer.prototype.unidentifyElementsByFilters = function(filters, exclusive){
+    if (typeof exclusive == "undefined"){ exclusive = false; } else { exclusive = !!exclusive; }
+    return this.setElementStatusByFilters("identified", false, filters, exclusive);
 };
 
 // Apply mouse event bindings to create status-related behavior (e.g. highlighted, selected, identified)

--- a/assets/js/app/DataLayer.js
+++ b/assets/js/app/DataLayer.js
@@ -37,12 +37,9 @@ LocusZoom.DataLayer = function(layout, parent) {
         this.state = this.parent.state;
         this.state_id = this.parent.id + "." + this.id;
         this.state[this.state_id] = this.state[this.state_id] || {};
-        if (typeof this.layout.highlighted == "object"){
-            this.state[this.state_id].highlighted = this.state[this.state_id].highlighted || [];
-        }
-        if (typeof this.layout.selected == "object"){
-            this.state[this.state_id].selected = this.state[this.state_id].selected || [];
-        }
+        this.state[this.state_id].highlighted = this.state[this.state_id].highlighted || [];
+        this.state[this.state_id].selected = this.state[this.state_id].selected || [];
+        this.state[this.state_id].identified = this.state[this.state_id].identified || [];
     } else {
         this.state = {};
         this.state_id = null;
@@ -394,6 +391,8 @@ LocusZoom.DataLayer.prototype.showOrHideTooltip = function(element){
     statuses.unhighlighted = !statuses.highlighted;
     statuses.selected = this.state[this.state_id].selected.indexOf(id) != -1;
     statuses.unselected = !statuses.selected;
+    statuses.identified = this.state[this.state_id].identified.indexOf(id) != -1;
+    statuses.unidentified = !statuses.identified;
 
     var show_resolved = resolveStatus(statuses, show_directive);
     var hide_resolved = resolveStatus(statuses, hide_directive);
@@ -409,6 +408,46 @@ LocusZoom.DataLayer.prototype.showOrHideTooltip = function(element){
     return this;
     
 };
+
+// Get an array of element indexes matching a set of filters
+// Filters should be of the form [field, value] (for equivalence testing) or [field, operator, value]
+// Return type can be "indexes" or "elements" and determines whether the returned array contains
+// indexes of matching elements in the data layer's data set or references to the matching elements
+LocusZoom.DataLayer.prototype.filter = function(filters, return_type){
+    if (typeof return_type == "undefined" || ["indexes","elements"].indexOf(return_type) == -1){
+        return_type = "indexes";
+    }
+    if (!Array.isArray(filters)){ return []; }
+    var test = function(element, filter){
+        var operators = {
+            "=": function(a,b){ return a == b; },
+            "<": function(a,b){ return a < b; },
+            "<=": function(a,b){ return a <= b; },
+            ">": function(a,b){ return a > b; },
+            ">=": function(a,b){ return a >= b; },
+            "%": function(a,b){ return a % b; }
+        };
+        if (!Array.isArray(filter)){ return false; }
+        if (filter.length == 2){
+            return element[filter[0]] == filter[1];
+        } else if (filter.length == 3 && operators[filter[1]]){
+            return operators[filter[1]](element[filter[0]], filter[2]);
+        } else {
+            return false;
+        }
+    };
+    var matches = [];
+    this.data.forEach(function(element, idx){
+        var match = true;
+        filters.forEach(function(filter){
+            if (!test(element, filter)){ match = false; }
+        });
+        if (match){ matches.push(return_type == "indexes" ? idx : element); }
+    });
+    return matches;
+};
+LocusZoom.DataLayer.prototype.filterIndexes = function(filters){ return this.filter(filters, "indexes"); };
+LocusZoom.DataLayer.prototype.filterElements = function(filters){ return this.filter(filters, "elements"); };
 
 // Toggle the highlighted status of an element
 LocusZoom.DataLayer.prototype.highlightElement = function(element){
@@ -450,11 +489,31 @@ LocusZoom.DataLayer.prototype.unselectAllElements = function(){
     return this;
 };
 
-// Toggle a status (e.g. highlighted, selected) on an element
+// Toggle the identified status of an element
+LocusZoom.DataLayer.prototype.identifyElement = function(element){
+    this.setElementStatus("identified", element, true);
+    return this;
+};
+LocusZoom.DataLayer.prototype.unidentifyElement = function(element){
+    this.setElementStatus("identified", element, false);
+    return this;
+};
+
+// Toggle the identified status of all elements
+LocusZoom.DataLayer.prototype.identifyAllElements = function(){
+    this.setAllElementStatus("identified", true);
+    return this;
+};
+LocusZoom.DataLayer.prototype.unidentifyAllElements = function(){
+    this.setAllElementStatus("identified", false);
+    return this;
+};
+
+// Toggle a status (e.g. highlighted, selected, identified) on an element
 LocusZoom.DataLayer.prototype.setElementStatus = function(status, element, toggle){
     
     // Sanity checks
-    if (typeof status == "undefined" || ["highlighted","selected"].indexOf(status) == -1){
+    if (typeof status == "undefined" || ["highlighted","selected","identified"].indexOf(status) == -1){
         throw("Invalid status passed to setElementStatus()");
     }
     if (typeof element == "undefined"){
@@ -499,7 +558,7 @@ LocusZoom.DataLayer.prototype.setElementStatus = function(status, element, toggl
 LocusZoom.DataLayer.prototype.setAllElementStatus = function(status, toggle){
     
     // Sanity check
-    if (typeof status == "undefined" || ["highlighted","selected"].indexOf(status) == -1){
+    if (typeof status == "undefined" || ["highlighted","selected","identified"].indexOf(status) == -1){
         throw("Invalid status passed to setAllElementStatus()");
     }
     if (typeof this.state[this.state_id][status] == "undefined"){ return this; }
@@ -529,7 +588,7 @@ LocusZoom.DataLayer.prototype.setAllElementStatus = function(status, toggle){
 LocusZoom.DataLayer.prototype.setElementStatusByFilters = function(status, toggle, filters){
     
     // Sanity check
-    if (typeof status == "undefined" || ["highlighted","selected"].indexOf(status) == -1){
+    if (typeof status == "undefined" || ["highlighted","selected","identified"].indexOf(status) == -1){
         throw("Invalid status passed to setElementStatusByFilters()");
     }
     if (typeof this.state[this.state_id][status] == "undefined"){ return this; }
@@ -545,8 +604,26 @@ LocusZoom.DataLayer.prototype.setElementStatusByFilters = function(status, toggl
     
     return this;
 };
+LocusZoom.DataLayer.prototype.highlightElementsByFilters = function(filters){
+    return this.setElementStatusByFilters("highlighted", true, filters);
+};
+LocusZoom.DataLayer.prototype.unhighlightElementsByFilters = function(filters){
+    return this.setElementStatusByFilters("highlighted", false, filters);
+};
+LocusZoom.DataLayer.prototype.selectElementsByFilters = function(filters){
+    return this.setElementStatusByFilters("selected", true, filters);
+};
+LocusZoom.DataLayer.prototype.unselectElementsByFilters = function(filters){
+    return this.setElementStatusByFilters("selected", false, filters);
+};
+LocusZoom.DataLayer.prototype.identifyElementsByFilters = function(filters){
+    return this.setElementStatusByFilters("identified", true, filters);
+};
+LocusZoom.DataLayer.prototype.unidentifyElementsByFilters = function(filters){
+    return this.setElementStatusByFilters("identified", false, filters);
+};
 
-// Apply mouse event bindings to create status-related behavior (e.g. highlighted, selected)
+// Apply mouse event bindings to create status-related behavior (e.g. highlighted, selected, identified)
 LocusZoom.DataLayer.prototype.applyStatusBehavior = function(status, selection){
 
     // Glossary for this function:
@@ -555,7 +632,7 @@ LocusZoom.DataLayer.prototype.applyStatusBehavior = function(status, selection){
     // action - a more verbose locuszoom-layout-specific form of an event (e.g. "onmouseover", "onshiftclick")
 
     // Sanity checks
-    if (typeof status == "undefined" || ["highlighted","selected"].indexOf(status) == -1){ return; }
+    if (typeof status == "undefined" || ["highlighted","selected","identified"].indexOf(status) == -1){ return; }
     if (typeof selection != "object"){ return; }
     if (typeof this.layout[status] != "object" || !this.layout[status]){ return; }
 
@@ -630,52 +707,12 @@ LocusZoom.DataLayer.prototype.applyStatusBehavior = function(status, selection){
 
 // Apply all supported status behaviors to a selection of objects
 LocusZoom.DataLayer.prototype.applyAllStatusBehaviors = function(selection){
-    var supported_statuses = ["highlighted","selected"];
+    var supported_statuses = ["highlighted","selected","identified"];
     supported_statuses.forEach(function(status){
         this.applyStatusBehavior(status, selection);
     }.bind(this));
     return this;
 };
-
-// Get an array of element indexes matching a set of filters
-// Filters should be of the form [field, value] (for equivalence testing) or [field, operator, value]
-// Return type can be "indexes" or "elements" and determines whether the returned array contains
-// indexes of matching elements in the data layer's data set or references to the matching elements
-LocusZoom.DataLayer.prototype.filter = function(filters, return_type){
-    if (typeof return_type == "undefined" || ["indexes","elements"].indexOf(return_type) == -1){
-        return_type = "indexes";
-    }
-    if (!Array.isArray(filters)){ return []; }
-    var test = function(element, filter){
-        var operators = {
-            "=": function(a,b){ return a == b; },
-            "<": function(a,b){ return a < b; },
-            "<=": function(a,b){ return a <= b; },
-            ">": function(a,b){ return a > b; },
-            ">=": function(a,b){ return a >= b; },
-            "%": function(a,b){ return a % b; }
-        };
-        if (!Array.isArray(filter)){ return false; }
-        if (filter.length == 2){
-            return element[filter[0]] == filter[1];
-        } else if (filter.length == 3 && operators[filter[1]]){
-            return operators[filter[1]](element[filter[0]], filter[2]);
-        } else {
-            return false;
-        }
-    };
-    var matches = [];
-    this.data.forEach(function(element, idx){
-        var match = true;
-        filters.forEach(function(filter){
-            if (!test(element, filter)){ match = false; }
-        });
-        if (match){ matches.push(return_type == "indexes" ? idx : element); }
-    });
-    return matches;
-};
-LocusZoom.DataLayer.prototype.filterIndexes = function(filters){ return this.filter(filters, "indexes"); };
-LocusZoom.DataLayer.prototype.filterElements = function(filters){ return this.filter(filters, "elements"); };
 
 // Get an object with the x and y coordinates of the panel's origin in terms of the entire page
 // Necessary for positioning any HTML elements over the panel

--- a/assets/js/app/Layouts.js
+++ b/assets/js/app/Layouts.js
@@ -323,7 +323,10 @@ LocusZoom.Layouts.add("data_layer", "genes", {
             + "<tr><td>Missense</td><td>{{exp_mis}}</td><td>{{n_mis}}</td><td>z = {{mis_z}}</td></tr>"
             + "<tr><td>LoF</td><td>{{exp_lof}}</td><td>{{n_lof}}</td><td>pLI = {{pLI}}</td></tr>"
             + "</table>"
-            + "<div style=\"width: 100%; text-align: right;\"><a href=\"http://exac.broadinstitute.org/gene/{{gene_id}}\" target=\"_new\">More data on ExAC</a></div>"
+            + "<table width=\"100%\"><tr>"
+            + "<td><button onclick=\"LocusZoom.getToolTipPlot(this).panels.association.identifyElementsByFilters([['position','>','{{start}}'],['position','<','{{end}}']], true); LocusZoom.getToolTipPanel(this).data_layers.genes.unselectAllElements();\">Identify variants in region</button></td>"
+            + "<td style=\"text-align: right;\"><a href=\"http://exac.broadinstitute.org/gene/{{gene_id}}\" target=\"_new\">More data on ExAC</a></td>"
+            + "</tr></table>"
     }
 });
 

--- a/assets/js/app/Layouts.js
+++ b/assets/js/app/Layouts.js
@@ -324,7 +324,7 @@ LocusZoom.Layouts.add("data_layer", "genes", {
             + "<tr><td>LoF</td><td>{{exp_lof}}</td><td>{{n_lof}}</td><td>pLI = {{pLI}}</td></tr>"
             + "</table>"
             + "<table width=\"100%\"><tr>"
-            + "<td><button onclick=\"LocusZoom.getToolTipPlot(this).panels.association.identifyElementsByFilters([['position','>','{{start}}'],['position','<','{{end}}']], true); LocusZoom.getToolTipPanel(this).data_layers.genes.unselectAllElements();\">Identify variants in region</button></td>"
+            + "<td><button onclick=\"LocusZoom.getToolTipPlot(this).panels.association.undimElementsByFilters([['position','>','{{start}}'],['position','<','{{end}}']], true); LocusZoom.getToolTipPanel(this).data_layers.genes.unselectAllElements();\">Identify variants in region</button></td>"
             + "<td style=\"text-align: right;\"><a href=\"http://exac.broadinstitute.org/gene/{{gene_id}}\" target=\"_new\">More data on ExAC</a></td>"
             + "</tr></table>"
     }

--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -349,3 +349,27 @@ LocusZoom.getToolTipData = function(node){
         return LocusZoom.getToolTipData(node.parentNode);
     }
 };
+
+// Shortcut method for getting a reference to the data layer that generated a tool tip.
+// Accepts the node object for any element contained within the tool tip.
+LocusZoom.getToolTipDataLayer = function(node){
+    var data = LocusZoom.getToolTipData(node);
+    if (data.getDataLayer){ return data.getDataLayer(); }
+    return null;
+};
+
+// Shortcut method for getting a reference to the panel that generated a tool tip.
+// Accepts the node object for any element contained within the tool tip.
+LocusZoom.getToolTipPanel = function(node){
+    var data_layer = LocusZoom.getToolTipDataLayer(node);
+    if (data_layer){ return data_layer.parent; }
+    return null;
+};
+
+// Shortcut method for getting a reference to the plot that generated a tool tip.
+// Accepts the node object for any element contained within the tool tip.
+LocusZoom.getToolTipPlot = function(node){
+    var panel = LocusZoom.getToolTipPanel(node);
+    if (panel){ return panel.parent; }
+    return null;
+};

--- a/assets/js/app/Panel.js
+++ b/assets/js/app/Panel.js
@@ -1096,6 +1096,37 @@ LocusZoom.Panel.prototype.scaleHeightToData = function(){
     }
 };
 
+// Toggle a status on elements in all child data layers based on a set of filters
+LocusZoom.Panel.prototype.setElementStatusByFilters = function(status, toggle, filters, exclusive){
+    this.data_layer_ids_by_z_index.forEach(function(id){
+        this.data_layers[id].setElementStatusByFilters(status, toggle, filters, exclusive);
+    }.bind(this));
+};
+LocusZoom.Panel.prototype.highlightElementsByFilters = function(filters, exclusive){
+    if (typeof exclusive == "undefined"){ exclusive = false; } else { exclusive = !!exclusive; }
+    return this.setElementStatusByFilters("highlighted", true, filters, exclusive);
+};
+LocusZoom.Panel.prototype.unhighlightElementsByFilters = function(filters, exclusive){
+    if (typeof exclusive == "undefined"){ exclusive = false; } else { exclusive = !!exclusive; }
+    return this.setElementStatusByFilters("highlighted", false, filters, exclusive);
+};
+LocusZoom.Panel.prototype.selectElementsByFilters = function(filters, exclusive){
+    if (typeof exclusive == "undefined"){ exclusive = false; } else { exclusive = !!exclusive; }
+    return this.setElementStatusByFilters("selected", true, filters, exclusive);
+};
+LocusZoom.Panel.prototype.unselectElementsByFilters = function(filters, exclusive){
+    if (typeof exclusive == "undefined"){ exclusive = false; } else { exclusive = !!exclusive; }
+    return this.setElementStatusByFilters("selected", false, filters, exclusive);
+};
+LocusZoom.Panel.prototype.identifyElementsByFilters = function(filters, exclusive){
+    if (typeof exclusive == "undefined"){ exclusive = false; } else { exclusive = !!exclusive; }
+    return this.setElementStatusByFilters("identified", true, filters, exclusive);
+};
+LocusZoom.Panel.prototype.unidentifyElementsByFilters = function(filters, exclusive){
+    if (typeof exclusive == "undefined"){ exclusive = false; } else { exclusive = !!exclusive; }
+    return this.setElementStatusByFilters("identified", false, filters, exclusive);
+};
+
 // Add a "basic" loader to a panel
 // This method is jsut a shortcut for adding the most commonly used type of loader
 // which appears when data is requested, animates (e.g. shows an infinitely cycling

--- a/assets/js/app/Panel.js
+++ b/assets/js/app/Panel.js
@@ -1096,36 +1096,39 @@ LocusZoom.Panel.prototype.scaleHeightToData = function(){
     }
 };
 
-// Toggle a status on elements in all child data layers based on a set of filters
+// Methods to set/unset element statuses across all data layers
 LocusZoom.Panel.prototype.setElementStatusByFilters = function(status, toggle, filters, exclusive){
     this.data_layer_ids_by_z_index.forEach(function(id){
         this.data_layers[id].setElementStatusByFilters(status, toggle, filters, exclusive);
     }.bind(this));
 };
-LocusZoom.Panel.prototype.highlightElementsByFilters = function(filters, exclusive){
-    if (typeof exclusive == "undefined"){ exclusive = false; } else { exclusive = !!exclusive; }
-    return this.setElementStatusByFilters("highlighted", true, filters, exclusive);
+LocusZoom.Panel.prototype.setAllElementStatus = function(status, toggle){
+    this.data_layer_ids_by_z_index.forEach(function(id){
+        this.data_layers[id].setAllElementStatus(status, toggle);
+    }.bind(this));
 };
-LocusZoom.Panel.prototype.unhighlightElementsByFilters = function(filters, exclusive){
-    if (typeof exclusive == "undefined"){ exclusive = false; } else { exclusive = !!exclusive; }
-    return this.setElementStatusByFilters("highlighted", false, filters, exclusive);
-};
-LocusZoom.Panel.prototype.selectElementsByFilters = function(filters, exclusive){
-    if (typeof exclusive == "undefined"){ exclusive = false; } else { exclusive = !!exclusive; }
-    return this.setElementStatusByFilters("selected", true, filters, exclusive);
-};
-LocusZoom.Panel.prototype.unselectElementsByFilters = function(filters, exclusive){
-    if (typeof exclusive == "undefined"){ exclusive = false; } else { exclusive = !!exclusive; }
-    return this.setElementStatusByFilters("selected", false, filters, exclusive);
-};
-LocusZoom.Panel.prototype.identifyElementsByFilters = function(filters, exclusive){
-    if (typeof exclusive == "undefined"){ exclusive = false; } else { exclusive = !!exclusive; }
-    return this.setElementStatusByFilters("identified", true, filters, exclusive);
-};
-LocusZoom.Panel.prototype.unidentifyElementsByFilters = function(filters, exclusive){
-    if (typeof exclusive == "undefined"){ exclusive = false; } else { exclusive = !!exclusive; }
-    return this.setElementStatusByFilters("identified", false, filters, exclusive);
-};
+LocusZoom.DataLayer.Statuses.verbs.forEach(function(verb, idx){
+    var adjective = LocusZoom.DataLayer.Statuses.adjectives[idx];
+    var antiverb = "un" + verb;
+    // Set/unset status for arbitrarily many elements given a set of filters
+    LocusZoom.Panel.prototype[verb + "ElementsByFilters"] = function(filters, exclusive){
+        if (typeof exclusive == "undefined"){ exclusive = false; } else { exclusive = !!exclusive; }
+        return this.setElementStatusByFilters(adjective, true, filters, exclusive);
+    };
+    LocusZoom.Panel.prototype[antiverb + "ElementsByFilters"] = function(filters, exclusive){
+        if (typeof exclusive == "undefined"){ exclusive = false; } else { exclusive = !!exclusive; }
+        return this.setElementStatusByFilters(adjective, false, filters, exclusive);
+    };
+    // Set/unset status for all elements
+    LocusZoom.Panel.prototype[verb + "AllElements"] = function(){
+        this.setAllElementStatus(adjective, true);
+        return this;
+    };
+    LocusZoom.Panel.prototype[antiverb + "AllElements"] = function(){
+        this.setAllElementStatus(adjective, false);
+        return this;
+    };
+});
 
 // Add a "basic" loader to a panel
 // This method is jsut a shortcut for adding the most commonly used type of loader

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -732,7 +732,7 @@ LocusZoom.Layouts.add("data_layer", "genes", {
             + "<tr><td>LoF</td><td>{{exp_lof}}</td><td>{{n_lof}}</td><td>pLI = {{pLI}}</td></tr>"
             + "</table>"
             + "<table width=\"100%\"><tr>"
-            + "<td><button onclick=\"LocusZoom.getToolTipPlot(this).panels.association.identifyElementsByFilters([['position','>','{{start}}'],['position','<','{{end}}']], true); LocusZoom.getToolTipPanel(this).data_layers.genes.unselectAllElements();\">Identify variants in region</button></td>"
+            + "<td><button onclick=\"LocusZoom.getToolTipPlot(this).panels.association.undimElementsByFilters([['position','>','{{start}}'],['position','<','{{end}}']], true); LocusZoom.getToolTipPanel(this).data_layers.genes.unselectAllElements();\">Identify variants in region</button></td>"
             + "<td style=\"text-align: right;\"><a href=\"http://exac.broadinstitute.org/gene/{{gene_id}}\" target=\"_new\">More data on ExAC</a></td>"
             + "</tr></table>"
     }
@@ -1475,8 +1475,8 @@ LocusZoom.DataLayer.DefaultLayout = {
 // names and applied or removed from elements to have a visual representation of the status,
 // as well as used as keys in the state for tracking which elements are in which status(es)
 LocusZoom.DataLayer.Statuses = {
-    verbs: ["highlight", "select", "idenfity", "dim", "hide"],
-    adjectives: ["highlighted", "selected", "idenfitied", "dimmed", "hidden"]
+    verbs: ["highlight", "select", "dim", "hide"],
+    adjectives: ["highlighted", "selected", "dimmed", "hidden"]
 };
 
 LocusZoom.DataLayer.prototype.getBaseId = function(){
@@ -1869,12 +1869,14 @@ LocusZoom.DataLayer.Statuses.verbs.forEach(function(verb, idx){
     var adjective = LocusZoom.DataLayer.Statuses.adjectives[idx];
     var antiverb = "un" + verb;
     // Set/unset a single element's status
-    LocusZoom.DataLayer.prototype[verb + "Element"] = function(element){
-        this.setElementStatus(adjective, element, true);
+    LocusZoom.DataLayer.prototype[verb + "Element"] = function(element, exclusive){
+        if (typeof exclusive == "undefined"){ exclusive = false; } else { exclusive = !!exclusive; }
+        this.setElementStatus(adjective, element, true, exclusive);
         return this;
     };
-    LocusZoom.DataLayer.prototype[antiverb + "Element"] = function(element){
-        this.setElementStatus(adjective, element, false);
+    LocusZoom.DataLayer.prototype[antiverb + "Element"] = function(element, exclusive){
+        if (typeof exclusive == "undefined"){ exclusive = false; } else { exclusive = !!exclusive; }
+        this.setElementStatus(adjective, element, false, exclusive);
         return this;
     };
     // Set/unset status for arbitrarily many elements given a set of filters
@@ -1898,7 +1900,7 @@ LocusZoom.DataLayer.Statuses.verbs.forEach(function(verb, idx){
 });
 
 // Toggle a status (e.g. highlighted, selected, identified) on an element
-LocusZoom.DataLayer.prototype.setElementStatus = function(status, element, toggle){
+LocusZoom.DataLayer.prototype.setElementStatus = function(status, element, toggle, exclusive){
     
     // Sanity checks
     if (typeof status == "undefined" || LocusZoom.DataLayer.Statuses.adjectives.indexOf(status) == -1){
@@ -1911,21 +1913,30 @@ LocusZoom.DataLayer.prototype.setElementStatus = function(status, element, toggl
         toggle = true;
     }
 
-    var id = this.getElementId(element);
-    
-    // Set/unset the proper status class on the appropriate DOM element
-    var element_id = id;
-    var attr_class = "lz-data_layer-" + this.layout.type + "-" + status;
-    if (this.layout.hover_element){
-        element_id += "_" + this.layout.hover_element;
-        attr_class = "lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element + "-" + status;
+    // Get an ID for the elment or return having changed nothing
+    try {
+        var element_id = this.getElementId(element);
+    } catch (get_element_id_error){
+        return this;
     }
-    d3.select("#" + element_id).classed(attr_class, toggle);
+
+    // Enforce exlcusivity (force all elements to have the opposite of toggle first)
+    if (exclusive){
+        this.setAllElementStatus(status, !toggle);
+    }
+    
+    // Set/unset the proper status class on the appropriate DOM element(s)
+    d3.select("#" + element_id).classed("lz-data_layer-" + this.layout.type + "-" + status, toggle);
+    if (this.layout.hover_element){
+        var hover_element_id = element_id + "_" + this.layout.hover_element;
+        var hover_element_class = "lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element + "-" + status;
+        d3.select("#" + hover_element_id).classed(hover_element_class, toggle);
+    }
     
     // Track element ID in the proper status state array
-    var element_status_idx = this.state[this.state_id][status].indexOf(id);
+    var element_status_idx = this.state[this.state_id][status].indexOf(element_id);
     if (toggle && element_status_idx == -1){
-        this.state[this.state_id][status].push(id);
+        this.state[this.state_id][status].push(element_id);
     }
     if (!toggle && element_status_idx != -1){
         this.state[this.state_id][status].splice(element_status_idx, 1);
@@ -1961,9 +1972,7 @@ LocusZoom.DataLayer.prototype.setElementStatusByFilters = function(status, toggl
     
     // Apply statuses
     this.filterElements(filters).forEach(function(element){
-        //if (this.state[this.state_id][status].indexOf(this.getElementId(element)) == -1){
-            this.setElementStatus(status, element, toggle);
-        //}
+        this.setElementStatus(status, element, toggle);
     }.bind(this));
     
     return this;
@@ -1982,9 +1991,7 @@ LocusZoom.DataLayer.prototype.setAllElementStatus = function(status, toggle){
     // Apply statuses
     if (toggle){
         this.data.forEach(function(element){
-            if (this.state[this.state_id][status].indexOf(this.getElementId(element)) == -1){
-                this.setElementStatus(status, element, true);
-            }
+            this.setElementStatus(status, element, true);
         }.bind(this));
     } else {
         var status_ids = this.state[this.state_id][status].slice();
@@ -1999,7 +2006,7 @@ LocusZoom.DataLayer.prototype.setAllElementStatus = function(status, toggle){
     return this;
 };
 
-// Apply mouse event bindings to create status-related behavior (e.g. highlighted, selected, identified)
+// Apply mouse event bindings to create status-related behavior (e.g. highlighted, selected, dimmed, hidden...)
 LocusZoom.DataLayer.prototype.applyStatusBehavior = function(status, selection){
 
     // Glossary for this function:

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -1444,9 +1444,9 @@ LocusZoom.DataLayer = function(layout, parent) {
         this.state = this.parent.state;
         this.state_id = this.parent.id + "." + this.id;
         this.state[this.state_id] = this.state[this.state_id] || {};
-        this.state[this.state_id].highlighted = this.state[this.state_id].highlighted || [];
-        this.state[this.state_id].selected = this.state[this.state_id].selected || [];
-        this.state[this.state_id].identified = this.state[this.state_id].identified || [];
+        LocusZoom.DataLayer.Statuses.adjectives.forEach(function(status){
+            this.state[this.state_id][status] = this.state[this.state_id][status] || [];
+        }.bind(this));
     } else {
         this.state = {};
         this.state_id = null;
@@ -1467,6 +1467,16 @@ LocusZoom.DataLayer.DefaultLayout = {
     fields: [],
     x_axis: {},
     y_axis: {}
+};
+
+// Available statuses that individual elements can have. Each status is described by
+// a verb/antiverb and an adjective. Verbs and antiverbs are used to generate data layer
+// methods for updating the status on one or more elements. Adjectives are used in class
+// names and applied or removed from elements to have a visual representation of the status,
+// as well as used as keys in the state for tracking which elements are in which status(es)
+LocusZoom.DataLayer.Statuses = {
+    verbs: ["highlight", "select", "idenfity", "dim", "hide"],
+    adjectives: ["highlighted", "selected", "idenfitied", "dimmed", "hidden"]
 };
 
 LocusZoom.DataLayer.prototype.getBaseId = function(){
@@ -1794,12 +1804,11 @@ LocusZoom.DataLayer.prototype.showOrHideTooltip = function(element){
     }
 
     var statuses = {};
-    statuses.highlighted = this.state[this.state_id].highlighted.indexOf(id) != -1;
-    statuses.unhighlighted = !statuses.highlighted;
-    statuses.selected = this.state[this.state_id].selected.indexOf(id) != -1;
-    statuses.unselected = !statuses.selected;
-    statuses.identified = this.state[this.state_id].identified.indexOf(id) != -1;
-    statuses.unidentified = !statuses.identified;
+    LocusZoom.DataLayer.Statuses.adjectives.forEach(function(status){
+        var antistatus = "un" + status;
+        statuses[status] = this.state[this.state_id][status].indexOf(id) != -1;
+        statuses[antistatus] = !statuses[status];
+    }.bind(this));
 
     var show_resolved = resolveStatus(statuses, show_directive);
     var hide_resolved = resolveStatus(statuses, hide_directive);
@@ -1856,75 +1865,47 @@ LocusZoom.DataLayer.prototype.filter = function(filters, return_type){
 LocusZoom.DataLayer.prototype.filterIndexes = function(filters){ return this.filter(filters, "indexes"); };
 LocusZoom.DataLayer.prototype.filterElements = function(filters){ return this.filter(filters, "elements"); };
 
-// Toggle the highlighted status of an element
-LocusZoom.DataLayer.prototype.highlightElement = function(element){
-    this.setElementStatus("highlighted", element, true);
-    return this;
-};
-LocusZoom.DataLayer.prototype.unhighlightElement = function(element){
-    this.setElementStatus("highlighted", element, false);
-    return this;
-};
-
-// Toggle the highlighted status of all elements
-LocusZoom.DataLayer.prototype.highlightAllElements = function(){
-    this.setAllElementStatus("highlighted", true);
-    return this;
-};
-LocusZoom.DataLayer.prototype.unhighlightAllElements = function(){
-    this.setAllElementStatus("highlighted", false);
-    return this;
-};
-
-// Toggle the selected status of an element
-LocusZoom.DataLayer.prototype.selectElement = function(element){
-    this.setElementStatus("selected", element, true);
-    return this;
-};
-LocusZoom.DataLayer.prototype.unselectElement = function(element){
-    this.setElementStatus("selected", element, false);
-    return this;
-};
-
-// Toggle the selected status of all elements
-LocusZoom.DataLayer.prototype.selectAllElements = function(){
-    this.setAllElementStatus("selected", true);
-    return this;
-};
-LocusZoom.DataLayer.prototype.unselectAllElements = function(){
-    this.setAllElementStatus("selected", false);
-    return this;
-};
-
-// Toggle the identified status of an element
-LocusZoom.DataLayer.prototype.identifyElement = function(element){
-    this.setElementStatus("identified", element, true);
-    return this;
-};
-LocusZoom.DataLayer.prototype.unidentifyElement = function(element){
-    this.setElementStatus("identified", element, false);
-    return this;
-};
-
-// Toggle the identified status of all elements
-LocusZoom.DataLayer.prototype.identifyAllElements = function(){
-    this.setAllElementStatus("identified", true);
-    return this;
-};
-LocusZoom.DataLayer.prototype.unidentifyAllElements = function(){
-    this.setAllElementStatus("identified", false);
-    return this;
-};
+LocusZoom.DataLayer.Statuses.verbs.forEach(function(verb, idx){
+    var adjective = LocusZoom.DataLayer.Statuses.adjectives[idx];
+    var antiverb = "un" + verb;
+    // Set/unset a single element's status
+    LocusZoom.DataLayer.prototype[verb + "Element"] = function(element){
+        this.setElementStatus(adjective, element, true);
+        return this;
+    };
+    LocusZoom.DataLayer.prototype[antiverb + "Element"] = function(element){
+        this.setElementStatus(adjective, element, false);
+        return this;
+    };
+    // Set/unset status for arbitrarily many elements given a set of filters
+    LocusZoom.DataLayer.prototype[verb + "ElementsByFilters"] = function(filters, exclusive){
+        if (typeof exclusive == "undefined"){ exclusive = false; } else { exclusive = !!exclusive; }
+        return this.setElementStatusByFilters(adjective, true, filters, exclusive);
+    };
+    LocusZoom.DataLayer.prototype[antiverb + "ElementsByFilters"] = function(filters, exclusive){
+        if (typeof exclusive == "undefined"){ exclusive = false; } else { exclusive = !!exclusive; }
+        return this.setElementStatusByFilters(adjective, false, filters, exclusive);
+    };
+    // Set/unset status for all elements
+    LocusZoom.DataLayer.prototype[verb + "AllElements"] = function(){
+        this.setAllElementStatus(adjective, true);
+        return this;
+    };
+    LocusZoom.DataLayer.prototype[antiverb + "AllElements"] = function(){
+        this.setAllElementStatus(adjective, false);
+        return this;
+    };
+});
 
 // Toggle a status (e.g. highlighted, selected, identified) on an element
 LocusZoom.DataLayer.prototype.setElementStatus = function(status, element, toggle){
     
     // Sanity checks
-    if (typeof status == "undefined" || ["highlighted","selected","identified"].indexOf(status) == -1){
-        throw("Invalid status passed to setElementStatus()");
+    if (typeof status == "undefined" || LocusZoom.DataLayer.Statuses.adjectives.indexOf(status) == -1){
+        throw("Invalid status passed to DataLayer.setElementStatus()");
     }
     if (typeof element == "undefined"){
-        throw("Invalid element passed to setElementStatus()");
+        throw("Invalid element passed to DataLayer.setElementStatus()");
     }
     if (typeof toggle == "undefined"){
         toggle = true;
@@ -1961,12 +1942,39 @@ LocusZoom.DataLayer.prototype.setElementStatus = function(status, element, toggl
     
 };
 
+// Toggle a status on elements in the data layer based on a set of filters
+LocusZoom.DataLayer.prototype.setElementStatusByFilters = function(status, toggle, filters, exclusive){
+    
+    // Sanity check
+    if (typeof status == "undefined" || LocusZoom.DataLayer.Statuses.adjectives.indexOf(status) == -1){
+        throw("Invalid status passed to DataLayer.setElementStatusByFilters()");
+    }
+    if (typeof this.state[this.state_id][status] == "undefined"){ return this; }
+    if (typeof toggle == "undefined"){ toggle = true; } else { toggle = !!toggle; }
+    if (typeof exclusive == "undefined"){ exclusive = false; } else { exclusive = !!exclusive; }
+    if (!Array.isArray(filters)){ filters = []; }
+
+    // Enforce exlcusivity (force all elements to have the opposite of toggle first)
+    if (exclusive){
+        this.setAllElementStatus(status, !toggle);
+    }
+    
+    // Apply statuses
+    this.filterElements(filters).forEach(function(element){
+        //if (this.state[this.state_id][status].indexOf(this.getElementId(element)) == -1){
+            this.setElementStatus(status, element, toggle);
+        //}
+    }.bind(this));
+    
+    return this;
+};
+
 // Toggle a status on all elements in the data layer
 LocusZoom.DataLayer.prototype.setAllElementStatus = function(status, toggle){
     
     // Sanity check
-    if (typeof status == "undefined" || ["highlighted","selected","identified"].indexOf(status) == -1){
-        throw("Invalid status passed to setAllElementStatus()");
+    if (typeof status == "undefined" || LocusZoom.DataLayer.Statuses.adjectives.indexOf(status) == -1){
+        throw("Invalid status passed to DataLayer.setAllElementStatus()");
     }
     if (typeof this.state[this.state_id][status] == "undefined"){ return this; }
     if (typeof toggle == "undefined"){ toggle = true; }
@@ -1991,57 +1999,6 @@ LocusZoom.DataLayer.prototype.setAllElementStatus = function(status, toggle){
     return this;
 };
 
-// Toggle a status on elements in the data layer based on a set of filters
-LocusZoom.DataLayer.prototype.setElementStatusByFilters = function(status, toggle, filters, exclusive){
-    
-    // Sanity check
-    if (typeof status == "undefined" || ["highlighted","selected","identified"].indexOf(status) == -1){
-        throw("Invalid status passed to setElementStatusByFilters()");
-    }
-    if (typeof this.state[this.state_id][status] == "undefined"){ return this; }
-    if (typeof toggle == "undefined"){ toggle = true; } else { toggle = !!toggle; }
-    if (typeof exclusive == "undefined"){ exclusive = false; } else { exclusive = !!exclusive; }
-    if (!Array.isArray(filters)){ filters = []; }
-
-    // Enforce exlcusivity (force all elements to have the opposite of toggle first)
-    if (exclusive){
-        this.setAllElementStatus(status, !toggle);
-    }
-    
-    // Apply statuses
-    this.filterElements(filters).forEach(function(element){
-        if (this.state[this.state_id][status].indexOf(this.getElementId(element)) == -1){
-            this.setElementStatus(status, element, toggle);
-        }
-    }.bind(this));
-    
-    return this;
-};
-LocusZoom.DataLayer.prototype.highlightElementsByFilters = function(filters, exclusive){
-    if (typeof exclusive == "undefined"){ exclusive = false; } else { exclusive = !!exclusive; }
-    return this.setElementStatusByFilters("highlighted", true, filters, exclusive);
-};
-LocusZoom.DataLayer.prototype.unhighlightElementsByFilters = function(filters, exclusive){
-    if (typeof exclusive == "undefined"){ exclusive = false; } else { exclusive = !!exclusive; }
-    return this.setElementStatusByFilters("highlighted", false, filters, exclusive);
-};
-LocusZoom.DataLayer.prototype.selectElementsByFilters = function(filters, exclusive){
-    if (typeof exclusive == "undefined"){ exclusive = false; } else { exclusive = !!exclusive; }
-    return this.setElementStatusByFilters("selected", true, filters, exclusive);
-};
-LocusZoom.DataLayer.prototype.unselectElementsByFilters = function(filters, exclusive){
-    if (typeof exclusive == "undefined"){ exclusive = false; } else { exclusive = !!exclusive; }
-    return this.setElementStatusByFilters("selected", false, filters, exclusive);
-};
-LocusZoom.DataLayer.prototype.identifyElementsByFilters = function(filters, exclusive){
-    if (typeof exclusive == "undefined"){ exclusive = false; } else { exclusive = !!exclusive; }
-    return this.setElementStatusByFilters("identified", true, filters, exclusive);
-};
-LocusZoom.DataLayer.prototype.unidentifyElementsByFilters = function(filters, exclusive){
-    if (typeof exclusive == "undefined"){ exclusive = false; } else { exclusive = !!exclusive; }
-    return this.setElementStatusByFilters("identified", false, filters, exclusive);
-};
-
 // Apply mouse event bindings to create status-related behavior (e.g. highlighted, selected, identified)
 LocusZoom.DataLayer.prototype.applyStatusBehavior = function(status, selection){
 
@@ -2051,7 +2008,7 @@ LocusZoom.DataLayer.prototype.applyStatusBehavior = function(status, selection){
     // action - a more verbose locuszoom-layout-specific form of an event (e.g. "onmouseover", "onshiftclick")
 
     // Sanity checks
-    if (typeof status == "undefined" || ["highlighted","selected","identified"].indexOf(status) == -1){ return; }
+    if (typeof status == "undefined" || LocusZoom.DataLayer.Statuses.adjectives.indexOf(status) == -1){ return; }
     if (typeof selection != "object"){ return; }
     if (typeof this.layout[status] != "object" || !this.layout[status]){ return; }
 
@@ -2126,8 +2083,7 @@ LocusZoom.DataLayer.prototype.applyStatusBehavior = function(status, selection){
 
 // Apply all supported status behaviors to a selection of objects
 LocusZoom.DataLayer.prototype.applyAllStatusBehaviors = function(selection){
-    var supported_statuses = ["highlighted","selected","identified"];
-    supported_statuses.forEach(function(status){
+    LocusZoom.DataLayer.Statuses.adjectives.forEach(function(status){
         this.applyStatusBehavior(status, selection);
     }.bind(this));
     return this;
@@ -7199,36 +7155,39 @@ LocusZoom.Panel.prototype.scaleHeightToData = function(){
     }
 };
 
-// Toggle a status on elements in all child data layers based on a set of filters
+// Methods to set/unset element statuses across all data layers
 LocusZoom.Panel.prototype.setElementStatusByFilters = function(status, toggle, filters, exclusive){
     this.data_layer_ids_by_z_index.forEach(function(id){
         this.data_layers[id].setElementStatusByFilters(status, toggle, filters, exclusive);
     }.bind(this));
 };
-LocusZoom.Panel.prototype.highlightElementsByFilters = function(filters, exclusive){
-    if (typeof exclusive == "undefined"){ exclusive = false; } else { exclusive = !!exclusive; }
-    return this.setElementStatusByFilters("highlighted", true, filters, exclusive);
+LocusZoom.Panel.prototype.setAllElementStatus = function(status, toggle){
+    this.data_layer_ids_by_z_index.forEach(function(id){
+        this.data_layers[id].setAllElementStatus(status, toggle);
+    }.bind(this));
 };
-LocusZoom.Panel.prototype.unhighlightElementsByFilters = function(filters, exclusive){
-    if (typeof exclusive == "undefined"){ exclusive = false; } else { exclusive = !!exclusive; }
-    return this.setElementStatusByFilters("highlighted", false, filters, exclusive);
-};
-LocusZoom.Panel.prototype.selectElementsByFilters = function(filters, exclusive){
-    if (typeof exclusive == "undefined"){ exclusive = false; } else { exclusive = !!exclusive; }
-    return this.setElementStatusByFilters("selected", true, filters, exclusive);
-};
-LocusZoom.Panel.prototype.unselectElementsByFilters = function(filters, exclusive){
-    if (typeof exclusive == "undefined"){ exclusive = false; } else { exclusive = !!exclusive; }
-    return this.setElementStatusByFilters("selected", false, filters, exclusive);
-};
-LocusZoom.Panel.prototype.identifyElementsByFilters = function(filters, exclusive){
-    if (typeof exclusive == "undefined"){ exclusive = false; } else { exclusive = !!exclusive; }
-    return this.setElementStatusByFilters("identified", true, filters, exclusive);
-};
-LocusZoom.Panel.prototype.unidentifyElementsByFilters = function(filters, exclusive){
-    if (typeof exclusive == "undefined"){ exclusive = false; } else { exclusive = !!exclusive; }
-    return this.setElementStatusByFilters("identified", false, filters, exclusive);
-};
+LocusZoom.DataLayer.Statuses.verbs.forEach(function(verb, idx){
+    var adjective = LocusZoom.DataLayer.Statuses.adjectives[idx];
+    var antiverb = "un" + verb;
+    // Set/unset status for arbitrarily many elements given a set of filters
+    LocusZoom.Panel.prototype[verb + "ElementsByFilters"] = function(filters, exclusive){
+        if (typeof exclusive == "undefined"){ exclusive = false; } else { exclusive = !!exclusive; }
+        return this.setElementStatusByFilters(adjective, true, filters, exclusive);
+    };
+    LocusZoom.Panel.prototype[antiverb + "ElementsByFilters"] = function(filters, exclusive){
+        if (typeof exclusive == "undefined"){ exclusive = false; } else { exclusive = !!exclusive; }
+        return this.setElementStatusByFilters(adjective, false, filters, exclusive);
+    };
+    // Set/unset status for all elements
+    LocusZoom.Panel.prototype[verb + "AllElements"] = function(){
+        this.setAllElementStatus(adjective, true);
+        return this;
+    };
+    LocusZoom.Panel.prototype[antiverb + "AllElements"] = function(){
+        this.setAllElementStatus(adjective, false);
+        return this;
+    };
+});
 
 // Add a "basic" loader to a panel
 // This method is jsut a shortcut for adding the most commonly used type of loader

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -1904,6 +1904,27 @@ LocusZoom.DataLayer.prototype.setAllElementStatus = function(status, toggle){
     return this;
 };
 
+// Toggle a status on elements in the data layer based on a set of filters
+LocusZoom.DataLayer.prototype.setElementStatusByFilters = function(status, toggle, filters){
+    
+    // Sanity check
+    if (typeof status == "undefined" || ["highlighted","selected"].indexOf(status) == -1){
+        throw("Invalid status passed to setElementStatusByFilters()");
+    }
+    if (typeof this.state[this.state_id][status] == "undefined"){ return this; }
+    if (typeof toggle == "undefined"){ toggle = true; }
+    if (!Array.isArray(filters)){ filters = []; }
+
+    // Apply statuses
+    this.filterElements(filters).forEach(function(element){
+        if (this.state[this.state_id][status].indexOf(this.getElementId(element)) == -1){
+            this.setElementStatus(status, element, toggle);
+        }
+    }.bind(this));
+    
+    return this;
+};
+
 // Apply mouse event bindings to create status-related behavior (e.g. highlighted, selected)
 LocusZoom.DataLayer.prototype.applyStatusBehavior = function(status, selection){
 
@@ -1994,6 +2015,46 @@ LocusZoom.DataLayer.prototype.applyAllStatusBehaviors = function(selection){
     }.bind(this));
     return this;
 };
+
+// Get an array of element indexes matching a set of filters
+// Filters should be of the form [field, value] (for equivalence testing) or [field, operator, value]
+// Return type can be "indexes" or "elements" and determines whether the returned array contains
+// indexes of matching elements in the data layer's data set or references to the matching elements
+LocusZoom.DataLayer.prototype.filter = function(filters, return_type){
+    if (typeof return_type == "undefined" || ["indexes","elements"].indexOf(return_type) == -1){
+        return_type = "indexes";
+    }
+    if (!Array.isArray(filters)){ return []; }
+    var test = function(element, filter){
+        var operators = {
+            "=": function(a,b){ return a == b; },
+            "<": function(a,b){ return a < b; },
+            "<=": function(a,b){ return a <= b; },
+            ">": function(a,b){ return a > b; },
+            ">=": function(a,b){ return a >= b; },
+            "%": function(a,b){ return a % b; }
+        };
+        if (!Array.isArray(filter)){ return false; }
+        if (filter.length == 2){
+            return element[filter[0]] == filter[1];
+        } else if (filter.length == 3 && operators[filter[1]]){
+            return operators[filter[1]](element[filter[0]], filter[2]);
+        } else {
+            return false;
+        }
+    };
+    var matches = [];
+    this.data.forEach(function(element, idx){
+        var match = true;
+        filters.forEach(function(filter){
+            if (!test(element, filter)){ match = false; }
+        });
+        if (match){ matches.push(return_type == "indexes" ? idx : element); }
+    });
+    return matches;
+};
+LocusZoom.DataLayer.prototype.filterIndexes = function(filters){ return this.filter(filters, "indexes"); };
+LocusZoom.DataLayer.prototype.filterElements = function(filters){ return this.filter(filters, "elements"); };
 
 // Get an object with the x and y coordinates of the panel's origin in terms of the entire page
 // Necessary for positioning any HTML elements over the panel

--- a/locuszoom.css
+++ b/locuszoom.css
@@ -51,8 +51,8 @@ svg.lz-locuszoom {
     stroke-opacity: 0.4;
     stroke-width: 4px; }
   svg.lz-locuszoom path.lz-data_layer-scatter-identified {
-    stroke: rgb(24, 24, 24);
-    stroke-opacity: 0.4;
+    stroke: #424242;
+    stroke-opacity: 0.8;
     stroke-width: 4px; }
   svg.lz-locuszoom path.lz-data_layer-scatter-selected {
     stroke: rgba(24, 24, 24, 1);

--- a/locuszoom.css
+++ b/locuszoom.css
@@ -53,13 +53,9 @@ svg.lz-locuszoom {
   svg.lz-locuszoom path.lz-data_layer-scatter-selected {
     stroke: rgba(24, 24, 24, 1);
     stroke-width: 4px; }
-  svg.lz-locuszoom path.lz-data_layer-scatter-identified {
-    stroke: #424242;
-    stroke-opacity: 0.8;
-    stroke-width: 4px; }
   svg.lz-locuszoom path.lz-data_layer-scatter-dimmed {
-    fill-opacity: 0.2;
-    stroke-opacity: 0.2; }
+    fill-opacity: 0.1;
+    stroke-opacity: 0.1; }
   svg.lz-locuszoom path.lz-data_layer-scatter-hidden {
     display: none; }
   svg.lz-locuszoom text.lz-data_layer-scatter-label {
@@ -76,8 +72,12 @@ svg.lz-locuszoom {
     fill: none;
     stroke: none;
     cursor: pointer; }
-  svg.lz-locuszoom g.lz-data_layer-gene {
+  svg.lz-locuszoom g.lz-data_layer-genes {
     cursor: pointer; }
+  svg.lz-locuszoom g.lz-data_layer-genes-dimmed {
+    opacity: 0.1; }
+  svg.lz-locuszoom g.lz-data_layer-genes-hidden {
+    display: none; }
   svg.lz-locuszoom text.lz-data_layer-genes.lz-label {
     font-style: italic; }
   svg.lz-locuszoom rect.lz-data_layer-genes.lz-data_layer-genes-bounding_box {
@@ -85,10 +85,6 @@ svg.lz-locuszoom {
     fill-opacity: 0;
     stroke-width: 0px; }
   svg.lz-locuszoom rect.lz-data_layer-genes.lz-data_layer-genes-bounding_box-highlighted {
-    fill: #363696;
-    fill-opacity: 0.1;
-    stroke-width: 0px; }
-  svg.lz-locuszoom rect.lz-data_layer-genes.lz-data_layer-genes-bounding_box-identified {
     fill: #363696;
     fill-opacity: 0.1;
     stroke-width: 0px; }

--- a/locuszoom.css
+++ b/locuszoom.css
@@ -50,13 +50,18 @@ svg.lz-locuszoom {
     stroke: rgb(24, 24, 24);
     stroke-opacity: 0.4;
     stroke-width: 4px; }
+  svg.lz-locuszoom path.lz-data_layer-scatter-selected {
+    stroke: rgba(24, 24, 24, 1);
+    stroke-width: 4px; }
   svg.lz-locuszoom path.lz-data_layer-scatter-identified {
     stroke: #424242;
     stroke-opacity: 0.8;
     stroke-width: 4px; }
-  svg.lz-locuszoom path.lz-data_layer-scatter-selected {
-    stroke: rgba(24, 24, 24, 1);
-    stroke-width: 4px; }
+  svg.lz-locuszoom path.lz-data_layer-scatter-dimmed {
+    fill-opacity: 0.2;
+    stroke-opacity: 0.2; }
+  svg.lz-locuszoom path.lz-data_layer-scatter-hidden {
+    display: none; }
   svg.lz-locuszoom text.lz-data_layer-scatter-label {
     fill: rgba(24, 24, 24, 1);
     alignment-baseline: middle; }

--- a/locuszoom.css
+++ b/locuszoom.css
@@ -50,6 +50,10 @@ svg.lz-locuszoom {
     stroke: rgb(24, 24, 24);
     stroke-opacity: 0.4;
     stroke-width: 4px; }
+  svg.lz-locuszoom path.lz-data_layer-scatter-identified {
+    stroke: rgb(24, 24, 24);
+    stroke-opacity: 0.4;
+    stroke-width: 4px; }
   svg.lz-locuszoom path.lz-data_layer-scatter-selected {
     stroke: rgba(24, 24, 24, 1);
     stroke-width: 4px; }
@@ -76,6 +80,10 @@ svg.lz-locuszoom {
     fill-opacity: 0;
     stroke-width: 0px; }
   svg.lz-locuszoom rect.lz-data_layer-genes.lz-data_layer-genes-bounding_box-highlighted {
+    fill: #363696;
+    fill-opacity: 0.1;
+    stroke-width: 0px; }
+  svg.lz-locuszoom rect.lz-data_layer-genes.lz-data_layer-genes-bounding_box-identified {
     fill: #363696;
     fill-opacity: 0.1;
     stroke-width: 0px; }


### PR DESCRIPTION
Work in progress

API methods to select, highlight, dim, or hide a collection of elements based on an arbitrary set of filters. This is designed to, for example, identify variants in an association data layer that pass some sort of filter test originating from anywhere else in the plot, such as a gene tooltip filtering for all variants within the transcript. This framework would hopefully provide means to approach the task of dynamically identifying credible sets, as another example.