### PR TITLE
Option to suppress "confirm to remove panel" modals

### DIFF
--- a/assets/js/app/Dashboard.js
+++ b/assets/js/app/Dashboard.js
@@ -185,6 +185,10 @@ LocusZoom.Dashboard.prototype.destroy = function(force){
  * @class
  * @param {Object} layout A JSON-serializable object of layout configuration parameters
  * @param {('left'|'right')} [layout.position='left']  Whether to float the component left or right.
+ * @param {('start'|'middle'|'end')} [layout.group_position] Buttons can optionally be gathered into a visually
+ *  distinctive group whose elements are closer together. If a button is identified as the start or end of a group,
+ *  it will be drawn with rounded corners and an extra margin of spacing from any button not part of the group.
+ *  For example, the region_nav_plot dashboard is a defined as a group.
  * @param {('gray'|'red'|'orange'|'yellow'|'green'|'blue'|'purple'} [layout.color='gray']  Color scheme for the
  *   component. Applies to buttons and menus.
  * @param {LocusZoom.Dashboard} parent The dashboard that contains this component
@@ -915,22 +919,23 @@ LocusZoom.Dashboard.Components.add("download", function(layout){
  *   NOTE: Will only work on panel dashboards.
  * @class LocusZoom.Dashboard.Components.remove_panel
  * @augments LocusZoom.Dashboard.Component
+ * @param {Boolean} [layout.suppress_confirm=false] If true, removes the panel without prompting user for confirmation
  */
-LocusZoom.Dashboard.Components.add("remove_panel", function(layout){
+LocusZoom.Dashboard.Components.add("remove_panel", function(layout) {
     LocusZoom.Dashboard.Component.apply(this, arguments);
-    this.update = function(){
+    this.update = function() {
         if (this.button){ return this; }
         this.button = new LocusZoom.Dashboard.Component.Button(this)
             .setColor(layout.color).setHtml("×").setTitle("Remove panel")
             .setOnclick(function(){
-                if (confirm("Are you sure you want to remove this panel? This cannot be undone!")){
-                    var panel = this.parent_panel;
-                    panel.dashboard.hide(true);
-                    d3.select(panel.parent.svg.node().parentNode).on("mouseover." + panel.getBaseId() + ".dashboard", null);
-                    d3.select(panel.parent.svg.node().parentNode).on("mouseout." + panel.getBaseId() + ".dashboard", null);
-                    return panel.parent.removePanel(panel.id);
+                if (!layout.suppress_confirm && !confirm("Are you sure you want to remove this panel? This cannot be undone!")){
+                    return false;
                 }
-                return false;
+                var panel = this.parent_panel;
+                panel.dashboard.hide(true);
+                d3.select(panel.parent.svg.node().parentNode).on("mouseover." + panel.getBaseId() + ".dashboard", null);
+                d3.select(panel.parent.svg.node().parentNode).on("mouseout." + panel.getBaseId() + ".dashboard", null);
+                return panel.parent.removePanel(panel.id);
             }.bind(this));
         this.button.show();
         return this;


### PR DESCRIPTION
Feature request per @benralexander , #121

# Purpose
When adding and removing a lot of panels, the "confirm to remove" modal becomes tedious. Ben has asked for a new option to suppress the modal.

Also expands documentation for layout configuration parameters that I noticed while working on this code.

# How to test this
This PR adds a new option, without changing the default behavior. If you do not specify the option, it will continue to prompt before removing the panel.

This option must be explicitly activated by modifying the layout for your plot, adding `suppress_confirm: true` to the `remove_panel` dashboard button layout options.