### PR TITLE
Fix issue with plot resizing when plot or panel min_height is specified

### DIFF
--- a/assets/js/app/Plot.js
+++ b/assets/js/app/Plot.js
@@ -83,6 +83,13 @@ LocusZoom.Plot = function(id, datasource, layout) {
     LocusZoom.Layouts.merge(this.layout, LocusZoom.Plot.DefaultLayout);
 
     /**
+     * Values in the layout object may change during rendering etc. Retain a copy of the original plot state
+     * @member {Object}
+     */
+    this._base_layout = JSON.parse(JSON.stringify(this.layout));
+
+
+    /**
      * Create a shortcut to the state in the layout on the Plot. Tracking in the layout allows the plot to be created
      *   with initial state/setup.
      *
@@ -558,6 +565,10 @@ LocusZoom.Plot.prototype.removePanel = function(id){
 
     // Call positionPanels() to keep panels from overlapping and ensure filling all available vertical space
     if (this.initialized){
+        // Allow the plot to shrink when panels are removed, by forcing it to recalculate min dimensions from scratch
+        this.layout.min_height = this._base_layout.min_height;
+        this.layout.min_width = this._base_layout.min_width;
+
         this.positionPanels();
         // An extra call to setDimensions with existing discrete dimensions fixes some rounding errors with tooltip
         // positioning. TODO: make this additional call unnecessary.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,6 +30,7 @@ gulp.task("test", function () {
         .on("error", function (err) {
             console.error(err);
             if (argv.force){
+                // Note: If running gulp via npm script, npm will intercept "--force" and not pass it to gulp
                 this.failed = true;
                 this.emit("end");
             } else {


### PR DESCRIPTION
## Purpose
Fix issue reported by @benralexander, where in certain situations the plot did not resize as expected when a panel was removed.

The issue was traced to an edge case that occurred when plots and/or panels specified a `min_height`. Specifically, the plot was "[remembering](https://github.com/statgen/locuszoom/blob/b65342df9626da4491f4814e3296ef6463284262/assets/js/app/Plot.js#L344-L351)" minimum constraints based on a panel that was no longer there- math.max provided a mechanism for `min_height` to grow, but not to shrink.
 
## Demonstrations
The issue is demonstrated below. It could be reproduced on many of our core sample plots, including [phewas_scatter](http://statgen.github.io/locuszoom/examples/phewas_scatter.html).

The browser demo in these images also applies proportional height constraints, so the numbers in the example below differ slightly vs unit tests.

**Before**
Removing a panel did not free up as much space as would be expected. Remaining panels stretched to fit a larger plot size. After plot removal, `plot.layout.height===667`
![resize_bug_demo_before](https://user-images.githubusercontent.com/2957073/30977029-557d7928-a444-11e7-87a0-8b6089e81aff.gif)

**After (if plot min_height is specified)**
Plot shrinks slightly (to the minimum required dimensions, `plot.layout.height===600`), but space is reallocated between the remaining panels, so the image appears to stretch and shrink a bit.

![resize_bug_demo_after_with_minheight](https://user-images.githubusercontent.com/2957073/30977870-e3ad6a58-a446-11e7-9d0a-49c87653d743.gif)

**After (if plot min_height is not specified)**
Plot shrinks by exactly the size of the removed panel- the user experience is as if the bottom section simply disappeared. `plot.layout.height===367` at end)
![resize_bug_demo_after_no_minheight](https://user-images.githubusercontent.com/2957073/30977720-680a8fde-a446-11e7-99fd-a3ef81f68d7b.gif)

## Reviewer notes
The resize logic supports a number of configuration options. I have done some basic manual regression testing on other examples, but please let me know if this fix could be problematic.

I intentionally left the behavior in the second screenshot as is- stretching seems a valid response to having more room than any one panel requested, and the user can get the desired appearance by providing panel min_heights (but omitting `min_height` for the layout of the parent plot). 

That said, this is nuanced behavior, so feedback is welcome.