### PR TITLE
Use an intermediary AST in LZ.parseFields()

### DIFF
--- a/assets/js/app/Data.js
+++ b/assets/js/app/Data.js
@@ -101,15 +101,13 @@ LocusZoom.Data.Field = function(field){
     // First look for a full match with transformations already applied by the data requester.
     // Otherwise prefer a namespace match and fall back to just a name match, applying transformations on the fly.
     this.resolve = function(d){
-        if (typeof d[this.full_name] != "undefined"){
-            return d[this.full_name];
-        } else {
+        if (typeof d[this.full_name] == "undefined"){
             var val = null;
             if (typeof d[this.namespace+":"+this.name] != "undefined"){ val = d[this.namespace+":"+this.name]; }
             else if (typeof d[this.name] != "undefined"){ val = d[this.name]; }
             d[this.full_name] = this.applyTransformations(val);
-            return d[this.full_name];
         }
+        return d[this.full_name];
     };
     
 };

--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -355,12 +355,7 @@ LocusZoom.parseFields = function (data, html) {
 
     var resolve = function(variable) {
         if (!resolve.cache.hasOwnProperty(variable)) {
-            try {
-                resolve.cache[variable] = (new LocusZoom.Data.Field(variable)).resolve(data);
-            } catch (error) {
-                console.error('Error while evaluating field ' + JSON.stringify(variable) + ': ' + error);
-                resolve.cache[variable] = variable;
-            }
+            resolve.cache[variable] = (new LocusZoom.Data.Field(variable)).resolve(data);
         }
         return resolve.cache[variable];
     };
@@ -369,13 +364,19 @@ LocusZoom.parseFields = function (data, html) {
         if (node.text) {
             return node.text;
         } else if (node.variable) {
-            var value = resolve(node.variable);
-            if (["string","number","boolean"].indexOf(typeof value) != -1) { return value; }
-            else if (value == null) { return ''; }
-            else { return '{{' + node.variable + '}}'; }
+            try {
+                var value = resolve(node.variable);
+                if (["string","number","boolean"].indexOf(typeof value) != -1) { return value; }
+                if (value == null) { return ''; }
+            } catch (error) { console.error("Error while processing variable " + JSON.stringify(node.variable)); }
+            return '{{' + node.variable + '}}';
         } else if (node.condition) {
-            if (resolve(node.condition)) { return node.then.map(render_node).join(''); }
-            else { return ''; }
+            try {
+                if (resolve(node.condition)) {
+                    return node.then.map(render_node).join('');
+                }
+            } catch (error) { console.error("Error while processign condition " + JSON.stringify(node.variable)); }
+            return '';
         } else { console.error('Error rendering tooltip due to unknown AST node ' + JSON.stringify(node)); }
     };
     return ast.map(render_node).join('');

--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -319,42 +319,54 @@ LocusZoom.parseFields = function (data, html) {
     if (typeof html != "string"){
         throw ("LocusZoom.parseFields invalid arguments: html is not a string");
     }
-    // Handle conditional blocks {{#if field}}...{{/if}} from back to front to handle nesting correctly
-    var if_regex = /\{\{#if ([0-9A-Za-z_:|]+)\}\}/g;
-    var fi_regex = /^(.*?)\{\{\/if\}\}(.*)/;
-    while(1) {
-        var m, match = false;
-        while(m = if_regex.exec(html)) { match = m; }
-        if (!match) break;
-        var before = html.slice(0, match.index);
-        var condition = match[1];
-        var x = fi_regex.exec(html.slice(match.index + match[0].length));
-        if (!x) { throw("failed to find {{/if}} after {{#if " + condition + "}}"); }
-        var then = x[1];
-        var rest = x[2];
-        if ((new LocusZoom.Data.Field(condition)).resolve(data)) {
-            html = before + then + rest;
-        } else {
-            html = before + rest;
-        }
+    // `tokens` is like [token,...]
+    // `token` is like {text: '...'} or {variable: 'foo|bar'} or {condition: 'foo|bar'} or {close: 'if'}
+    var tokens = [];
+    var regex = /\{\{(?:(#if )?([A-Za-z0-9_:\|]+)|(\/if))\}\}/;
+    while (html.length > 0){
+        var m = regex.exec(html);
+        if (!m) { tokens.push({text: html}); html = ''; }
+        else if (m.index != 0) { tokens.push({text: html.slice(0, m.index)}); html = html.slice(m.index); }
+        else if (m[1] == "#if ") { tokens.push({condition: m[2]}); html = html.slice(m[0].length); }
+        else if (m[2]) { tokens.push({variable: m[2]}); html = html.slice(m[0].length); }
+        else if (m[3] == "/if") { tokens.push({close: 'if'}); html = html.slice(m[0].length); }
+        else { throw [m, html] }
     }
-    // Match all things that look like fields in the HTML
-    var matches = html.match(/{{[A-Za-z0-9_:|]+}}/g);
-    if (matches){
-        // Remove duplicates
-        matches.reduce(function(a,b){if(a.indexOf(b)<0)a.push(b);return a;},[]);
-        // Replace matches with resolved values from the data object
-        matches.forEach(function(match){
-            var field = new LocusZoom.Data.Field(match.substring(2, match.length-2));
-            var value = field.resolve(data);
-            if (["string","number","boolean"].indexOf(typeof value) != -1){
-                html = html.replace(match, value);
-            } else if (value == null){
-                html = html.replace(match, "");
-            }
-        });
-    }
-    return html;
+    var astify = function() {
+        var token = tokens.shift();
+        if (token.text || token.variable) {
+            return token;
+        } else if (token.condition) {
+            token.then = [];
+            while(tokens[0].close != 'if') token.then.push(astify());
+            tokens.shift(); //consume {{/if}}
+            return token;
+        } else { throw 'what?' }
+    };
+    // `ast` is like [thing,...]
+    // `thing` is like {text: '...'} or {variable:'foo|bar'} or {condition: 'foo|bar', then:[thing,...]}
+    var ast = [];
+    while (tokens.length > 0) ast.push(astify());
+
+    var resolve = function(variable) {
+        if (!resolve.cache.hasOwnProperty(variable))
+            resolve.cache[variable] = (new LocusZoom.Data.Field(variable)).resolve(data);
+        return resolve.cache[variable];
+    };
+    resolve.cache = {};
+    var render_node = function(node) {
+        if (node.text) {
+            return node.text;
+        } else if (node.variable) {
+            var value = resolve(node.variable);
+            return (["string","number","boolean"].indexOf(typeof value) != -1) ? value :
+                (value == null) ? '' :
+                '{{' + node.variable + '}}';
+        } else if (node.condition) {
+            return resolve(node.condition) ? node.then.map(render_node).join('') : '';
+        } else { throw 'foo' }
+    };
+    return ast.map(render_node).join('');
 };
 
 // Shortcut method for getting the data bound to a tool tip.

--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -325,12 +325,12 @@ LocusZoom.parseFields = function (data, html) {
     var regex = /\{\{(?:(#if )?([A-Za-z0-9_:\|]+)|(\/if))\}\}/;
     while (html.length > 0){
         var m = regex.exec(html);
-        if (!m) { tokens.push({text: html}); html = ''; }
+        if (!m) { tokens.push({text: html}); html = ""; }
         else if (m.index != 0) { tokens.push({text: html.slice(0, m.index)}); html = html.slice(m.index); }
         else if (m[1] == "#if ") { tokens.push({condition: m[2]}); html = html.slice(m[0].length); }
         else if (m[2]) { tokens.push({variable: m[2]}); html = html.slice(m[0].length); }
-        else if (m[3] == "/if") { tokens.push({close: 'if'}); html = html.slice(m[0].length); }
-        else { console.error('Error tokenizing tooltip when remaining template is: ' + html); html=html.slice(m[0].length); }
+        else if (m[3] == "/if") { tokens.push({close: "if"}); html = html.slice(m[0].length); }
+        else { console.error("Error tokenizing tooltip when remaining template is: " + html); html=html.slice(m[0].length); }
     }
     var astify = function() {
         var token = tokens.shift();
@@ -339,17 +339,17 @@ LocusZoom.parseFields = function (data, html) {
         } else if (token.condition) {
             token.then = [];
             while(tokens.length > 0) {
-                if (tokens[0].close == 'if') { tokens.shift(); break; }
+                if (tokens[0].close == "if") { tokens.shift(); break; }
                 token.then.push(astify());
             }
             return token;
         } else {
-            return { text: '' };
-            console.error('Error making tooltip AST due to unknown token ' + JSON.stringify(token));
+            console.error("Error making tooltip AST due to unknown token " + JSON.stringify(token));
+            return { text: "" };
         }
     };
     // `ast` is like [thing,...]
-    // `thing` is like {text: '...'} or {variable:'foo|bar'} or {condition: 'foo|bar', then:[thing,...]}
+    // `thing` is like {text: "..."} or {variable:"foo|bar"} or {condition: "foo|bar", then:[thing,...]}
     var ast = [];
     while (tokens.length > 0) ast.push(astify());
 
@@ -367,19 +367,19 @@ LocusZoom.parseFields = function (data, html) {
             try {
                 var value = resolve(node.variable);
                 if (["string","number","boolean"].indexOf(typeof value) != -1) { return value; }
-                if (value == null) { return ''; }
+                if (value == null) { return ""; }
             } catch (error) { console.error("Error while processing variable " + JSON.stringify(node.variable)); }
-            return '{{' + node.variable + '}}';
+            return "{{" + node.variable + "}}";
         } else if (node.condition) {
             try {
                 if (resolve(node.condition)) {
-                    return node.then.map(render_node).join('');
+                    return node.then.map(render_node).join("");
                 }
             } catch (error) { console.error("Error while processign condition " + JSON.stringify(node.variable)); }
-            return '';
-        } else { console.error('Error rendering tooltip due to unknown AST node ' + JSON.stringify(node)); }
+            return "";
+        } else { console.error("Error rendering tooltip due to unknown AST node " + JSON.stringify(node)); }
     };
-    return ast.map(render_node).join('');
+    return ast.map(render_node).join("");
 };
 
 // Shortcut method for getting the data bound to a tool tip.

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -362,42 +362,67 @@ LocusZoom.parseFields = function (data, html) {
     if (typeof html != "string"){
         throw ("LocusZoom.parseFields invalid arguments: html is not a string");
     }
-    // Handle conditional blocks {{#if field}}...{{/if}} from back to front to handle nesting correctly
-    var if_regex = /\{\{#if ([0-9A-Za-z_:|]+)\}\}/g;
-    var fi_regex = /^(.*?)\{\{\/if\}\}(.*)/;
-    while(1) {
-        var m, match = false;
-        while(m = if_regex.exec(html)) { match = m; }
-        if (!match) break;
-        var before = html.slice(0, match.index);
-        var condition = match[1];
-        var x = fi_regex.exec(html.slice(match.index + match[0].length));
-        if (!x) { throw("failed to find {{/if}} after {{#if " + condition + "}}"); }
-        var then = x[1];
-        var rest = x[2];
-        if ((new LocusZoom.Data.Field(condition)).resolve(data)) {
-            html = before + then + rest;
-        } else {
-            html = before + rest;
-        }
+    // `tokens` is like [token,...]
+    // `token` is like {text: '...'} or {variable: 'foo|bar'} or {condition: 'foo|bar'} or {close: 'if'}
+    var tokens = [];
+    var regex = /\{\{(?:(#if )?([A-Za-z0-9_:\|]+)|(\/if))\}\}/;
+    while (html.length > 0){
+        var m = regex.exec(html);
+        if (!m) { tokens.push({text: html}); html = ""; }
+        else if (m.index != 0) { tokens.push({text: html.slice(0, m.index)}); html = html.slice(m.index); }
+        else if (m[1] == "#if ") { tokens.push({condition: m[2]}); html = html.slice(m[0].length); }
+        else if (m[2]) { tokens.push({variable: m[2]}); html = html.slice(m[0].length); }
+        else if (m[3] == "/if") { tokens.push({close: "if"}); html = html.slice(m[0].length); }
+        else { console.error("Error tokenizing tooltip when remaining template is: " + html); html=html.slice(m[0].length); }
     }
-    // Match all things that look like fields in the HTML
-    var matches = html.match(/{{[A-Za-z0-9_:|]+}}/g);
-    if (matches){
-        // Remove duplicates
-        matches.reduce(function(a,b){if(a.indexOf(b)<0)a.push(b);return a;},[]);
-        // Replace matches with resolved values from the data object
-        matches.forEach(function(match){
-            var field = new LocusZoom.Data.Field(match.substring(2, match.length-2));
-            var value = field.resolve(data);
-            if (["string","number","boolean"].indexOf(typeof value) != -1){
-                html = html.replace(match, value);
-            } else if (value == null){
-                html = html.replace(match, "");
+    var astify = function() {
+        var token = tokens.shift();
+        if (token.text || token.variable) {
+            return token;
+        } else if (token.condition) {
+            token.then = [];
+            while(tokens.length > 0) {
+                if (tokens[0].close == "if") { tokens.shift(); break; }
+                token.then.push(astify());
             }
-        });
-    }
-    return html;
+            return token;
+        } else {
+            console.error("Error making tooltip AST due to unknown token " + JSON.stringify(token));
+            return { text: "" };
+        }
+    };
+    // `ast` is like [thing,...]
+    // `thing` is like {text: "..."} or {variable:"foo|bar"} or {condition: "foo|bar", then:[thing,...]}
+    var ast = [];
+    while (tokens.length > 0) ast.push(astify());
+
+    var resolve = function(variable) {
+        if (!resolve.cache.hasOwnProperty(variable)) {
+            resolve.cache[variable] = (new LocusZoom.Data.Field(variable)).resolve(data);
+        }
+        return resolve.cache[variable];
+    };
+    resolve.cache = {};
+    var render_node = function(node) {
+        if (node.text) {
+            return node.text;
+        } else if (node.variable) {
+            try {
+                var value = resolve(node.variable);
+                if (["string","number","boolean"].indexOf(typeof value) != -1) { return value; }
+                if (value == null) { return ""; }
+            } catch (error) { console.error("Error while processing variable " + JSON.stringify(node.variable)); }
+            return "{{" + node.variable + "}}";
+        } else if (node.condition) {
+            try {
+                if (resolve(node.condition)) {
+                    return node.then.map(render_node).join("");
+                }
+            } catch (error) { console.error("Error while processign condition " + JSON.stringify(node.variable)); }
+            return "";
+        } else { console.error("Error rendering tooltip due to unknown AST node " + JSON.stringify(node)); }
+    };
+    return ast.map(render_node).join("");
 };
 
 // Shortcut method for getting the data bound to a tool tip.
@@ -6423,15 +6448,13 @@ LocusZoom.Data.Field = function(field){
     // First look for a full match with transformations already applied by the data requester.
     // Otherwise prefer a namespace match and fall back to just a name match, applying transformations on the fly.
     this.resolve = function(d){
-        if (typeof d[this.full_name] != "undefined"){
-            return d[this.full_name];
-        } else {
+        if (typeof d[this.full_name] == "undefined"){
             var val = null;
             if (typeof d[this.namespace+":"+this.name] != "undefined"){ val = d[this.namespace+":"+this.name]; }
             else if (typeof d[this.name] != "undefined"){ val = d[this.name]; }
             d[this.full_name] = this.applyTransformations(val);
-            return d[this.full_name];
         }
+        return d[this.full_name];
     };
     
 };

--- a/test/LocusZoom.js
+++ b/test/LocusZoom.js
@@ -221,11 +221,11 @@ describe("LocusZoom Core", function(){
             });
             it("should handle conditional blocks", function() {
                 var data = {
-                    "foo:field_1": 123,
+                    "foo:field_1": 1234,
                     "bar:field2": "foo"
                 };
                 var html = "{{#if foo:field_1}}<strong>{{foo:field_1}}{{#if bar:field2}} and {{bar:field2}}{{/if}}, {{#if nope}}wat{{/if}}{{bar:field2|herp|derp}}; {{field3}}</strong>{{/if}}";
-                var expected_value = "<strong>123 and foo, fooherpderp; </strong>";
+                var expected_value = "<strong>1234 and foo, fooherpderp; </strong>";
                 assert.equal(LocusZoom.parseFields(data, html), expected_value);
                 var data2 = {
                     "fieldA": "",

--- a/test/LocusZoom.js
+++ b/test/LocusZoom.js
@@ -246,7 +246,7 @@ describe("LocusZoom Core", function(){
                 var html2 = "{{#if fieldA}}A1<br>{{/if}}"
                           + "{{#if fieldA|derp}}A2<br>{{/if}}"
                           + "{{#if foo:fieldB}}B1<br>{{/if}}"
-                          + "{{#if foo:fieldB|derp}}B2<br>{{/if}}"
+                          + "{{#if foo:fieldB|derp}}B2<br>{{/if}}";
                 var expected_value2 = "A2<br>B2<br>";
                 assert.equal(LocusZoom.parseFields(data2, html2), expected_value2);
             });

--- a/test/LocusZoom.js
+++ b/test/LocusZoom.js
@@ -238,6 +238,15 @@ describe("LocusZoom Core", function(){
                 var expected_value2 = "A2<br>B2<br>";
                 assert.equal(LocusZoom.parseFields(data2, html2), expected_value2);
             });
+            it("should handle bad input", function() {
+                var data = {
+                    "foo:field_1": 12345,
+                    "bar:field2": "foo"
+                };
+                var html = "{{#iff foo:field_1}}<strong>{{{foo:field_1}}{{#if bar:field2}}} and {{{bar:field2|nope}}{{/if}}{{/if}}{{/if}}, {{#if {{wat}}}}{{#if nope}}{{#if unclosed}}wat{{bar:field2|herp||derp}}; {{field3}}</strong>";
+                var expected_value = "{{#iff foo:field_1}}<strong>{12345} and {bar:field2|nope, {{#if }}";
+                assert.equal(LocusZoom.parseFields(data, html), expected_value);
+            });
         });
         
         describe("Validate State", function() {

--- a/test/LocusZoom.js
+++ b/test/LocusZoom.js
@@ -219,12 +219,24 @@ describe("LocusZoom Core", function(){
                 var expected_value = "<strong>123 and foo, fooherpderp; </strong>";
                 assert.equal(LocusZoom.parseFields(data, html), expected_value);
             });
+            it("should hide non-existant fields but show broken ones", function() {
+                var data = {
+                    "foo:field_1": 12345,
+                    "bar:field2": "foo"
+                };
+                var html = "{{bar:field2||nope|}}{{wat}}{{bar:field2|herp||derp}}";
+                var expected_value = "{{bar:field2||nope|}}{{bar:field2|herp||derp}}";
+                assert.equal(LocusZoom.parseFields(data, html), expected_value);
+            });
             it("should handle conditional blocks", function() {
                 var data = {
                     "foo:field_1": 1234,
                     "bar:field2": "foo"
                 };
-                var html = "{{#if foo:field_1}}<strong>{{foo:field_1}}{{#if bar:field2}} and {{bar:field2}}{{/if}}, {{#if nope}}wat{{/if}}{{bar:field2|herp|derp}}; {{field3}}</strong>{{/if}}";
+                var html = "{{#if foo:field_1}}<strong>{{foo:field_1}}"
+                         + "{{#if bar:field2}} and {{bar:field2}}{{/if}}, "
+                         + "{{#if nope}}wat{{/if}}"
+                         + "{{bar:field2|herp|derp}}; {{field3}}</strong>{{/if}}";
                 var expected_value = "<strong>1234 and foo, fooherpderp; </strong>";
                 assert.equal(LocusZoom.parseFields(data, html), expected_value);
                 var data2 = {
@@ -238,13 +250,29 @@ describe("LocusZoom Core", function(){
                 var expected_value2 = "A2<br>B2<br>";
                 assert.equal(LocusZoom.parseFields(data2, html2), expected_value2);
             });
-            it("should handle bad input", function() {
+            it("should treat broken/non-existant conditions as false", function() {
                 var data = {
                     "foo:field_1": 12345,
                     "bar:field2": "foo"
                 };
-                var html = "{{#iff foo:field_1}}<strong>{{{foo:field_1}}{{#if bar:field2}}} and {{{bar:field2|nope}}{{/if}}{{/if}}{{/if}}, {{#if {{wat}}}}{{#if nope}}{{#if unclosed}}wat{{bar:field2|herp||derp}}; {{field3}}</strong>";
-                var expected_value = "{{#iff foo:field_1}}<strong>{12345} and {bar:field2|nope, {{#if }}";
+                var html = "a{{#if foo:field_3}}b{{/if}}c";
+                var expected_value = "ac";
+                assert.equal(LocusZoom.parseFields(data, html), expected_value);
+                var html2 = "a{{#if foo:field_1|nope}}b{{/if}}c";
+                assert.equal(LocusZoom.parseFields(data, html2), expected_value);
+            });
+            it("should handle nasty input", function() {
+                var data = {
+                    "foo:field_1": 12345,
+                    "bar:field2": "foo"
+                };
+                var html = "{{#iff foo:field_1}}<strong>{{{{foo:field_1}}}}"
+                         + "{{#if bar:field2}} and {{bar:field2||nope|}}{{/if}}{{/if}}{{/if}}, "
+                         + "{{#if {{wat}}}}"
+                         + "{{#if nope}}.{{#if unclosed}}. {{field3}}";
+                var expected_value = "{{#iff foo:field_1}}<strong>{{12345}}"
+                                   + " and {{bar:field2||nope|}}, "
+                                   + "{{#if }}";
                 assert.equal(LocusZoom.parseFields(data, html), expected_value);
             });
         });


### PR DESCRIPTION
This avoids some of the odd behavior of the previous conditional-template implementation.  If the AST were cached it could also be much faster, but oh well.