### PR TITLE
Treat zero as truthy in conditions

### DIFF
--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -377,7 +377,8 @@ LocusZoom.parseFields = function (data, html) {
             return "{{" + node.variable + "}}";
         } else if (node.condition) {
             try {
-                if (resolve(node.condition)) {
+                var condition = resolve(node.condition);
+                if (condition || condition === 0) {
                     return node.then.map(render_node).join("");
                 }
             } catch (error) { console.error("Error while processing condition " + JSON.stringify(node.variable)); }

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -420,7 +420,8 @@ LocusZoom.parseFields = function (data, html) {
             return "{{" + node.variable + "}}";
         } else if (node.condition) {
             try {
-                if (resolve(node.condition)) {
+                var condition = resolve(node.condition);
+                if (condition || condition === 0) {
                     return node.then.map(render_node).join("");
                 }
             } catch (error) { console.error("Error while processing condition " + JSON.stringify(node.variable)); }

--- a/test/LocusZoom.js
+++ b/test/LocusZoom.js
@@ -250,6 +250,14 @@ describe("LocusZoom Core", function(){
                 var expected_value2 = "A2<br>B2<br>";
                 assert.equal(LocusZoom.parseFields(data2, html2), expected_value2);
             });
+            it("should treat 0 as truthy in conditions", function() {
+                var data = {
+                    "foo": 0
+                };
+                var html = "a{{#if foo}}{{foo}}{{/if}}";
+                var expected_value = "a0";
+                assert.equal(LocusZoom.parseFields(data, html), expected_value);
+            });
             it("should treat broken/non-existant conditions as false", function() {
                 var data = {
                     "foo:field_1": 12345,


### PR DESCRIPTION
In PheWeb, I'm generating tooltips based on the list of fields defined in my parser, even though each trait might have different fields actually present.  So, I make a big template like:
```
{{#if rsid}}<b>{{rsid}}</b><br>{{/if}}
{{#if pvalue}}pvalue: {{pvalue|scinotation}}{{/if}}
{{#if beta}}beta: {{beta}}{{#if sebeta}} ({{sebeta}}){{/if}}{{/if}}
```

But this won't show `pvalue` or `beta` if they are `0`.  (I know, pval oughtn't be zero, but I didn't make the data.)

I could just do
```
LocusZoom.TransformationFunctions.add("truthy_or_0", x => (x || x === 0))
```

and then replace the above template with
```
{{#if rsid|truthy_or_0}}<b>{{rsid}}</b><br>{{/if}}
{{#if pvalue|truthy_or_0}}pvalue: {{pvalue|scinotation}}{{/if}}
{{#if beta|truthy_or_0}}beta: {{beta}}{{#if sebeta|truthy_or_0}} ({{sebeta}}){{/if}}{{/if}}
```
but I suspect that almost all users would prefer to treat 0 as truthy.