### PR TITLE
[hold] Improve user-facing error message

### DIFF
--- a/assets/js/app/Data.js
+++ b/assets/js/app/Data.js
@@ -430,7 +430,8 @@ LocusZoom.Data.LDSource.prototype.getURL = function(state, chain, fields) {
             var columns = "";
             if (!keys.id){ columns += (columns.length ? ", " : "") + "id"; }
             if (!keys.pvalue){ columns += (columns.length ? ", " : "") + "pvalue"; }
-            throw("Unable to find necessary column(s) for merge: " + columns + " (available: " + keys._names_ + ")");
+            console.error("Unable to find necessary column(s) for merge: " + columns + " (available: " + keys._names_ + ")");
+            throw("No variants in range for this data set.  Expand the range, or try a different data set");
         }
         refVar = chain.body[findExtremeValue(chain.body, keys.pvalue)][keys.id];
     }


### PR DESCRIPTION
# Purpose
Patch proposed by @benralexander . PR created on his behalf by request.

A developer-focused error was being shown to users (likely in [this block](https://github.com/abought/locuszoom/blob/24c5a3780914b0bcd80ca9fd9d0797e2bb9e3f0a/assets/js/app/Panel.js#L543-L563)) Replace that error with more user-friendly text.

Ben provides the following notes about how to reproduce:
> If users sometimes specify a genomic range in which no variants exist (definitely easy to do in some of our data sets, and especially if they have 'zoomed in') then the default error message was leaving them confused.  The message we've provided instead at least gives them a hint about what they should do next.  Clearly a more general approach would provide the calling routine with more options for error handling in this common case.