### PR TITLE
Fix Interval Tool Tip Behaviors

### DIFF
--- a/assets/css/locuszoom.scss
+++ b/assets/css/locuszoom.scss
@@ -154,19 +154,19 @@ svg.#{$namespace}-locuszoom {
     font-style: italic;
   }
 
-  rect.#{$namespace}-data_layer-genes.#{$namespace}-data_layer-genes-bounding_box {
+  rect.#{$namespace}-data_layer-genes.#{$namespace}-data_layer-genes-statusnode {
     fill: rgb(54, 54, 150);
     fill-opacity: 0;
     stroke-width: 0px;
   }
 
-  rect.#{$namespace}-data_layer-genes.#{$namespace}-data_layer-genes-bounding_box-highlighted {
+  rect.#{$namespace}-data_layer-genes.#{$namespace}-data_layer-genes-statusnode-highlighted {
     fill: rgb(54, 54, 150);
     fill-opacity: 0.1;
     stroke-width: 0px;
   }
 
-  rect.#{$namespace}-data_layer-genes.#{$namespace}-data_layer-genes-bounding_box-selected {
+  rect.#{$namespace}-data_layer-genes.#{$namespace}-data_layer-genes-statusnode-selected {
     fill: rgb(54, 54, 150);
     fill-opacity: 0.15;
     stroke: #{$default_black};
@@ -196,19 +196,19 @@ svg.#{$namespace}-locuszoom {
     display: none;
   }
 
-  rect.#{$namespace}-data_layer-intervals.#{$namespace}-data_layer-intervals-bounding_box {
+  rect.#{$namespace}-data_layer-intervals.#{$namespace}-data_layer-intervals-statusnode {
     fill: rgb(54, 54, 150);
     fill-opacity: 0;
     stroke-width: 0px;
   }
 
-  rect.#{$namespace}-data_layer-intervals.#{$namespace}-data_layer-intervals-bounding_box-highlighted {
+  rect.#{$namespace}-data_layer-intervals.#{$namespace}-data_layer-intervals-statusnode-highlighted {
     fill: rgb(54, 54, 150);
     fill-opacity: 0.2;
     stroke-width: 0px;
   }
 
-  rect.#{$namespace}-data_layer-intervals.#{$namespace}-data_layer-intervals-bounding_box-selected {
+  rect.#{$namespace}-data_layer-intervals.#{$namespace}-data_layer-intervals-statusnode-selected {
     fill: rgb(54, 54, 150);
     fill-opacity: 0.35;
     stroke: #{$default_black};

--- a/assets/js/app/DataLayer.js
+++ b/assets/js/app/DataLayer.js
@@ -163,6 +163,19 @@ LocusZoom.DataLayer.prototype.getElementId = function(element){
 };
 
 /**
+ * Fetch an ID that may bind a data element to a separate visual node for displaying status
+ * Examples of this might be seperate visual nodes to show select/highlight statuses, or
+ * even a common/shared node to show status across many elements in a set.
+ * Abstract method. It should be overridden by data layers that implement seperate status
+ * nodes specifically to the use case of the data layer type.
+ * @param {String|Object} element
+ * @returns {String|null}
+ */
+LocusZoom.DataLayer.prototype.getElementStatusNodeId = function(element){
+    return null;
+};
+
+/**
  * Returns a reference to the underlying data associated with a single visual element in the data layer, as
  *   referenced by the unique identifier for the element
 
@@ -724,13 +737,9 @@ LocusZoom.DataLayer.prototype.setElementStatus = function(status, element, toggl
     
     // Set/unset the proper status class on the appropriate DOM element(s)
     d3.select("#" + element_id).classed("lz-data_layer-" + this.layout.type + "-" + status, toggle);
-    if (this.layout.hover_element){
-        var hover_element_class = "lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element + "-" + status;
-        var selector = d3.select("#" + element_id + "_" + this.layout.hover_element);
-        if (this.layout.group_hover_elements_on_field){
-            selector = this.group_hover_elements[element[this.layout.group_hover_elements_on_field]];
-        }
-        selector.classed(hover_element_class, toggle);
+    var element_status_node_id = this.getElementStatusNodeId(element);
+    if (element_status_node_id !== null){
+        d3.select("#" + element_status_node_id).classed("lz-data_layer-" + this.layout.type + "-statusnode-" + status, toggle);
     }
     
     // Track element ID in the proper status state array

--- a/assets/js/app/DataLayers/genes.js
+++ b/assets/js/app/DataLayers/genes.js
@@ -22,12 +22,20 @@ LocusZoom.DataLayers.add("genes", function(layout){
         exon_height: 16,
         bounding_box_padding: 6,
         track_vertical_spacing: 10,
-        hover_element: "bounding_box"
     };
     layout = LocusZoom.Layouts.merge(layout, this.DefaultLayout);
 
     // Apply the arguments to set LocusZoom.DataLayer as the prototype
     LocusZoom.DataLayer.apply(this, arguments);
+
+    /**
+     * Generate a statusnode ID for a given element
+     * @override
+     * @returns {String}
+     */
+    this.getElementStatusNodeId = function(element){
+        return this.getElementId(element) + "-statusnode";
+    };
 
     /**
      * Helper function to sum layout values to derive total height for a single gene track
@@ -218,16 +226,16 @@ LocusZoom.DataLayers.add("genes", function(layout){
 
                 var data_layer = gene.parent;
 
-                // Render gene bounding box
-                var bboxes = d3.select(this).selectAll("rect.lz-data_layer-genes.lz-data_layer-genes-bounding_box")
-                    .data([gene], function(d){ return d.gene_name + "_bbox"; });
+                // Render gene bounding boxes (status nodes to show selected/highlighted)
+                var bboxes = d3.select(this).selectAll("rect.lz-data_layer-genes.lz-data_layer-genes-statusnode")
+                    .data([gene], function(d){ return data_layer.getElementStatusNodeId(d); });
 
                 bboxes.enter().append("rect")
-                    .attr("class", "lz-data_layer-genes lz-data_layer-genes-bounding_box");
+                    .attr("class", "lz-data_layer-genes lz-data_layer-genes-statusnode");
                 
                 bboxes
                     .attr("id", function(d){
-                        return data_layer.getElementId(d) + "_bounding_box";
+                        return data_layer.getElementStatusNodeId(d);
                     })
                     .attr("rx", function(){
                         return data_layer.layout.bounding_box_padding;
@@ -451,7 +459,7 @@ LocusZoom.DataLayers.add("genes", function(layout){
         var stroke_width = 1; // as defined in the default stylesheet
         var page_origin = this.getPageOrigin();
         var tooltip_box = tooltip.selector.node().getBoundingClientRect();
-        var gene_bbox_id = this.getElementId(tooltip.data) + "_bounding_box";
+        var gene_bbox_id = this.getElementStatusNodeId(tooltip.data);
         var gene_bbox = d3.select("#" + gene_bbox_id).node().getBBox();
         var data_layer_height = this.parent.layout.height - (this.parent.layout.margin.top + this.parent.layout.margin.bottom);
         var data_layer_width = this.parent.layout.width - (this.parent.layout.margin.left + this.parent.layout.margin.right);

--- a/assets/js/app/DataLayers/intervals.js
+++ b/assets/js/app/DataLayers/intervals.js
@@ -22,8 +22,6 @@ LocusZoom.DataLayers.add("intervals", function(layout){
         track_height: 15,
         track_vertical_spacing: 3,
         bounding_box_padding: 2,
-        hover_element: "bounding_box",
-        group_hover_elements_on_field: null,
         always_hide_legend: false,
         color: "#B8B8B8",
         fill_opacity: 1
@@ -32,11 +30,19 @@ LocusZoom.DataLayers.add("intervals", function(layout){
 
     // Apply the arguments to set LocusZoom.DataLayer as the prototype
     LocusZoom.DataLayer.apply(this, arguments);
-
-    // Set layout.group_hover_elements_on_field if starting in split mode
-    if (this.layout.split_tracks && this.layout.track_split_field){
-        this.layout.group_hover_elements_on_field = this.layout.track_split_field;
-    }
+    
+    /**
+     * To define shared highlighting on the track split field define the status node id override
+     * to generate an ID common to the track when we're actively splitting data out to separate tracks
+     * @override
+     * @returns {String}
+     */
+    this.getElementStatusNodeId = function(element){
+        if (this.layout.split_tracks){
+            return (this.getBaseId() + "-statusnode-" + element[this.layout.track_split_field]).replace(/(:|\.|\[|\]|,)/g, "_");
+        }
+        return this.getElementId(element) + "-statusnode";
+    }.bind(this);
     
     // Helper function to sum layout values to derive total height for a single interval track
     this.getTrackHeight = function(){
@@ -47,7 +53,6 @@ LocusZoom.DataLayers.add("intervals", function(layout){
 
     this.tracks = 1;
     this.previous_tracks = 1;
-    this.group_hover_elements = {};
     
     // track-number-indexed object with arrays of interval indexes in the dataset
     this.interval_track_index = { 1: [] };
@@ -147,29 +152,26 @@ LocusZoom.DataLayers.add("intervals", function(layout){
 
         this.assignTracks();
 
-        // First: render or remove group bounding boxes based on whether we're track split
-        if (this.layout.split_tracks){
-            Object.keys(this.group_hover_elements).forEach(function(key){
-                if (!this.track_split_field_index[key]){ this.group_hover_elements[key].remove(); }
-            }.bind(this));
-            Object.keys(this.track_split_field_index).forEach(function(key){
-                if (!this.group_hover_elements[key]){
-                    this.group_hover_elements[key] = this.svg.group.insert("rect", ":first-child")
-                        .attr("class", "lz-data_layer-intervals lz-data_layer-intervals-bounding_box");
-                }
-                this.group_hover_elements[key]
-                    .attr("rx", this.layout.bounding_box_padding).attr("ry", this.layout.bounding_box_padding)
-                    .attr("width", this.parent.layout.cliparea.width)
-                    .attr("height", this.getTrackHeight() - this.layout.track_vertical_spacing)
-                    .attr("x", 0)
-                    .attr("y", (this.track_split_field_index[key]-1) * this.getTrackHeight());
-            }.bind(this));
-        } else {
-            Object.keys(this.group_hover_elements).forEach(function(key){
-                this.group_hover_elements[key].remove();
-            }.bind(this));
-            this.group_hover_elements = {};
-        }
+        // Remove any shared highlight nodes and re-render them if we're splitting on tracks
+        // At most there will only be dozen or so nodes here (one per track) and each time
+        // we render data we may have new tracks, so wiping/redrawing all is reasonable.
+        this.svg.group.selectAll(".lz-data_layer-intervals-statusnode.lz-data_layer-intervals-shared").remove();
+        Object.keys(this.track_split_field_index).forEach(function(key){
+            // Make a psuedo-element so that we can generate an id for the shared node
+            var psuedoElement = {};
+            psuedoElement[this.layout.track_split_field] = key;
+            // Insert the shared node
+            var sharedstatusnode_style = {display: (this.layout.split_tracks ? null : "none")};
+            this.svg.group.insert("rect", ":first-child")
+                .attr("id", this.getElementStatusNodeId(psuedoElement))
+                .attr("class", "lz-data_layer-intervals lz-data_layer-intervals-statusnode lz-data_layer-intervals-shared")
+                .attr("rx", this.layout.bounding_box_padding).attr("ry", this.layout.bounding_box_padding)
+                .attr("width", this.parent.layout.cliparea.width)
+                .attr("height", this.getTrackHeight() - this.layout.track_vertical_spacing)
+                .attr("x", 0)
+                .attr("y", (this.track_split_field_index[key]-1) * this.getTrackHeight())
+                .style(sharedstatusnode_style);
+        }.bind(this));
 
         var width, height, x, y, fill, fill_opacity;
             
@@ -185,52 +187,47 @@ LocusZoom.DataLayers.add("intervals", function(layout){
 
                 var data_layer = interval.parent;
 
-                // Render interval bounding box (displayed behind intervals to show highlight
-                // without needing to modify interval display element(s)) if not in split view
-                var bboxes = d3.select(this).selectAll("rect.lz-data_layer-intervals.lz-data_layer-intervals-bounding_box")
-                    .data([interval], function(d){ return d[data_layer.layout.id_field] + "_bbox"; });
-                if (data_layer.layout.split_tracks){
-                    bboxes.remove();
+                // Render interval status nodes (displayed behind intervals to show highlight
+                // without needing to modify interval display element(s))
+                var statusnode_style = {display: (data_layer.layout.split_tracks ? "none" : null)};
+                var statusnodes = d3.select(this).selectAll("rect.lz-data_layer-intervals.lz-data_layer-intervals-statusnode.lz-data_layer-intervals-statusnode-discrete")
+                    .data([interval], function(d){ return data_layer.getElementId(d) + "-statusnode"; });
+                statusnodes.enter().insert("rect", ":first-child")
+                    .attr("class", "lz-data_layer-intervals lz-data_layer-intervals-statusnode lz-data_layer-intervals-statusnode-discrete");
+                statusnodes
+                    .attr("id", function(d){
+                        return data_layer.getElementId(d) + "-statusnode";
+                    })
+                    .attr("rx", function(){
+                        return data_layer.layout.bounding_box_padding;
+                    })
+                    .attr("ry", function(){
+                        return data_layer.layout.bounding_box_padding;
+                    })
+                    .style(statusnode_style);
+                width = function(d){
+                    return d.display_range.width + (2 * data_layer.layout.bounding_box_padding);
+                };
+                height = function(){
+                    return data_layer.getTrackHeight() - data_layer.layout.track_vertical_spacing;
+                };
+                x = function(d){
+                    return d.display_range.start - data_layer.layout.bounding_box_padding;
+                };
+                y = function(d){
+                    return ((d.track-1) * data_layer.getTrackHeight());
+                };
+                if (data_layer.canTransition()){
+                    statusnodes
+                        .transition()
+                        .duration(data_layer.layout.transition.duration || 0)
+                        .ease(data_layer.layout.transition.ease || "cubic-in-out")
+                        .attr("width", width).attr("height", height).attr("x", x).attr("y", y);
                 } else {
-                    bboxes.enter().insert("rect", ":first-child")
-                        .attr("class", "lz-data_layer-intervals lz-data_layer-intervals-bounding_box");
-                    
-                    bboxes
-                        .attr("id", function(d){
-                            return data_layer.getElementId(d) + "_bounding_box";
-                        })
-                        .attr("rx", function(){
-                            return data_layer.layout.bounding_box_padding;
-                        })
-                        .attr("ry", function(){
-                            return data_layer.layout.bounding_box_padding;
-                        });
-                    
-                    width = function(d){
-                        return d.display_range.width + (2 * data_layer.layout.bounding_box_padding);
-                    };
-                    height = function(){
-                        return data_layer.getTrackHeight() - data_layer.layout.track_vertical_spacing;
-                    };
-                    x = function(d){
-                        return d.display_range.start - data_layer.layout.bounding_box_padding;
-                    };
-                    y = function(d){
-                        return ((d.track-1) * data_layer.getTrackHeight());
-                    };
-                    if (data_layer.canTransition()){
-                        bboxes
-                            .transition()
-                            .duration(data_layer.layout.transition.duration || 0)
-                            .ease(data_layer.layout.transition.ease || "cubic-in-out")
-                            .attr("width", width).attr("height", height).attr("x", x).attr("y", y);
-                    } else {
-                        bboxes
-                            .attr("width", width).attr("height", height).attr("x", x).attr("y", y);
-                    }
-                    
-                    bboxes.exit().remove();
+                    statusnodes
+                        .attr("width", width).attr("height", height).attr("x", x).attr("y", y);
                 }
+                statusnodes.exit().remove();
 
                 // Render primary interval rects
                 var rects = d3.select(this).selectAll("rect.lz-data_layer-intervals.lz-interval_rect")
@@ -357,12 +354,7 @@ LocusZoom.DataLayers.add("intervals", function(layout){
         var stroke_width = 1; // as defined in the default stylesheet
         var page_origin = this.getPageOrigin();
         var tooltip_box = tooltip.selector.node().getBoundingClientRect();
-        var interval_bbox;
-        if (this.layout.split_tracks){
-            interval_bbox = d3.select("#" + this.getElementId(tooltip.data)).node().getBBox();
-        } else {
-            interval_bbox = d3.select("#" + this.getElementId(tooltip.data) + "_bounding_box").node().getBBox();
-        }
+        var interval_bbox = d3.select("#" + this.getElementStatusNodeId(tooltip.data)).node().getBBox();
         var data_layer_height = this.parent.layout.height - (this.parent.layout.margin.top + this.parent.layout.margin.bottom);
         var data_layer_width = this.parent.layout.width - (this.parent.layout.margin.left + this.parent.layout.margin.right);
         // Position horizontally: attempt to center on the portion of the interval that's visible,
@@ -450,7 +442,6 @@ LocusZoom.DataLayers.add("intervals", function(layout){
     // necessary display values to animate a complete merge/split
     this.toggleSplitTracks = function(){
         this.layout.split_tracks = !this.layout.split_tracks;
-        this.layout.group_hover_elements_on_field = this.layout.split_tracks ? this.layout.track_split_field : null;
         if (this.parent.legend && !this.layout.always_hide_legend){
             this.parent.layout.margin.bottom = 5 + (this.layout.split_tracks ? 0 : this.parent.legend.layout.height + 5);
         }

--- a/assets/js/app/DataLayers/intervals.js
+++ b/assets/js/app/DataLayers/intervals.js
@@ -39,7 +39,7 @@ LocusZoom.DataLayers.add("intervals", function(layout){
      */
     this.getElementStatusNodeId = function(element){
         if (this.layout.split_tracks){
-            return (this.getBaseId() + "-statusnode-" + element[this.layout.track_split_field]).replace(/[:.\[\],]/g, "_");
+            return (this.getBaseId() + "-statusnode-" + element[this.layout.track_split_field]).replace(/[:.[\],]/g, "_");
         }
         return this.getElementId(element) + "-statusnode";
     }.bind(this);

--- a/assets/js/app/DataLayers/intervals.js
+++ b/assets/js/app/DataLayers/intervals.js
@@ -39,7 +39,7 @@ LocusZoom.DataLayers.add("intervals", function(layout){
      */
     this.getElementStatusNodeId = function(element){
         if (this.layout.split_tracks){
-            return (this.getBaseId() + "-statusnode-" + element[this.layout.track_split_field]).replace(/(:|\.|\[|\]|,)/g, "_");
+            return (this.getBaseId() + "-statusnode-" + element[this.layout.track_split_field]).replace(/[:.\[\],]/g, "_");
         }
         return this.getElementId(element) + "-statusnode";
     }.bind(this);

--- a/assets/js/app/DataLayers/intervals.js
+++ b/assets/js/app/DataLayers/intervals.js
@@ -32,6 +32,11 @@ LocusZoom.DataLayers.add("intervals", function(layout){
 
     // Apply the arguments to set LocusZoom.DataLayer as the prototype
     LocusZoom.DataLayer.apply(this, arguments);
+
+    // Set layout.group_hover_elements_on_field if starting in split mode
+    if (this.layout.split_tracks && this.layout.track_split_field){
+        this.layout.group_hover_elements_on_field = this.layout.track_split_field;
+    }
     
     // Helper function to sum layout values to derive total height for a single interval track
     this.getTrackHeight = function(){
@@ -186,8 +191,8 @@ LocusZoom.DataLayers.add("intervals", function(layout){
                     .data([interval], function(d){ return d[data_layer.layout.id_field] + "_bbox"; });
                 if (data_layer.layout.split_tracks){
                     bboxes.remove();
-                } else {                    
-                    bboxes.enter().append("rect")
+                } else {
+                    bboxes.enter().insert("rect", ":first-child")
                         .attr("class", "lz-data_layer-intervals lz-data_layer-intervals-bounding_box");
                     
                     bboxes

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -4536,6 +4536,11 @@ LocusZoom.DataLayers.add("intervals", function(layout){
 
     // Apply the arguments to set LocusZoom.DataLayer as the prototype
     LocusZoom.DataLayer.apply(this, arguments);
+
+    // Set layout.group_hover_elements_on_field if starting in split mode
+    if (this.layout.split_tracks && this.layout.track_split_field){
+        this.layout.group_hover_elements_on_field = this.layout.track_split_field;
+    }
     
     // Helper function to sum layout values to derive total height for a single interval track
     this.getTrackHeight = function(){
@@ -4690,8 +4695,8 @@ LocusZoom.DataLayers.add("intervals", function(layout){
                     .data([interval], function(d){ return d[data_layer.layout.id_field] + "_bbox"; });
                 if (data_layer.layout.split_tracks){
                     bboxes.remove();
-                } else {                    
-                    bboxes.enter().append("rect")
+                } else {
+                    bboxes.enter().insert("rect", ":first-child")
                         .attr("class", "lz-data_layer-intervals lz-data_layer-intervals-bounding_box");
                     
                     bboxes

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -4560,7 +4560,7 @@ LocusZoom.DataLayers.add("intervals", function(layout){
      */
     this.getElementStatusNodeId = function(element){
         if (this.layout.split_tracks){
-            return (this.getBaseId() + "-statusnode-" + element[this.layout.track_split_field]).replace(/(:|\.|\[|\]|,)/g, "_");
+            return (this.getBaseId() + "-statusnode-" + element[this.layout.track_split_field]).replace(/[:.\[\],]/g, "_");
         }
         return this.getElementId(element) + "-statusnode";
     }.bind(this);
@@ -4723,7 +4723,7 @@ LocusZoom.DataLayers.add("intervals", function(layout){
                         return data_layer.layout.bounding_box_padding;
                     })
                     .attr("ry", function(){
-                            return data_layer.layout.bounding_box_padding;
+                        return data_layer.layout.bounding_box_padding;
                     })
                     .style(statusnode_style);
                 width = function(d){

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -2042,6 +2042,19 @@ LocusZoom.DataLayer.prototype.getElementId = function(element){
 };
 
 /**
+ * Fetch an ID that may bind a data element to a separate visual node for displaying status
+ * Examples of this might be seperate visual nodes to show select/highlight statuses, or
+ * even a common/shared node to show status across many elements in a set.
+ * Abstract method. It should be overridden by data layers that implement seperate status
+ * nodes specifically to the use case of the data layer type.
+ * @param {String|Object} element
+ * @returns {String|null}
+ */
+LocusZoom.DataLayer.prototype.getElementStatusNodeId = function(element){
+    return null;
+};
+
+/**
  * Returns a reference to the underlying data associated with a single visual element in the data layer, as
  *   referenced by the unique identifier for the element
 
@@ -2603,13 +2616,9 @@ LocusZoom.DataLayer.prototype.setElementStatus = function(status, element, toggl
     
     // Set/unset the proper status class on the appropriate DOM element(s)
     d3.select("#" + element_id).classed("lz-data_layer-" + this.layout.type + "-" + status, toggle);
-    if (this.layout.hover_element){
-        var hover_element_class = "lz-data_layer-" + this.layout.type + "-" + this.layout.hover_element + "-" + status;
-        var selector = d3.select("#" + element_id + "_" + this.layout.hover_element);
-        if (this.layout.group_hover_elements_on_field){
-            selector = this.group_hover_elements[element[this.layout.group_hover_elements_on_field]];
-        }
-        selector.classed(hover_element_class, toggle);
+    var element_status_node_id = this.getElementStatusNodeId(element);
+    if (element_status_node_id !== null){
+        d3.select("#" + element_status_node_id).classed("lz-data_layer-" + this.layout.type + "-statusnode-" + status, toggle);
     }
     
     // Track element ID in the proper status state array
@@ -4035,12 +4044,20 @@ LocusZoom.DataLayers.add("genes", function(layout){
         exon_height: 16,
         bounding_box_padding: 6,
         track_vertical_spacing: 10,
-        hover_element: "bounding_box"
     };
     layout = LocusZoom.Layouts.merge(layout, this.DefaultLayout);
 
     // Apply the arguments to set LocusZoom.DataLayer as the prototype
     LocusZoom.DataLayer.apply(this, arguments);
+
+    /**
+     * Generate a statusnode ID for a given element
+     * @override
+     * @returns {String}
+     */
+    this.getElementStatusNodeId = function(element){
+        return this.getElementId(element) + "-statusnode";
+    };
 
     /**
      * Helper function to sum layout values to derive total height for a single gene track
@@ -4231,16 +4248,16 @@ LocusZoom.DataLayers.add("genes", function(layout){
 
                 var data_layer = gene.parent;
 
-                // Render gene bounding box
-                var bboxes = d3.select(this).selectAll("rect.lz-data_layer-genes.lz-data_layer-genes-bounding_box")
-                    .data([gene], function(d){ return d.gene_name + "_bbox"; });
+                // Render gene bounding boxes (status nodes to show selected/highlighted)
+                var bboxes = d3.select(this).selectAll("rect.lz-data_layer-genes.lz-data_layer-genes-statusnode")
+                    .data([gene], function(d){ return data_layer.getElementStatusNodeId(d); });
 
                 bboxes.enter().append("rect")
-                    .attr("class", "lz-data_layer-genes lz-data_layer-genes-bounding_box");
+                    .attr("class", "lz-data_layer-genes lz-data_layer-genes-statusnode");
                 
                 bboxes
                     .attr("id", function(d){
-                        return data_layer.getElementId(d) + "_bounding_box";
+                        return data_layer.getElementStatusNodeId(d);
                     })
                     .attr("rx", function(){
                         return data_layer.layout.bounding_box_padding;
@@ -4464,7 +4481,7 @@ LocusZoom.DataLayers.add("genes", function(layout){
         var stroke_width = 1; // as defined in the default stylesheet
         var page_origin = this.getPageOrigin();
         var tooltip_box = tooltip.selector.node().getBoundingClientRect();
-        var gene_bbox_id = this.getElementId(tooltip.data) + "_bounding_box";
+        var gene_bbox_id = this.getElementStatusNodeId(tooltip.data);
         var gene_bbox = d3.select("#" + gene_bbox_id).node().getBBox();
         var data_layer_height = this.parent.layout.height - (this.parent.layout.margin.top + this.parent.layout.margin.bottom);
         var data_layer_width = this.parent.layout.width - (this.parent.layout.margin.left + this.parent.layout.margin.right);
@@ -4526,8 +4543,6 @@ LocusZoom.DataLayers.add("intervals", function(layout){
         track_height: 15,
         track_vertical_spacing: 3,
         bounding_box_padding: 2,
-        hover_element: "bounding_box",
-        group_hover_elements_on_field: null,
         always_hide_legend: false,
         color: "#B8B8B8",
         fill_opacity: 1
@@ -4536,11 +4551,19 @@ LocusZoom.DataLayers.add("intervals", function(layout){
 
     // Apply the arguments to set LocusZoom.DataLayer as the prototype
     LocusZoom.DataLayer.apply(this, arguments);
-
-    // Set layout.group_hover_elements_on_field if starting in split mode
-    if (this.layout.split_tracks && this.layout.track_split_field){
-        this.layout.group_hover_elements_on_field = this.layout.track_split_field;
-    }
+    
+    /**
+     * To define shared highlighting on the track split field define the status node id override
+     * to generate an ID common to the track when we're actively splitting data out to separate tracks
+     * @override
+     * @returns {String}
+     */
+    this.getElementStatusNodeId = function(element){
+        if (this.layout.split_tracks){
+            return (this.getBaseId() + "-statusnode-" + element[this.layout.track_split_field]).replace(/(:|\.|\[|\]|,)/g, "_");
+        }
+        return this.getElementId(element) + "-statusnode";
+    }.bind(this);
     
     // Helper function to sum layout values to derive total height for a single interval track
     this.getTrackHeight = function(){
@@ -4551,7 +4574,6 @@ LocusZoom.DataLayers.add("intervals", function(layout){
 
     this.tracks = 1;
     this.previous_tracks = 1;
-    this.group_hover_elements = {};
     
     // track-number-indexed object with arrays of interval indexes in the dataset
     this.interval_track_index = { 1: [] };
@@ -4651,29 +4673,26 @@ LocusZoom.DataLayers.add("intervals", function(layout){
 
         this.assignTracks();
 
-        // First: render or remove group bounding boxes based on whether we're track split
-        if (this.layout.split_tracks){
-            Object.keys(this.group_hover_elements).forEach(function(key){
-                if (!this.track_split_field_index[key]){ this.group_hover_elements[key].remove(); }
-            }.bind(this));
-            Object.keys(this.track_split_field_index).forEach(function(key){
-                if (!this.group_hover_elements[key]){
-                    this.group_hover_elements[key] = this.svg.group.insert("rect", ":first-child")
-                        .attr("class", "lz-data_layer-intervals lz-data_layer-intervals-bounding_box");
-                }
-                this.group_hover_elements[key]
-                    .attr("rx", this.layout.bounding_box_padding).attr("ry", this.layout.bounding_box_padding)
-                    .attr("width", this.parent.layout.cliparea.width)
-                    .attr("height", this.getTrackHeight() - this.layout.track_vertical_spacing)
-                    .attr("x", 0)
-                    .attr("y", (this.track_split_field_index[key]-1) * this.getTrackHeight());
-            }.bind(this));
-        } else {
-            Object.keys(this.group_hover_elements).forEach(function(key){
-                this.group_hover_elements[key].remove();
-            }.bind(this));
-            this.group_hover_elements = {};
-        }
+        // Remove any shared highlight nodes and re-render them if we're splitting on tracks
+        // At most there will only be dozen or so nodes here (one per track) and each time
+        // we render data we may have new tracks, so wiping/redrawing all is reasonable.
+        this.svg.group.selectAll(".lz-data_layer-intervals-statusnode.lz-data_layer-intervals-shared").remove();
+        Object.keys(this.track_split_field_index).forEach(function(key){
+            // Make a psuedo-element so that we can generate an id for the shared node
+            var psuedoElement = {};
+            psuedoElement[this.layout.track_split_field] = key;
+            // Insert the shared node
+            var sharedstatusnode_style = {display: (this.layout.split_tracks ? null : "none")};
+            this.svg.group.insert("rect", ":first-child")
+                .attr("id", this.getElementStatusNodeId(psuedoElement))
+                .attr("class", "lz-data_layer-intervals lz-data_layer-intervals-statusnode lz-data_layer-intervals-shared")
+                .attr("rx", this.layout.bounding_box_padding).attr("ry", this.layout.bounding_box_padding)
+                .attr("width", this.parent.layout.cliparea.width)
+                .attr("height", this.getTrackHeight() - this.layout.track_vertical_spacing)
+                .attr("x", 0)
+                .attr("y", (this.track_split_field_index[key]-1) * this.getTrackHeight())
+                .style(sharedstatusnode_style);
+        }.bind(this));
 
         var width, height, x, y, fill, fill_opacity;
             
@@ -4689,52 +4708,47 @@ LocusZoom.DataLayers.add("intervals", function(layout){
 
                 var data_layer = interval.parent;
 
-                // Render interval bounding box (displayed behind intervals to show highlight
-                // without needing to modify interval display element(s)) if not in split view
-                var bboxes = d3.select(this).selectAll("rect.lz-data_layer-intervals.lz-data_layer-intervals-bounding_box")
-                    .data([interval], function(d){ return d[data_layer.layout.id_field] + "_bbox"; });
-                if (data_layer.layout.split_tracks){
-                    bboxes.remove();
+                // Render interval status nodes (displayed behind intervals to show highlight
+                // without needing to modify interval display element(s))
+                var statusnode_style = {display: (data_layer.layout.split_tracks ? "none" : null)};
+                var statusnodes = d3.select(this).selectAll("rect.lz-data_layer-intervals.lz-data_layer-intervals-statusnode.lz-data_layer-intervals-statusnode-discrete")
+                    .data([interval], function(d){ return data_layer.getElementId(d) + "-statusnode"; });
+                statusnodes.enter().insert("rect", ":first-child")
+                    .attr("class", "lz-data_layer-intervals lz-data_layer-intervals-statusnode lz-data_layer-intervals-statusnode-discrete");
+                statusnodes
+                    .attr("id", function(d){
+                        return data_layer.getElementId(d) + "-statusnode";
+                    })
+                    .attr("rx", function(){
+                        return data_layer.layout.bounding_box_padding;
+                    })
+                    .attr("ry", function(){
+                            return data_layer.layout.bounding_box_padding;
+                    })
+                    .style(statusnode_style);
+                width = function(d){
+                    return d.display_range.width + (2 * data_layer.layout.bounding_box_padding);
+                };
+                height = function(){
+                    return data_layer.getTrackHeight() - data_layer.layout.track_vertical_spacing;
+                };
+                x = function(d){
+                    return d.display_range.start - data_layer.layout.bounding_box_padding;
+                };
+                y = function(d){
+                    return ((d.track-1) * data_layer.getTrackHeight());
+                };
+                if (data_layer.canTransition()){
+                    statusnodes
+                        .transition()
+                        .duration(data_layer.layout.transition.duration || 0)
+                        .ease(data_layer.layout.transition.ease || "cubic-in-out")
+                        .attr("width", width).attr("height", height).attr("x", x).attr("y", y);
                 } else {
-                    bboxes.enter().insert("rect", ":first-child")
-                        .attr("class", "lz-data_layer-intervals lz-data_layer-intervals-bounding_box");
-                    
-                    bboxes
-                        .attr("id", function(d){
-                            return data_layer.getElementId(d) + "_bounding_box";
-                        })
-                        .attr("rx", function(){
-                            return data_layer.layout.bounding_box_padding;
-                        })
-                        .attr("ry", function(){
-                            return data_layer.layout.bounding_box_padding;
-                        });
-                    
-                    width = function(d){
-                        return d.display_range.width + (2 * data_layer.layout.bounding_box_padding);
-                    };
-                    height = function(){
-                        return data_layer.getTrackHeight() - data_layer.layout.track_vertical_spacing;
-                    };
-                    x = function(d){
-                        return d.display_range.start - data_layer.layout.bounding_box_padding;
-                    };
-                    y = function(d){
-                        return ((d.track-1) * data_layer.getTrackHeight());
-                    };
-                    if (data_layer.canTransition()){
-                        bboxes
-                            .transition()
-                            .duration(data_layer.layout.transition.duration || 0)
-                            .ease(data_layer.layout.transition.ease || "cubic-in-out")
-                            .attr("width", width).attr("height", height).attr("x", x).attr("y", y);
-                    } else {
-                        bboxes
-                            .attr("width", width).attr("height", height).attr("x", x).attr("y", y);
-                    }
-                    
-                    bboxes.exit().remove();
+                    statusnodes
+                        .attr("width", width).attr("height", height).attr("x", x).attr("y", y);
                 }
+                statusnodes.exit().remove();
 
                 // Render primary interval rects
                 var rects = d3.select(this).selectAll("rect.lz-data_layer-intervals.lz-interval_rect")
@@ -4861,12 +4875,7 @@ LocusZoom.DataLayers.add("intervals", function(layout){
         var stroke_width = 1; // as defined in the default stylesheet
         var page_origin = this.getPageOrigin();
         var tooltip_box = tooltip.selector.node().getBoundingClientRect();
-        var interval_bbox;
-        if (this.layout.split_tracks){
-            interval_bbox = d3.select("#" + this.getElementId(tooltip.data)).node().getBBox();
-        } else {
-            interval_bbox = d3.select("#" + this.getElementId(tooltip.data) + "_bounding_box").node().getBBox();
-        }
+        var interval_bbox = d3.select("#" + this.getElementStatusNodeId(tooltip.data)).node().getBBox();
         var data_layer_height = this.parent.layout.height - (this.parent.layout.margin.top + this.parent.layout.margin.bottom);
         var data_layer_width = this.parent.layout.width - (this.parent.layout.margin.left + this.parent.layout.margin.right);
         // Position horizontally: attempt to center on the portion of the interval that's visible,
@@ -4954,7 +4963,6 @@ LocusZoom.DataLayers.add("intervals", function(layout){
     // necessary display values to animate a complete merge/split
     this.toggleSplitTracks = function(){
         this.layout.split_tracks = !this.layout.split_tracks;
-        this.layout.group_hover_elements_on_field = this.layout.split_tracks ? this.layout.track_split_field : null;
         if (this.parent.legend && !this.layout.always_hide_legend){
             this.parent.layout.margin.bottom = 5 + (this.layout.split_tracks ? 0 : this.parent.legend.layout.height + 5);
         }

--- a/locuszoom.app.js
+++ b/locuszoom.app.js
@@ -4560,7 +4560,7 @@ LocusZoom.DataLayers.add("intervals", function(layout){
      */
     this.getElementStatusNodeId = function(element){
         if (this.layout.split_tracks){
-            return (this.getBaseId() + "-statusnode-" + element[this.layout.track_split_field]).replace(/[:.\[\],]/g, "_");
+            return (this.getBaseId() + "-statusnode-" + element[this.layout.track_split_field]).replace(/[:.[\],]/g, "_");
         }
         return this.getElementId(element) + "-statusnode";
     }.bind(this);

--- a/locuszoom.css
+++ b/locuszoom.css
@@ -90,15 +90,15 @@ svg.lz-locuszoom {
     display: none; }
   svg.lz-locuszoom text.lz-data_layer-genes.lz-label {
     font-style: italic; }
-  svg.lz-locuszoom rect.lz-data_layer-genes.lz-data_layer-genes-bounding_box {
+  svg.lz-locuszoom rect.lz-data_layer-genes.lz-data_layer-genes-statusnode {
     fill: #363696;
     fill-opacity: 0;
     stroke-width: 0px; }
-  svg.lz-locuszoom rect.lz-data_layer-genes.lz-data_layer-genes-bounding_box-highlighted {
+  svg.lz-locuszoom rect.lz-data_layer-genes.lz-data_layer-genes-statusnode-highlighted {
     fill: #363696;
     fill-opacity: 0.1;
     stroke-width: 0px; }
-  svg.lz-locuszoom rect.lz-data_layer-genes.lz-data_layer-genes-bounding_box-selected {
+  svg.lz-locuszoom rect.lz-data_layer-genes.lz-data_layer-genes-statusnode-selected {
     fill: #363696;
     fill-opacity: 0.15;
     stroke: rgb(24, 24, 24);
@@ -118,15 +118,15 @@ svg.lz-locuszoom {
     opacity: 0.1; }
   svg.lz-locuszoom g.lz-data_layer-intervals-hidden {
     display: none; }
-  svg.lz-locuszoom rect.lz-data_layer-intervals.lz-data_layer-intervals-bounding_box {
+  svg.lz-locuszoom rect.lz-data_layer-intervals.lz-data_layer-intervals-statusnode {
     fill: #363696;
     fill-opacity: 0;
     stroke-width: 0px; }
-  svg.lz-locuszoom rect.lz-data_layer-intervals.lz-data_layer-intervals-bounding_box-highlighted {
+  svg.lz-locuszoom rect.lz-data_layer-intervals.lz-data_layer-intervals-statusnode-highlighted {
     fill: #363696;
     fill-opacity: 0.2;
     stroke-width: 0px; }
-  svg.lz-locuszoom rect.lz-data_layer-intervals.lz-data_layer-intervals-bounding_box-selected {
+  svg.lz-locuszoom rect.lz-data_layer-intervals.lz-data_layer-intervals-statusnode-selected {
     fill: #363696;
     fill-opacity: 0.35;
     stroke: rgb(24, 24, 24);


### PR DESCRIPTION
## The Problem(s)

As @welchr documented in #106 tool tips were not working for interval annotation tracks in merge-tracks mode *(Referred to in the solution as Issue A)*.

In addition, I noticed that while tool tips always worked in split-tracks mode, the bounding box to highlight the track wasn't appearing when a plot was first loaded in split-tracks mode but would appear after merging and re-splitting tracks *(Referred to in the solution as Issue B)*.

## This Solution

**Edited to reflect current approach**

This branch addresses both issues by refactoring the notion of how a data layer may have separate **status nodes** to class when applying a status (like highlighted or selected) *in addition* to classing the node most closely bound to the element by ID.

We see this on intervals as well as genes, where what we're rendering for data is not necessarily what will provide a visual cue that a status is applied (as opposed to a simpler scatter plot element which shows status with a CSS class change alone). Both of these data layers have "bounding box" nodes that render behind data and can even have a layout-defineable padding.

To abstract this behavior including showing status with a "shared" node (e.g. highlight the whole track for intervals but only when splitting tracks) this refactor introduces the concept of **status nodes** as described above and relies on a new method `DataLayer.getElementStatusNodeId()` to select the proper element to apply the status to. This method is abstracted for all data layers and will just return null, skipping any classing of status nodes that probably don't exist. But genes and intervals override this function:

* Genes merely appends "-statusnode" to the element's ID to get a statusnode ID (in a strict 1:1 relationship). This is essentially what it was doing before, but where it used to be repeated a few times throughout the data layer file now it happens in one place.
* Intervals now behaves just like genes when not in split tracks mode, but when split this function can return the status node ID for the "shared" node to show status (again: highlight or select) for the entire track.

These changes eliminate two undocumented layout directives: `hover_element` and `group_hover_elements_on_field` (the former appeared in genes and intervals and the latter only appeared in intervals). These were "dynamic" layout directives that wouldn't make sense for a user to define up front anyway, so it's arguably better that this can all be done more abstractly now. The main point of `group_hover_elements_on_field` was actually a way of saying "use the track split field as defined in the layout" but at the abstract data layer level... now the interval layer can express that in terms of the `getElementStatusNodeId()` override instead.