### PR TITLE
Apply floor/ceiling to axis-extent before upper_/lower_buffer

### DIFF
--- a/assets/js/app/DataLayer.js
+++ b/assets/js/app/DataLayer.js
@@ -253,8 +253,14 @@ LocusZoom.DataLayer.prototype.getAxisExtent = function(dimension){
         extent = d3.extent(extent);
 
         // Apply floor/ceiling, if applicable
-        if (!isNaN(this.layout[axis].floor)){ extent[0] = this.layout[axis].floor; }
-        if (!isNaN(this.layout[axis].ceiling)){ extent[1] = this.layout[axis].ceiling; }
+        if (!isNaN(this.layout[axis].floor)) {
+            extent[0] = this.layout[axis].floor;
+            extent[1] = d3.max(extent);
+        }
+        if (!isNaN(this.layout[axis].ceiling)) {
+            extent[1] = this.layout[axis].ceiling;
+            extent[0] = d3.min(extent);
+        }
 
         return extent;
 

--- a/assets/js/app/DataLayer.js
+++ b/assets/js/app/DataLayer.js
@@ -239,7 +239,7 @@ LocusZoom.DataLayer.prototype.getAxisExtent = function(dimension){
             return +f.resolve(d);
         }.bind(this));
 
-        // Apply floor/ceiling, for calculation of `original_extent_span`
+        // Apply floor/ceiling
         if (!isNaN(this.layout[axis].floor)) {
             extent[0] = this.layout[axis].floor;
             extent[1] = d3.max(extent);
@@ -251,25 +251,21 @@ LocusZoom.DataLayer.prototype.getAxisExtent = function(dimension){
 
         // Apply upper/lower buffers, if applicable
         var original_extent_span = extent[1] - extent[0];
-        if (!isNaN(this.layout[axis].lower_buffer)){ extent.push(extent[0] - (original_extent_span * this.layout[axis].lower_buffer)); }
-        if (!isNaN(this.layout[axis].upper_buffer)){ extent.push(extent[1] + (original_extent_span * this.layout[axis].upper_buffer)); }
+        if (isNaN(this.layout[axis].floor) && !isNaN(this.layout[axis].lower_buffer)) {
+            extent[0] -= original_extent_span * this.layout[axis].lower_buffer;
+        }
+        if (isNaN(this.layout[axis].ceiling) && !isNaN(this.layout[axis].upper_buffer)) {
+            extent[1] += original_extent_span * this.layout[axis].upper_buffer;
+        }
 
         // Apply minimum extent
-        if (typeof this.layout[axis].min_extent == "object" && !isNaN(this.layout[axis].min_extent[0]) && !isNaN(this.layout[axis].min_extent[1])){
-            extent.push(this.layout[axis].min_extent[0], this.layout[axis].min_extent[1]);
-        }
-
-        // Generate a new base extent
-        extent = d3.extent(extent);
-
-        // Apply floor/ceiling, if applicable
-        if (!isNaN(this.layout[axis].floor)) {
-            extent[0] = this.layout[axis].floor;
-            extent[1] = d3.max(extent);
-        }
-        if (!isNaN(this.layout[axis].ceiling)) {
-            extent[1] = this.layout[axis].ceiling;
-            extent[0] = d3.min(extent);
+        if (typeof this.layout[axis].min_extent == "object") {
+            if (isNaN(this.layout[axis].floor) && !isNaN(this.layout[axis].min_extent[0])) {
+                extent[0] = Math.min(extent[0], this.layout[axis].min_extent[0]);
+            }
+            if (isNaN(this.layout[axis].ceiling) && !isNaN(this.layout[axis].min_extent[1])) {
+                extent[1] = Math.max(extent[1], this.layout[axis].min_extent[1]);
+            }
         }
 
         return extent;

--- a/assets/js/app/DataLayer.js
+++ b/assets/js/app/DataLayer.js
@@ -239,6 +239,16 @@ LocusZoom.DataLayer.prototype.getAxisExtent = function(dimension){
             return +f.resolve(d);
         }.bind(this));
 
+        // Apply floor/ceiling, for calculation of `original_extent_span`
+        if (!isNaN(this.layout[axis].floor)) {
+            extent[0] = this.layout[axis].floor;
+            extent[1] = d3.max(extent);
+        }
+        if (!isNaN(this.layout[axis].ceiling)) {
+            extent[1] = this.layout[axis].ceiling;
+            extent[0] = d3.min(extent);
+        }
+
         // Apply upper/lower buffers, if applicable
         var original_extent_span = extent[1] - extent[0];
         if (!isNaN(this.layout[axis].lower_buffer)){ extent.push(extent[0] - (original_extent_span * this.layout[axis].lower_buffer)); }


### PR DESCRIPTION
It seems like the point of the upper buffer is to be sure you always have ≥5% of the plot area open above your points, to avoid having the top points hitting the top clippath.  If all your association results in the current window have p-values in [20,25], then currently the upper-buffer is based on that range of 5.  ie, 5*5%, when I really wanted 25*5%.  This PR fixes that.  Also, it handles a bug with reversed axes when exactly one of floor/ceiling is declared and all the data is on the wrong side of it.

This will require changes to https://github.com/statgen/locuszoom/wiki/Data-Layer#axes .  If you agree with the idea, I'll draft them.

I'm currently using this modified version in PheWeb.