### PR TITLE
Implement conditional blocks in parseField templates

### DIFF
--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -319,7 +319,7 @@ LocusZoom.parseFields = function (data, html) {
     if (typeof html != "string"){
         throw ("LocusZoom.parseFields invalid arguments: html is not a string");
     }
-    // Handle conditional blocks {{#if attr}}...{{/if}} from back to front to handle nesting correctly
+    // Handle conditional blocks {{#if field}}...{{/if}} from back to front to handle nesting correctly
     var if_regex = /\{\{#if ([0-9A-Za-z_:|]+)\}\}/g;
     var fi_regex = /^(.*?)\{\{\/if\}\}(.*)/;
     while(1) {

--- a/test/LocusZoom.js
+++ b/test/LocusZoom.js
@@ -219,6 +219,15 @@ describe("LocusZoom Core", function(){
                 var expected_value = "<strong>123 and foo, fooherpderp; </strong>";
                 assert.equal(LocusZoom.parseFields(data, html), expected_value);
             });
+            it("should handle conditional blocks", function() {
+                var data = {
+                    "foo:field_1": 123,
+                    "bar:field2": "foo"
+                };
+                var html = "{{#if foo:field_1}}<strong>{{foo:field_1}}{{#if bar:field2}} and {{bar:field2}}{{/if}}, {{#if nope}}wat{{/if}}{{bar:field2|herp|derp}}; {{field3}}</strong>{{/if}}";
+                var expected_value = "<strong>123 and foo, fooherpderp; </strong>";
+                assert.equal(LocusZoom.parseFields(data, html), expected_value);
+            });
         });
         
         describe("Validate State", function() {

--- a/test/LocusZoom.js
+++ b/test/LocusZoom.js
@@ -227,6 +227,16 @@ describe("LocusZoom Core", function(){
                 var html = "{{#if foo:field_1}}<strong>{{foo:field_1}}{{#if bar:field2}} and {{bar:field2}}{{/if}}, {{#if nope}}wat{{/if}}{{bar:field2|herp|derp}}; {{field3}}</strong>{{/if}}";
                 var expected_value = "<strong>123 and foo, fooherpderp; </strong>";
                 assert.equal(LocusZoom.parseFields(data, html), expected_value);
+                var data2 = {
+                    "fieldA": "",
+                    "fieldB": ""
+                };
+                var html2 = "{{#if fieldA}}A1<br>{{/if}}"
+                          + "{{#if fieldA|derp}}A2<br>{{/if}}"
+                          + "{{#if foo:fieldB}}B1<br>{{/if}}"
+                          + "{{#if foo:fieldB|derp}}B2<br>{{/if}}"
+                var expected_value2 = "A2<br>B2<br>";
+                assert.equal(LocusZoom.parseFields(data2, html2), expected_value2);
             });
         });
         


### PR DESCRIPTION
I haven't tested anything but latest Chrome.

The test is for this template:

```
{{#if foo:field_1}}
  <strong>
    {{foo:field_1}}
    {{#if bar:field2}}
       and {{bar:field2}}
    {{/if}}, 
    {{#if nope}}
      wat
    {{/if}}
    {{bar:field2|herp|derp}}; 
    {{field3}}
  </strong>
{{/if}}
```

It runs iteratively, always handling the last if-then block in the template, in order to handle nesting correctlyish.  Unfortunately, that means that users can make templates like: 
```
{{#if pvalue{{#if foo}}|neglog10{{/if}}}}
  {{pvalue{{#if foo}}|neglog10{{/if}}}}
{{/if}}
```

There is no way for user data to meaningfully affect program execution, so it seems fine.

I don't know what happens when errors occur.  I don't see any way to make an infinite loop.

Mustache and Handlebars parse an AST and then evaluate that.  Good for them.