### PR TITLE
[rfr] Refactor data source internals

### DIFF
--- a/assets/css/locuszoom.scss
+++ b/assets/css/locuszoom.scss
@@ -183,17 +183,13 @@ svg.#{$namespace}-locuszoom {
   }
 
   rect.#{$namespace}-data_layer-genes.#{$namespace}-boundary {
-    stroke: rgb(54, 54, 150);
     stroke-opacity: 1;
     stroke-width: 1px;
-    fill: #000099;
   }
 
   rect.#{$namespace}-data_layer-genes.#{$namespace}-exon {
-    stroke: rgb(54, 54, 150);
     stroke-opacity: 1;
     stroke-width: 1px;
-    fill: #000099;
   }
 
   g.#{$namespace}-data_layer-intervals-faded {

--- a/assets/js/app/Data.js
+++ b/assets/js/app/Data.js
@@ -38,10 +38,15 @@ LocusZoom.DataSources.prototype.add = function(ns, x) {
 /** @protected */
 LocusZoom.DataSources.prototype.set = function(ns, x) {
     if (Array.isArray(x)) {
+        // If passed array of source name and options, make the source
         var dsobj = LocusZoom.KnownDataSources.create.apply(null, x);
+        // Each datasource in the chain should be aware of its assigned namespace
+        dsobj.source_id = ns;
         this.sources[ns] = dsobj;
     } else {
+        // If passed the already-created source object
         if (x !== null) {
+            x.source_id = ns;
             this.sources[ns] = x;
         } else {
             delete this.sources[ns];
@@ -212,7 +217,7 @@ LocusZoom.Data.Requester = function(sources) {
     this.getData = function(state, fields) {
         var requests = split_requests(fields);
         // Create an array of functions that, when called, will trigger the request to the specified datasource
-        var promises = Object.keys(requests).map(function(key) {
+        var request_handles = Object.keys(requests).map(function(key) {
             if (!sources.get(key)) {
                 throw("Datasource for namespace " + key + " not found");
             }
@@ -221,10 +226,10 @@ LocusZoom.Data.Requester = function(sources) {
         });
         //assume the fields are requested in dependent order
         //TODO: better manage dependencies
-        var ret = Q.when({header:{}, body:{}});
-        for(var i=0; i < promises.length; i++) {
+        var ret = Q.when({header:{}, body:{}, discrete: {}});
+        for(var i=0; i < request_handles.length; i++) {
             // If a single datalayer uses multiple sources, perform the next request when the previous one completes
-            ret = ret.then(promises[i]);
+            ret = ret.then(request_handles[i]);
         }
         return ret;
     };
@@ -273,7 +278,7 @@ LocusZoom.Data.Source.prototype.parseInit = function(init) {
 };
 
 /**
- * Fetch the internal string used to represent this data when cache is used
+ * A unique identifier that indicates whether cached data is valid for this request
  * @protected
  * @param state
  * @param chain
@@ -281,12 +286,16 @@ LocusZoom.Data.Source.prototype.parseInit = function(init) {
  * @returns {String|undefined}
  */
 LocusZoom.Data.Source.prototype.getCacheKey = function(state, chain, fields) {
-    var url = this.getURL && this.getURL(state, chain, fields);
-    return url;
+    return this.getURL && this.getURL(state, chain, fields);
 };
 
 /**
- * Fetch data from a remote location
+ * Stub: build the URL for any requests made by this source.
+ */
+LocusZoom.Data.Source.prototype.getURL = function(state, chain, fields) { return this.url; };
+
+/**
+ * Perform a network request to fetch data for this source
  * @protected
  * @param {Object} state The state of the parent plot
  * @param chain
@@ -296,11 +305,9 @@ LocusZoom.Data.Source.prototype.fetchRequest = function(state, chain, fields) {
     var url = this.getURL(state, chain, fields);
     return LocusZoom.createCORSPromise("GET", url); 
 };
-// TODO: move this.getURL stub into parent class and add documentation; parent should not check for methods known only to children
-
 
 /**
- * TODO Rename to handleRequest (to disambiguate from, say HTTP get requests) and update wiki docs and other references
+ * Gets the data for just this source, typically via a network request (caching where possible)
  * @protected
  */
 LocusZoom.Data.Source.prototype.getRequest = function(state, chain, fields) {
@@ -321,15 +328,17 @@ LocusZoom.Data.Source.prototype.getRequest = function(state, chain, fields) {
 };
 
 /**
- * Fetch the data from the specified data source, and format it in a way that can be used by the consuming plot
- * @protected
+ * Fetch the data from the specified data source, and apply transformations requested by an external consumer.
+ * This is the public-facing datasource method that will most commonly be called by external code.
+ *
+ * @public
  * @param {Object} state The current "state" of the plot, such as chromosome and start/end positions
- * @param {String[]} fields Array of field names that the plot has requested from this data source. (without the "namespace" prefix)  TODO: Clarify how this fieldname maps to raw datasource output, and how it differs from outnames
+ * @param {String[]} fields Array of field names that the plot has requested from this data source. (without the "namespace" prefix)
  * @param {String[]} outnames  Array describing how the output data should refer to this field. This represents the
  *     originally requested field name, including the namespace. This must be an array with the same length as `fields`
  * @param {Function[]} trans The collection of transformation functions to be run on selected fields.
  *     This must be an array with the same length as `fields`
- * @returns {function(this:LocusZoom.Data.Source)} A callable operation that can be used as part of the data chain
+ * @returns {function} A callable operation that can be used as part of the data chain
  */
 LocusZoom.Data.Source.prototype.getData = function(state, fields, outnames, trans) {
     if (this.preGetData) {
@@ -357,108 +366,108 @@ LocusZoom.Data.Source.prototype.getData = function(state, fields, outnames, tran
 };
 
 /**
- * Parse response data. Return an object containing "header" (metadata or request parameters) and "body"
- *   (data to be used for plotting). The response from this request is combined with responses from all other requests
- *   in the chain.
- * @public
- * @param {String|Object} resp The raw data associated with the response
- * @param {Object} chain The combined parsed response data from this and all other requests made in the chain
- * @param {String[]} fields Array of field names that the plot has requested from this data source. (without the "namespace" prefix)  TODO: Clarify how this fieldname maps to raw datasource output, and how it differs from outnames
- * @param {String[]} outnames  Array describing how the output data should refer to this field. This represents the
- *     originally requested field name, including the namespace. This must be an array with the same length as `fields`
- * @param {Function[]} trans The collection of transformation functions to be run on selected fields.
- *     This must be an array with the same length as `fields`
- * @returns {{header: ({}|*), body: {}}}
- */
-LocusZoom.Data.Source.prototype.parseResponse = function(resp, chain, fields, outnames, trans) {
-    var json = typeof resp == "string" ? JSON.parse(resp) : resp;
-    var records = this.parseData(json.data || json, fields, outnames, trans);
-    return {header: chain.header || {}, body: records};
-};
-/**
- * Some API endpoints return an object containing several arrays, representing columns of data. Each array should have
- *   the same length, and a given array index corresponds to a single row.
+ * Ensure the server response is in a canonical form, an array of one object per record. [ {field: oneval} ].
+ * If the server response contains columns, reformats the response from {column1: [], column2: []} to the above.
  *
- * This gathers column data into an array of objects, each one representing the combined data for a given record.
- *   See `parseData` for usage
+ * Does not apply namespacing or transformations.
  *
+ * May be overridden by data sources that inherently return more complex payloads, or that exist to annotate other
+ *  sources.
+ *
+ * @param {Object[]|Object} data The original parsed server response
  * @protected
- * @param {Object} x A response payload object
- * @param {Array} fields
- * @param {Array} outnames
- * @param {Array} trans
- * @returns {Object[]}
  */
-LocusZoom.Data.Source.prototype.parseArraysToObjects = function(x, fields, outnames, trans) {
-    //intended for an object of arrays
-    //{"id":[1,2], "val":[5,10]}
-    var records = [];
-    fields.forEach(function(f, i) {
-        if (!(f in x)) {throw "field " + f + " not found in response for " + outnames[i];}
-    });
-    // Safeguard: check that arrays are of same length
-    var keys = Object.keys(x);
-    var N = x[keys[0]].length;
+LocusZoom.Data.Source.prototype.normalizeResponse = function (data) {
+    if (Array.isArray(data)) {
+        // Already in the desired form
+        return data;
+    }
+
+    // Otherwise, assume the server response is an object representing columns of data.
+    // Each array should have the same length (verify), and a given array index corresponds to a single row.
+    var keys = Object.keys(data);
+    var N = data[keys[0]].length;
     var sameLength = keys.every(function(key) {
-        var item = x[key];
+        var item = data[key];
         return item.length === N;
     });
     if (!sameLength) {
         throw this.constructor.SOURCE_NAME + " expects a response in which all arrays of data are the same length";
     }
 
+    // Go down the rows, and create an object for each record
+    var records = [];
+    var fields = Object.keys(data);
     for(var i = 0; i < N; i++) {
         var record = {};
-        for(var j=0; j<fields.length; j++) {
-            var val = x[fields[j]][i];
-            if (trans && trans[j]) {
-                val = trans[j](val);
-            }
-            record[outnames[j]] = val;
+        for(var j = 0; j < fields.length; j++) {
+            record[fields[j]] = data[fields[j]][i];
         }
         records.push(record);
     }
     return records;
 };
 
+/** @deprecated */
+LocusZoom.Data.Source.prototype.prepareData = function (records) {
+    console.warn("Warning: .prepareData() is deprecated. Use .annotateData() instead");
+    return this.annotateData(records);
+};
+
 /**
- *  Given an array response in which each record is represented as one coherent bundle of data (an object of
- *    {field:value} entries), perform any parsing or transformations required to represent the field in a form required
- *    by the datalayer. See `parseData` for usage.
- * @protected
- * @param {Object[]} x An array of response payload objects, each describing one record
- * @param {Array} fields
- * @param {Array} outnames
- * @param {Array} trans
- * @returns {Object[]}
+ * Hook to post-process the data returned by this source with new, additional behavior.
+ *   (eg cleaning up API values or performing complex calculations on the returned data)
+ *
+ * @param {Object[]} records The parsed data from the source (eg standardized api response)
+ * @param {Object} chain The data chain object. For example, chain.headers may provide useful annotation metadata
+ * @returns {Object[]|Promise} The modified set of records
  */
-LocusZoom.Data.Source.prototype.parseObjectsToObjects = function(x, fields, outnames, trans) {
+LocusZoom.Data.Source.prototype.annotateData = function(records, chain) {
+    // Default behavior: no transformations
+    return records;
+};
+
+/**
+ * Clean up the server records for use by datalayers: extract only certain fields, with the specified names.
+ *   Apply per-field transformations as appropriate.
+ *
+ * This hook can be overridden, eg to create a source that always returns all records and ignores the "fields" array.
+ *  This is particularly common for sources at the end of a chain- many "dependent" sources do not allow
+ *  cherry-picking individual fields, in which case by **convention** the fields array specifies "last_source_name:all"
+ *
+ * @param {Object[]} data One record object per element
+ * @param {String[]} fields The names of fields to extract (as named in the source data). Eg "afield"
+ * @param {String[]} outnames How to represent the source fields in the output. Eg "namespace:afield|atransform"
+ * @param {function[]} trans An array of transformation functions (if any). One function per data element, or null.
+ * @protected
+ */
+LocusZoom.Data.Source.prototype.extractFields = function (data, fields, outnames, trans) {
     //intended for an array of objects
-    // [ {"id":1, "val":5}, {"id":2, "val":10}]
-    var records = [];
+    //  [ {"id":1, "val":5}, {"id":2, "val":10}]
+    // Since a number of sources exist that do not obey this format, we will provide a convenient pass-through
+    if (!Array.isArray(data)) {
+        return data;
+    }
+
     var fieldFound = [];
-    for (var k=0; k<fields.length; k++) { 
+    for (var k=0; k<fields.length; k++) {
         fieldFound[k] = 0;
     }
 
-    if (!x.length) {
-        // Do not attempt to parse records if there are no records, and bubble up an informative error message.
-        throw "No data found for specified query";
-    }
-    for (var i = 0; i < x.length; i++) {
-        var record = {};
-        for (var j=0; j<fields.length; j++) {
-            var val = x[i][fields[j]];
+    var records = data.map(function (item) {
+        var output_record = {};
+        for (var j=0; j < fields.length; j++) {
+            var val = item[fields[j]];
             if (typeof val != "undefined") {
                 fieldFound[j] = 1;
             }
             if (trans && trans[j]) {
                 val = trans[j](val);
             }
-            record[outnames[j]] = val;
+            output_record[outnames[j]] = val;
         }
-        records.push(record);
-    }
+        return output_record;
+    });
     fieldFound.forEach(function(v, i) {
         if (!v) {throw "field " + fields[i] + " not found in response for " + outnames[i];}
     });
@@ -466,34 +475,80 @@ LocusZoom.Data.Source.prototype.parseObjectsToObjects = function(x, fields, outn
 };
 
 /**
- * Parse the response data  TODO Hide private entries from user-facing api docs
+ * Combine records from this source with others in the chain to yield final chain body.
+ *   Handles merging this data with other sources (if applicable).
+ *
+ * @param {Object[]} data The data That would be returned from this source alone
+ * @param {Object} chain The data chain built up during previous requests
+ * @param {String[]} fields
+ * @param {String[]} outnames
+ * @return {Promise|Object[]} The new chain body
  * @protected
- * @param {Object} x The raw response data to be parsed
- * @param {String[]} fields Array of field names that the plot has requested from this data source. (without the "namespace" prefix)  TODO: Clarify how this fieldname maps to raw datasource output, and how it differs from outnames
- * @param {String[]} outnames  Array describing how the output data should refer to this field. This represents the
- *     originally requested field name, including the namespace. This must be an array with the same length as `fields`
- * @param {Function[]} trans The collection of transformation functions to be run on selected fields.
- *     This must be an array with the same length as `fields`
  */
-LocusZoom.Data.Source.prototype.parseData = function(x, fields, outnames, trans) {
-    var records;
-    if (Array.isArray(x)) { 
-        records = this.parseObjectsToObjects(x, fields, outnames, trans);
-    } else {
-        records = this.parseArraysToObjects(x, fields, outnames, trans);
-    }
-    // Perform any custom transformations on the resulting data
-    return this.prepareData(records);
+LocusZoom.Data.Source.prototype.combineChainBody = function (data, chain, fields, outnames) {
+    return data;
 };
 
 /**
- * Post-process the server response. This is a hook that allows custom sources to specify any optional transformations
- *   that should be performed on the data that is returned from the server.
- * @param {Object[]} records
- * @returns Object[]
+ * Coordinates the work of parsing a response and returning records. This is broken into 4 steps, which may be
+ *  overridden separately for fine-grained control. Each step can return either raw data or a promise.
+ *
+ * @public
+ * @param {String|Object} resp The raw data associated with the response
+ * @param {Object} chain The combined parsed response data from this and all other requests made in the chain
+ * @param {String[]} fields Array of requested field names (as they would appear in the response payload)
+ * @param {String[]} outnames  Array of field names as they will be represented in the data returned by this source,
+ *  including the namespace. This must be an array with the same length as `fields`
+ * @param {Function[]} trans The collection of transformation functions to be run on selected fields.
+ *     This must be an array with the same length as `fields`
+ * @returns {Promise|{header: ({}|*), discrete: {}, body: []}} A promise that resolves to an object containing
+ *   request metadata (headers), the consolidated data for plotting (body), and the individual responses that would be
+ *   returned by each source in the chain in isolation (discrete)
  */
-LocusZoom.Data.Source.prototype.prepareData = function(records) {
-    return records;
+LocusZoom.Data.Source.prototype.parseResponse = function(resp, chain, fields, outnames, trans) {
+    var source_id = this.source_id || this.constructor.SOURCE_NAME;
+    if (!chain.discrete) {
+        chain.discrete = {};
+    }
+
+    var json = typeof resp == "string" ? JSON.parse(resp) : resp;
+
+    var self = this;
+    // Perform the 4 steps of parsing the payload and return a combined chain object
+    return Q.when(self.normalizeResponse(json.data || json))
+        .then(function(standardized) {
+            // Perform calculations on the data from just this source
+            return Q.when(self.annotateData(standardized, chain));
+        }).then(function (data) {
+            return Q.when(self.extractFields(data, fields, outnames, trans));
+        }).then(function (one_source_body) {
+            // Store a copy of the data that would be returned by parsing this source in isolation (and taking the
+            //   fields array into account). This is useful when we want to re-use the source output in many ways.
+            chain.discrete[source_id] = one_source_body;
+            return Q.when(self.combineChainBody(one_source_body, chain, fields, outnames));
+        }).then(function (new_body) {
+            return { header: chain.header || {}, discrete: chain.discrete, body: new_body };
+        });
+};
+
+/** @deprecated */
+LocusZoom.Data.Source.prototype.parseArraysToObjects = function(data, fields, outnames, trans) {
+    console.warn("Warning: .parseArraysToObjects() is no longer used. A stub is provided for legacy use");
+    var standard = this.normalizeResponse(data);
+    return this.extractFields(standard, fields, outnames, trans);
+};
+
+/** @deprecated */
+LocusZoom.Data.Source.prototype.parseObjectsToObjects = function(data, fields, outnames, trans) {
+    console.warn("Warning: .parseObjectsToObjects() is deprecated. Use .extractFields() instead");
+    return this.extractFields(data, fields, outnames, trans);
+};
+
+/** @deprecated */
+LocusZoom.Data.Source.prototype.parseData = function(data, fields, outnames, trans) {
+    console.warn("Warning: .parseData() is no longer used. A stub is provided for legacy use");
+    var standard = this.normalizeResponse(data);
+    return this.extractFields(standard, fields, outnames, trans);
 };
 
 /**
@@ -530,6 +585,9 @@ LocusZoom.Data.Source.extend = function(constructorFun, uniqueName, base) {
 /**
  * Datasources can be instantiated from a JSON object instead of code. This represents an existing source in that data format.
  *   For example, this can be helpful when sharing plots, or to share settings with others when debugging
+ *
+ * Custom sources with their own parameters may need to re-implement this method
+ *
  * @public
  * @returns {Object}
  */
@@ -635,6 +693,8 @@ LocusZoom.Data.LDSource.prototype.findRequestedFields = function(fields, outname
     return obj;
 };
 
+LocusZoom.Data.LDSource.prototype.normalizeResponse = function (data) { return data; };
+
 LocusZoom.Data.LDSource.prototype.getURL = function(state, chain, fields) {
     var findExtremeValue = function(x, pval, sign) {
         pval = pval || "pvalue";
@@ -678,8 +738,7 @@ LocusZoom.Data.LDSource.prototype.getURL = function(state, chain, fields) {
         "&fields=chr,pos,rsquare";
 };
 
-LocusZoom.Data.LDSource.prototype.parseResponse = function(resp, chain, fields, outnames) {
-    var json = JSON.parse(resp);
+LocusZoom.Data.LDSource.prototype.combineChainBody = function (data, chain, fields, outnames) {
     var keys = this.findMergeFields(chain);
     var reqFields = this.findRequestedFields(fields, outnames);
     if (!keys.position) {
@@ -708,12 +767,13 @@ LocusZoom.Data.LDSource.prototype.parseResponse = function(resp, chain, fields, 
             }
         }
     };
-    leftJoin(chain.body, json.data, reqFields.ldout, "rsquare");
+    leftJoin(chain.body, data, reqFields.ldout, "rsquare");
     if(reqFields.isrefvarin && chain.header.ldrefvar) {
         tagRefVariant(chain.body, chain.header.ldrefvar, keys.id, reqFields.isrefvarout);
     }
-    return chain;   
+    return chain.body;
 };
+
 
 /**
  * Data Source for Gene Data, as fetched from the LocusZoom API server (or compatible)
@@ -733,10 +793,10 @@ LocusZoom.Data.GeneSource.prototype.getURL = function(state, chain, fields) {
         " and end ge " + state.start;
 };
 
-LocusZoom.Data.GeneSource.prototype.parseResponse = function(resp, chain, fields, outnames) {
-    var json = JSON.parse(resp);
-    return {header: chain.header, body: json.data};
-};
+// Genes have a very complex internal data format. Bypass any record parsing, and provide the data layer with the
+// exact information returned by the API. (ignoring the fields array in the layout)
+LocusZoom.Data.GeneSource.prototype.normalizeResponse = function (data) { return data; };
+LocusZoom.Data.GeneSource.prototype.extractFields = function (data, fields, outnames, trans) { return data; };
 
 /**
  * Data Source for Gene Constraint Data, as fetched from the LocusZoom API server (or compatible)
@@ -751,6 +811,8 @@ LocusZoom.Data.GeneConstraintSource = LocusZoom.Data.Source.extend(function(init
 LocusZoom.Data.GeneConstraintSource.prototype.getURL = function() {
     return this.url;
 };
+
+LocusZoom.Data.GeneConstraintSource.prototype.normalizeResponse = function (data) { return data; };
 
 LocusZoom.Data.GeneConstraintSource.prototype.getCacheKey = function(state, chain, fields) {
     return this.url + JSON.stringify(state);
@@ -773,13 +835,11 @@ LocusZoom.Data.GeneConstraintSource.prototype.fetchRequest = function(state, cha
     return LocusZoom.createCORSPromise("POST", url, body, headers);
 };
 
-LocusZoom.Data.GeneConstraintSource.prototype.parseResponse = function(resp, chain, fields, outnames) {
-    if (!resp){
-        return { header: chain.header, body: chain.body };
+LocusZoom.Data.GeneConstraintSource.prototype.combineChainBody = function (data, chain, fields, outnames) {
+    if (!data) {
+        return chain;
     }
-    var data = JSON.parse(resp);
-    // Loop through the array of genes in the body and match each to a result from the constraints request
-    var constraint_fields = ["bp", "exp_lof", "exp_mis", "exp_syn", "lof_z", "mis_z", "mu_lof", "mu_mis","mu_syn", "n_exons", "n_lof", "n_mis", "n_syn", "pLI", "syn_z"]; 
+    var constraint_fields = ["bp", "exp_lof", "exp_mis", "exp_syn", "lof_z", "mis_z", "mu_lof", "mu_mis","mu_syn", "n_exons", "n_lof", "n_mis", "n_syn", "pLI", "syn_z"];
     chain.body.forEach(function(gene, i){
         var gene_id = gene.gene_id;
         if (gene_id.indexOf(".")){
@@ -800,7 +860,7 @@ LocusZoom.Data.GeneConstraintSource.prototype.parseResponse = function(resp, cha
             }
         });
     });
-    return { header: chain.header, body: chain.body };
+    return chain.body;
 };
 
 /**
@@ -816,7 +876,7 @@ LocusZoom.Data.RecombinationRateSource = LocusZoom.Data.Source.extend(function(i
 LocusZoom.Data.RecombinationRateSource.prototype.getURL = function(state, chain, fields) {
     var source = state.recombsource || chain.header.recombsource || this.params.source || 15;
     return this.url + "?filter=id in " + source +
-        " and chromosome eq '" + state.chr + "'" + 
+        " and chromosome eq '" + state.chr + "'" +
         " and position le " + state.end +
         " and position ge " + state.start;
 };
@@ -881,4 +941,82 @@ LocusZoom.Data.PheWASSource.prototype.getURL = function(state, chain, fields) {
         build.map(function(item) {return "build=" + encodeURIComponent(item);}).join("&")
     ];
     return url.join("");
+};
+
+/**
+ * Base class for "connectors"- this is meant to be subclassed, rather than used directly.
+ *
+ * A connector is a source that makes no server requests and caches no data of its own. Instead, it decides how to
+ *  combine data from other sources in the chain. Connectors are useful when we want to request (or calculate) some
+ *  useful piece of information once, but apply it to many different kinds of record types.
+ *
+ * Typically, a subclass will implement the field merging logic in `combineChainBody`.
+ *
+ * @public
+ * @class
+ * @augments LocusZoom.Data.Source
+ * @param {Object} init Configuration for this source
+ * @param {Object} init.sources Specify how the hard-coded logic should find the data it relies on in the chain,
+ *  as {internal_name: chain_source_id} pairs. This allows writing a reusable connector that does not need to make
+ *  assumptions about what namespaces a source is using.
+ * @type {*|Function}
+ */
+LocusZoom.Data.ConnectorSource = LocusZoom.Data.Source.extend(function(init) {
+    if (!init || !init.sources) {
+        throw "Connectors must specify the data they require as init.sources = {internal_name: chain_source_id}} pairs";
+    }
+
+    /**
+     * Tells the connector how to find the data it relies on
+     *
+     * For example, a connector that applies burden test information to the genes layer might specify:
+     *  {gene_ns: "gene", aggregation_ns: "aggregation"}
+     *
+     * @member {Object}
+     */
+    this._source_name_mapping = init.sources;
+
+    // Validate that this source has been told how to find the required information
+    var specified_ids = Object.keys(init.sources);
+    var self = this;
+    this.REQUIRED_SOURCES.forEach(function (k) {
+        if (specified_ids.indexOf(k) === -1) {
+            throw "Configuration for " + self.constructor.SOURCE_NAME + " must specify a source ID corresponding to " + k;
+        }
+    });
+    this.parseInit(init);
+}, "ConnectorSource");
+
+/** @property {String[]} Specifies the sources that must be provided in the original config object */
+LocusZoom.Data.ConnectorSource.prototype.REQUIRED_SOURCES = [];
+
+LocusZoom.Data.ConnectorSource.prototype.parseInit = function(init) {};  // Stub
+
+LocusZoom.Data.ConnectorSource.prototype.getRequest = function(state, chain, fields) {
+    // Connectors do not have their own data by definition, but they *do* depend on other sources having been loaded
+    //  first. This method performs basic validation, and preserves the accumulated body from the chain so far.
+    var self = this;
+    Object.keys(this._source_name_mapping).forEach(function(ns) {
+        var chain_source_id = self._source_name_mapping[ns];
+        if (chain.discrete && !chain.discrete[chain_source_id]) {
+            throw self.constructor.SOURCE_NAME + " cannot be used before loading required data for: " + chain_source_id;
+        }
+    });
+    return Q.when(chain.body || []);
+};
+
+LocusZoom.Data.ConnectorSource.prototype.parseResponse = function(data, chain, fields, outnames) {
+    // A connector source does not update chain.discrete, but it may use it. It bypasses data formatting
+    //  and field selection (because it has no data of its own)
+    // Typically connectors are called with `connector_name:all` in the fields array. Since they are only responsible
+    //  for joining two sources, the final fields array is already limited by whatever came in.
+    return Q.when(this.combineChainBody(data, chain, fields, outnames))
+        .then(function(new_body) {
+            return {header: chain.header || {}, discrete: chain.discrete || {}, body: new_body};
+        });
+};
+
+LocusZoom.Data.ConnectorSource.prototype.combineChainBody = function(records, chain) {
+    // Stub method: specifies how to combine the data
+    throw "This method must be implemented in a subclass";
 };

--- a/assets/js/app/Layouts.js
+++ b/assets/js/app/Layouts.js
@@ -434,7 +434,7 @@ LocusZoom.Layouts.add("data_layer", "genes", {
     namespace: { "gene": "gene", "constraint": "constraint" },
     id: "genes",
     type: "genes",
-    fields: ["{{namespace[gene]}}gene", "{{namespace[constraint]}}constraint"],
+    fields: ["{{namespace[gene]}}all", "{{namespace[constraint]}}all"],
     id_field: "gene_id",
     behaviors: {
         onmouseover: [

--- a/examples/js/credible-sets-example.js
+++ b/examples/js/credible-sets-example.js
@@ -8,53 +8,55 @@
      - gwas-credible-sets (available via NPM)
  */
 
-'use strict';
+"use strict";
+
+/* global gwasCredibleSets */
 
 // Specify a custom datasource that adds a "credible sets" field to the prepared API response
 LocusZoom.KnownDataSources.extend("AssociationLZ", "CredibleAssociationLZ", {
-  prepareData: function (records) {
-      // This is a somewhat crude method for adding fields in the front end, after the API response has been returned.
-      //  In the future, features for lazy evaluation and dynamic namespacing of calculated fields may be added.
+    annotateData: function (records) {
+        // This is a somewhat crude method for adding fields in the front end, after the API response has been returned.
+        //  In the future, features for lazy evaluation and dynamic namespacing of calculated fields may be added.
 
-      // Calculate raw bayes factors and posterior probabilities based on information returned from the API
-      var nlogpvals = records.map(function (item) {
-          return item['assoc:log_pvalue']
-      });
-      var scores = gwasCredibleSets.scoring.bayesFactors(nlogpvals);
-      var posteriorProbabilities = gwasCredibleSets.scoring.normalizeProbabilities(scores);
+        // Calculate raw bayes factors and posterior probabilities based on information returned from the API
+        var nlogpvals = records.map(function (item) {
+            return item["log_pvalue"];
+        });
+        var scores = gwasCredibleSets.scoring.bayesFactors(nlogpvals);
+        var posteriorProbabilities = gwasCredibleSets.scoring.normalizeProbabilities(scores);
 
-      // Use scores to mark the credible set in various ways (depending on your visualization preferences,
-      //    some of these may be unneeded)
-      var credibleSet = gwasCredibleSets.marking.findCredibleSet(scores);
-      var credSetScaled= gwasCredibleSets.marking.rescaleCredibleSet(credibleSet);
-      var credSetBool = gwasCredibleSets.marking.markBoolean(credibleSet);
+        // Use scores to mark the credible set in various ways (depending on your visualization preferences,
+        //    some of these may be unneeded)
+        var credibleSet = gwasCredibleSets.marking.findCredibleSet(scores);
+        var credSetScaled = gwasCredibleSets.marking.rescaleCredibleSet(credibleSet);
+        var credSetBool = gwasCredibleSets.marking.markBoolean(credibleSet);
 
-      // Annotate each response record based on credible set membership
-      records.forEach(function (item, index) {
-          item["assoc:credibleSetPosteriorProb"] = posteriorProbabilities[index];
-          item["assoc:credibleSetContribution"] = credSetScaled[index]; // Visualization helper: normalized to contribution within the set
-          item["assoc:isCredible"] = credSetBool[index];
-      });
-      return records;
-  }
+        // Annotate each response record based on credible set membership
+        records.forEach(function (item, index) {
+            item["credibleSetPosteriorProb"] = posteriorProbabilities[index];
+            item["credibleSetContribution"] = credSetScaled[index]; // Visualization helper: normalized to contribution within the set
+            item["isCredible"] = credSetBool[index];
+        });
+        return records;
+    }
 });
 
 
-LocusZoom.Layouts.add("tooltip", "credible_set_association", function() {
+LocusZoom.Layouts.add("tooltip", "credible_set_association", function () {
     // Extend a known tooltip with an extra row of info showing posterior probabilities
-    var l = LocusZoom.Layouts.get("tooltip", "standard_association", { unnamespaced: true });
-    l.html += "<br>Posterior probability: <strong>{{assoc:credibleSetPosteriorProb|scinotation}}</strong>";
+    var l = LocusZoom.Layouts.get("tooltip", "standard_association", {unnamespaced: true});
+    l.html += "<br>Posterior probability: <strong>{{{{namespace[assoc]}}credibleSetPosteriorProb|scinotation}}</strong>";
     return l;
 }());
 
 LocusZoom.Layouts.add("tooltip", "credible_set_annotation", {
-    namespace: { "assoc": "assoc" },
+    namespace: {"assoc": "assoc"},
     closable: true,
-    show: { or: ["highlighted", "selected"] },
-    hide: { and: ["unhighlighted", "unselected"] },
+    show: {or: ["highlighted", "selected"]},
+    hide: {and: ["unhighlighted", "unselected"]},
     html: "<strong>{{{{namespace[assoc]}}variant}}</strong><br>"
-        + "P Value: <strong>{{{{namespace[assoc]}}log_pvalue|logtoscinotation}}</strong><br>" +
-          "<br>Posterior probability: <strong>{{assoc:credibleSetPosteriorProb|scinotation}}</strong>"
+    + "P Value: <strong>{{{{namespace[assoc]}}log_pvalue|logtoscinotation}}</strong><br>" +
+    "<br>Posterior probability: <strong>{{{{namespace[assoc]}}credibleSetPosteriorProb|scinotation}}</strong>"
 });
 
 // Define layouts that incorporate credible set annotations into the plot
@@ -69,23 +71,23 @@ LocusZoom.Layouts.add("data_layer", "credible_set_annotation", {
     color: "#00CC00",
     // Credible set markings are derived fields. Although they don't need to be specified in the fields array,
     //  we DO need to specify the fields used to do the calculation (eg pvalue)
-    fields: ["{{namespace[assoc]}}variant", "{{namespace[assoc]}}position", "{{namespace[assoc]}}log_pvalue"],
+    fields: ["{{namespace[assoc]}}variant", "{{namespace[assoc]}}position", "{{namespace[assoc]}}log_pvalue", "{{namespace[assoc]}}credibleSetPosteriorProb", "{{namespace[assoc]}}credibleSetContribution", "{{namespace[assoc]}}isCredible"],
     filters: [
         // Specify which points to show on the track. Any selection must satisfy ALL filters
-        ["assoc:isCredible", true]
+        ["{{namespace[assoc]}}isCredible", true]
     ],
     behaviors: {
         onmouseover: [
-            { action: "set", status: "highlighted" }
+            {action: "set", status: "highlighted"}
         ],
         onmouseout: [
-            { action: "unset", status: "highlighted" }
+            {action: "unset", status: "highlighted"}
         ],
         onclick: [
-            { action: "toggle", status: "selected", exclusive: true }
+            {action: "toggle", status: "selected", exclusive: true}
         ],
         onshiftclick: [
-            { action: "toggle", status: "selected" }
+            {action: "toggle", status: "selected"}
         ]
     },
     tooltip: LocusZoom.Layouts.get("tooltip", "credible_set_annotation"),
@@ -98,7 +100,7 @@ LocusZoom.Layouts.add("panel", "credible_set_panel", {
     height: 100,
     min_height: 100,
     proportional_width: 1,
-    margin: { top: 35, right: 50, bottom: 40, left: 50 },
+    margin: {top: 35, right: 50, bottom: 40, left: 50},
     inner_border: "rgb(210, 210, 210)",
     interaction: {
         drag_background_to_pan: true,
@@ -106,7 +108,7 @@ LocusZoom.Layouts.add("panel", "credible_set_panel", {
         x_linked: true
     },
     data_layers: [
-        LocusZoom.Layouts.get("data_layer", "credible_set_annotation", { unnamespaced: true })
+        LocusZoom.Layouts.get("data_layer", "credible_set_annotation", {unnamespaced: true})
     ]
 });
 
@@ -117,84 +119,93 @@ LocusZoom.Layouts.add("plot", "association_credible_sets", {
     responsive_resize: true,
     min_region_scale: 20000,
     max_region_scale: 1000000,
-    dashboard: LocusZoom.Layouts.get("dashboard", "standard_plot", { unnamespaced: true }),
+    dashboard: LocusZoom.Layouts.get("dashboard", "standard_plot", {unnamespaced: true}),
     panels: [
-        function() {
+        function () {
             // Use a slightly modified association panel: custom tooltip
-            var l = LocusZoom.Layouts.get("panel", "association", { unnamespaced: true });
+            var assoc_panel = LocusZoom.Layouts.get("panel", "association", {unnamespaced: true});
 
             // Add "display options" button to control how credible set coloring is overlaid on the standard association plot
-            l.dashboard.components.push(
+            assoc_panel.dashboard.components.push(
                 {
-              type: "display_options",
-              position: "right",
-              color: "blue",
-              // Below: special config specific to this widget
-              button_html: "Display options...",
-              button_title: "Control how plot items are displayed",
+                    type: "display_options",
+                    position: "right",
+                    color: "blue",
+                    // Below: special config specific to this widget
+                    button_html: "Display options...",
+                    button_title: "Control how plot items are displayed",
 
-              layer_name: "associationpvalues",
-              default_config_display_name: "Linkage Disequilibrium (default)", // display name for the default plot color option (allow user to revert to plot defaults)
+                    layer_name: "associationpvalues",
+                    default_config_display_name: "Linkage Disequilibrium (default)", // display name for the default plot color option (allow user to revert to plot defaults)
 
-              options: [
-                  {
-                      // First dropdown menu item
-                      display_name: "95% credible set (boolean)",  // Human readable representation of field name
-                      display: {  // Specify layout directives that control display of the plot for this option
-                          point_shape: "circle",
-                          point_size: 40,
-                          color: {
-                              field: "assoc:isCredible",
-                              scale_function: "if",
-                              parameters: {
-                                  field_value: true,
-                                  then: "#00CC00",
-                                  else: "#CCCCCC"
-                              }
-                          },
-                          legend: [ // Tells the legend how to represent this display option
-                              { shape: "circle", color: "#00CC00", size: 40, label: "In credible set", class: "lz-data_layer-scatter" },
-                              { shape: "circle", color: "#CCCCCC", size: 40, label: "Not in credible set", class: "lz-data_layer-scatter" }
-                          ]
-                      }
-                  },
-                  {
-                      // Second option. The same plot- or even the same field- can be colored in more than one way.
-                      display_name: "95% credible set (gradient by contribution)",
-                      display: {
-                          point_shape: "circle",
-                          point_size: 40,
-                          color: [
-                              {
-                                  field: "assoc:credibleSetContribution",
-                                  scale_function: "if",
-                                  parameters: {
-                                      field_value: 0,
-                                      then: "#777777"
-                                  }
-                              },
-                              {
-                                  scale_function: "interpolate",
-                                  field: "assoc:credibleSetContribution",
-                                  parameters: {
-                                      breaks: [0, 1],
-                                      values: ["#fafe87", "#9c0000"]
-                                  }
-                              }
-                          ],
-                          legend: [
-                              { shape: "circle", color: "#777777", size: 40, label: "No contribution", class: "lz-data_layer-scatter" },
-                              { shape: "circle", color: "#fafe87", size: 40, label: "Some contribution", class: "lz-data_layer-scatter" },
-                              { shape: "circle", color: "#9c0000", size: 40, label: "Most contribution", class: "lz-data_layer-scatter" }
-                          ]
-                      }
-                  }
-              ]
-          }
+                    options: [
+                        {
+                            // First dropdown menu item
+                            display_name: "95% credible set (boolean)",  // Human readable representation of field name
+                            display: {  // Specify layout directives that control display of the plot for this option
+                                point_shape: "circle",
+                                point_size: 40,
+                                color: {
+                                    field: "assoc:isCredible",
+                                    scale_function: "if",
+                                    parameters: {
+                                        field_value: true,
+                                        then: "#00CC00",
+                                        else: "#CCCCCC"
+                                    }
+                                },
+                                legend: [ // Tells the legend how to represent this display option
+                                    { shape: "circle", color: "#00CC00", size: 40, label: "In credible set", class: "lz-data_layer-scatter" },
+                                    { shape: "circle", color: "#CCCCCC", size: 40, label: "Not in credible set", class: "lz-data_layer-scatter" }
+                                ]
+                            }
+                        },
+                        {
+                            // Second option. The same plot- or even the same field- can be colored in more than one way.
+                            display_name: "95% credible set (gradient by contribution)",
+                            display: {
+                                point_shape: "circle",
+                                point_size: 40,
+                                color: [
+                                    { // FIXME: Display options dropdown should support namespacing (namespaces have already been resolved by the time this works, so "assoc" is hardcoded)
+                                        field: "assoc:credibleSetContribution",
+                                        scale_function: "if",
+                                        parameters: {
+                                            field_value: 0,
+                                            then: "#777777"
+                                        }
+                                    },
+                                    {
+                                        scale_function: "interpolate",
+                                        field: "assoc:credibleSetContribution",
+                                        parameters: {
+                                            breaks: [0, 1],
+                                            values: ["#fafe87", "#9c0000"]
+                                        }
+                                    }
+                                ],
+                                legend: [
+                                    { shape: "circle", color: "#777777", size: 40, label: "No contribution", class: "lz-data_layer-scatter" },
+                                    { shape: "circle", color: "#fafe87", size: 40, label: "Some contribution", class: "lz-data_layer-scatter" },
+                                    { shape: "circle", color: "#9c0000", size: 40, label: "Most contribution", class: "lz-data_layer-scatter" }
+                                ]
+                            }
+                        }
+                    ]
+                }
             );
-            l.data_layers[2].tooltip = LocusZoom.Layouts.get("tooltip", "credible_set_association");
-            return l;
+            var assoc_layer = assoc_panel.data_layers[2];
+            assoc_layer.tooltip = LocusZoom.Layouts.get("tooltip", "credible_set_association");
+
+            //["{{namespace[assoc]}}variant", "{{namespace[assoc]}}position", "{{namespace[assoc]}}log_pvalue", "{{namespace[assoc]}}credibleSetPosteriorProb", "{{namespace[assoc]}}credibleSetContribution", "{{namespace[assoc]}}isCredible"]
+
+            // assoc_layer.fields.push("{{namespace[assoc]}}credibleSetPosteriorProb", "{{namespace[assoc]}}credibleSetContribution", "{{namespace[assoc]}}isCredible");
+            assoc_layer.fields = [
+                "{{namespace[assoc]}}variant", "{{namespace[assoc]}}position", "{{namespace[assoc]}}log_pvalue", "{{namespace[assoc]}}log_pvalue|logtoscinotation", "{{namespace[assoc]}}ref_allele", "{{namespace[assoc]}}credibleSetPosteriorProb", "{{namespace[assoc]}}credibleSetContribution", "{{namespace[assoc]}}isCredible",
+                "{{namespace[ld]}}state", "{{namespace[ld]}}isrefvar"];
+
+            return assoc_panel;
         }(),
-        LocusZoom.Layouts.get("panel", "credible_set_panel", { unnamespaced: true })
+        LocusZoom.Layouts.get("panel", "credible_set_panel", {unnamespaced: true})
     ]
 });

--- a/index.html
+++ b/index.html
@@ -9,6 +9,8 @@
     <!-- Necessary includes for LocusZoom.js -->
     <script src="dist/locuszoom.vendor.min.js" type="text/javascript"></script>
     <script src="dist/locuszoom.app.min.js" type="text/javascript"></script>
+    <script type="application/javascript" src="dist/ext/lz-dynamic-urls.min.js"></script>
+
     <link rel="stylesheet" href="dist/locuszoom.css" type="text/css"/>
     
     <title>LocusZoom.js</title>
@@ -51,7 +53,7 @@
           <ul class="top_hits" style="padding-left: 0.2rem; min-width: 110px;"></ul>
         </div>
         <div class="ten columns">
-          <div id="plot" data-region="10:114550452-115067678"></div>
+          <div id="plot"></div>
         </div>
       </div>
       <p>To see other forms of LocusZoom.js in action take a look at <a href="http://locuszoom.org/locuszoomjs.php">locuszoom.org</a> or the <a href="#examples">examples</a> on this page.</p>
@@ -207,7 +209,13 @@
     }
 
     // Get the standard association plot layout from LocusZoom's built-in layouts
-    layout = LocusZoom.Layouts.get("plot", "standard_association");
+    var stateUrlMapping = {chr: "chrom", start: "start", end: "end"};
+    // Fetch initial position from the URL, or use some defaults
+    var initialState = LocusZoom.ext.DynamicUrls.paramsFromUrl(stateUrlMapping);
+    if (!Object.keys(initialState).length) {
+        initialState = {chr: 10, start: 114550452, end: 115067678};
+    }
+    layout = LocusZoom.Layouts.get("plot", "standard_association", {state: initialState});
     layout.dashboard = LocusZoom.Layouts.get("dashboard", "region_nav_plot");
 
     // Add a button to show the study abstract the layout
@@ -220,8 +228,13 @@
         menu_html: abstract
     });
 
-    // Generate the LocusZoom plot
-    var plot = LocusZoom.populate("#plot", data_sources, layout);
+    // Generate the LocusZoom plot, and reflect the initial plot state in url
+    window.plot = LocusZoom.populate("#plot", data_sources, layout);
+
+    // Changes in the plot can be reflected in the URL, and vice versa (eg browser back button can go back to
+    //   a previously viewed region)
+    LocusZoom.ext.DynamicUrls.plotUpdatesUrl(plot, stateUrlMapping);
+    LocusZoom.ext.DynamicUrls.plotWatchesUrl(plot, stateUrlMapping);
 
     // Add a basic loader to each panel (one that shows when data is requested and hides when one rendering)
     plot.layout.panels.forEach(function(panel){

--- a/test/unit/Data.js
+++ b/test/unit/Data.js
@@ -4,7 +4,7 @@
   LocusZoom.js Data Test Suite
   Test LocusZoom Data access objects
 */
-describe("LocusZoom Data", function(){
+describe("LocusZoom Data", function() {
     describe("LocusZoom.Data.Field", function() {
         beforeEach(function() {
             LocusZoom.TransformationFunctions.add("herp", function(x) { return x.toString() + "herp"; });
@@ -156,6 +156,14 @@ describe("LocusZoom Data", function(){
             should.not.exist(ds.get("t1"));
             should.exist(ds.get("t2"));
         });
+        it("should provide a source_id for all sources defined as part of a chain", function() {
+            var ds = new LocusZoom.DataSources();
+            ds.add("t1", new TestSource1());
+            ds.add("t2", ["test2", {}]);
+
+            assert.equal(ds.sources.t1.source_id, "t1", "Directly added source is aware of chain namespace");
+            assert.equal(ds.sources.t2.source_id, "t2", "Source created via options is aware of chain namespace");
+        });
     });
 
     describe("LocusZoom Data.Source", function() {
@@ -256,40 +264,247 @@ describe("LocusZoom Data", function(){
             });
         });
 
-        describe("Source.parseArraysToObjects", function() {
-            it("should require all columns of data to be of same length", function() {
+        describe("Source.getData", function() {
+            beforeEach(function() {
+                this.sandbox = sinon.sandbox.create();
+            });
+
+            it("dependentSource skips making a request if previous sources did not add data to chain.body", function() {
                 var source = new LocusZoom.Data.Source();
-                assert.throws(
-                    function() {
-                        source.parseArraysToObjects(
-                            {a: [1], b: [1,2], c: [1,2,3]},
-                            [], [], []);
-                    },
-                    /expects a response in which all arrays of data are the same length/
-                );
+                source.dependentSource = true;
+                var requestStub = this.sandbox.stub(source, "getRequest");
+
+                var callable = source.getData();
+                var noRecordsChain = { body: [] };
+                callable(noRecordsChain);
+
+                assert.ok(requestStub.notCalled, "Request should be skipped");
+            });
+
+            it("dependentSource makes a request if chain.body has data from previous sources", function(done) {
+                var source = new LocusZoom.Data.Source();
+                source.dependentSource = false;
+                var requestStub = this.sandbox.stub(source, "getRequest").callsFake(function() { return Q.when(); });
+                this.sandbox.stub(source, "parseResponse").callsFake(function() {
+                    // Because this is an async test, `done` will serve as proof that parseResponse was called
+                    done();
+                });
+
+                var callable = source.getData();
+                var hasRecordsChain = { body: [{ some: "data" }] };
+                callable(hasRecordsChain);
+
+                assert.ok(requestStub.called, "Request was made");
+            });
+
+            afterEach(function() {
+                this.sandbox.restore();
             });
         });
 
-        describe("Source.prepareData", function() {
-            it("should annotate returned records with an additional custom field", function () {
-                var custom_source_class = LocusZoom.KnownDataSources.extend(
-                    "StaticJSON",
-                    "AnnotatedJSON",
-                    {
-                        prepareData: function(records) {
+        describe("Source.parseResponse", function() {
+            // Parse response is a wrapper for a set of helper methods. Test them individually, and combined.
+            describe("Source.parseArraysToObjects", function() {
+                it("should provide a legacy wrapper for completely deprecated method", function() {
+                    var source = new LocusZoom.Data.Source();
+                    var res = source.parseArraysToObjects(
+                        {a: [1], b: [1]},
+                        ["a", "b"], ["namespace:a|add1", "bork:bork"], [function(v) { return v + 1; }, null]
+                    );
+
+                    assert.deepEqual(res, [{"namespace:a|add1": 2, "bork:bork": 1}], "Transformations were applied");
+                });
+            });
+
+            describe("Source.parseObjectsToObjects", function () {
+                it("should provide a legacy wrapper for completely deprecated method", function() {
+                    var source = new LocusZoom.Data.Source();
+                    var stub = sinon.stub(source, "extractFields");
+                    source.parseObjectsToObjects([], [], [], []);
+                    assert.ok(stub.called, "extractFields was called");
+                });
+            });
+
+            describe("Source.normalizeResponse", function () {
+                it("should create one object per piece of data", function() {
+                    var source = new LocusZoom.Data.Source();
+                    var res = source.normalizeResponse(
+                        { a: [1, 2], b: [3, 4] } );
+                    assert.deepEqual(
+                        res,
+                        [ {a: 1, b: 3}, {a: 2, b: 4} ],
+                        "Correct number and union of elements"
+                    );
+                });
+
+                it("should require all columns of data to be of same length", function() {
+                    var source = new LocusZoom.Data.Source();
+                    assert.throws(
+                        function() {
+                            source.normalizeResponse( { a: [1], b: [1,2], c: [1,2,3] } );
+                        },
+                        /expects a response in which all arrays of data are the same length/
+                    );
+                });
+
+                it("should return the data unchanged if it is already in the desired shape", function () {
+                    var source = new LocusZoom.Data.Source();
+                    var data = [ {a: 1, b: 3}, {a: 2, b: 4} ];
+                    var res = source.normalizeResponse( data );
+                    assert.deepEqual(res, data);
+                });
+            });
+
+            describe("Source.annotateData", function() {
+                it("should be able to add fields to the returned records", function () {
+                    var source = LocusZoom.subclass(LocusZoom.Data.Source, {
+                        annotateData(records) {
                             // Custom hook that adds a field to every parsed record
                             return records.map(function(item) {
                                 item.force = true;
                                 return item;
                             });
                         }
-                    }
-                );
-                var source = new custom_source_class([{r:2, d:2}, {c:3, p: "o"}]);
-                // Async test depends on promise
-                return source.getData({}, [], [])({header: []}).then(function(records) {
-                    records.body.forEach(function(item) {
-                        assert.ok(item.force, "Record should have an additional key not in raw server payload");
+                    });
+
+                    // Async test depends on promise
+                    return new source().parseResponse([{a:1, b:1}, {a:2, b: 2}], {}, ["a", "b", "force"], ["a", "b", "force"], []).then(function(records) {
+                        records.body.forEach(function(item) {
+                            assert.ok(item.force, "Record should have an additional key not in raw server payload");
+                        });
+                    });
+                });
+
+                it("should be able to annotate based on info in the body and chain", function() {
+                    var source = LocusZoom.subclass(LocusZoom.Data.Source, {
+                        annotateData (records, chain) { return records + chain.header.param; }
+                    });
+                    var result = new source().annotateData(
+                        "some data",
+                        { header: { param: " up the chain" } }
+                    );
+                    assert.equal(result, "some data up the chain");
+                });
+            });
+
+            describe("Source.extractFields", function () {
+                it("allows a legacy alias via parseArraysToObjects", function () {
+                    var source = new LocusZoom.Data.Source();
+                    var res = source.parseArraysToObjects(
+                        [ {"id":1, "val":5}, {"id":2, "val":10}],
+                        ["id"], ["namespace:id"], [null]
+                    );
+
+                    assert.deepEqual(res, [{"namespace:id": 1}, {"namespace:id": 2}]);
+                });
+
+                it("extracts the specified fields from each record", function () {
+                    var source = new LocusZoom.Data.Source();
+                    var res = source.extractFields(
+                        [ {"id":1, "val":5}, {"id":2, "val":10}],
+                        ["id"], ["namespace:id"], [null]
+                    );
+                    assert.deepEqual(res, [{"namespace:id": 1}, {"namespace:id": 2}]);
+                });
+
+                it("applies value transformations where appropriate", function () {
+                    var source = new LocusZoom.Data.Source();
+                    var res = source.extractFields(
+                        [ {"id":1, "val":5}, {"id":2, "val":10}],
+                        ["id", "val"], ["namespace:id|add1", "bork:bork"], [function (val) { return val + 1; }, null]
+                    );
+                    // Output fields can be mapped to any arbitrary based on the field->outnames provided
+                    assert.deepEqual(res, [{"namespace:id|add1": 2, "bork:bork": 5}, {"namespace:id|add1": 3, "bork:bork": 10}]);
+                });
+
+                it("throws an error when requesting a field not present in at least one record", function () {
+                    var source = new LocusZoom.Data.Source();
+
+
+                    assert.throws(function() {
+                        source.extractFields(
+                            [ {"a":1}, {"a":2}],
+                            ["b"], ["namespace:b"], [null]
+                        );
+                    }, /field b not found in response for namespace:b/);
+                });
+            });
+
+            describe("Source.combineChainBody", function () {
+                it("returns only the body by default", function() {
+                    var source = new LocusZoom.Data.Source();
+
+                    var expectedBody = [ { "namespace:a": 1 } ];
+                    var res = source.combineChainBody(expectedBody, {header: {}, body: [], discrete: {}});
+
+                    assert.deepEqual(res, expectedBody);
+                });
+
+                it("can build a body based on records from all sources in the chain", function() {
+                    var base_source = LocusZoom.subclass(LocusZoom.Data.Source, {
+                        combineChainBody(records, chain) {
+                            return records.map(function(item, index) {
+                                return Object.assign({}, item, chain.body[index]);
+                            });
+                        }
+                    });
+                    var source = new base_source();
+
+                    var records = [ { "namespace:a": 1 } ];
+                    var res = source.combineChainBody(records, {header: {}, body: [{"namespace:b": 2}], discrete: {}});
+
+                    assert.deepEqual(res, [{ "namespace:a":1, "namespace:b": 2 }]);
+                });
+            });
+
+            describe("integration of steps", function () {
+                it("should interpret a string response as JSON", function () {
+                    var source = new LocusZoom.Data.Source();
+
+                    return source.parseResponse('{"a_field": ["val"]}', {}, ["a_field"], ["namespace:a_field"], [null])
+                        .then(function (chain) {
+                            assert.deepEqual(chain.body, [{"namespace:a_field": "val"}]);
+                        });
+                });
+
+                it("should store annotations in body and chain.discrete where appropriate", function() {
+                    var source = LocusZoom.subclass(LocusZoom.Data.Source, {
+                        annotateData: function (data) { return data + " with annotation"; },
+                        normalizeResponse(data) { return data; },
+                        extractFields(data) { return data; }
+                    });
+                    source.prototype.constructor.SOURCE_NAME = "fake_source";
+
+                    var result = new source().parseResponse({data: "a response"}, {});
+                    return result.then(function(chain) {
+                        assert.deepEqual(chain.discrete, {fake_source: "a response with annotation"}, "Discrete response uses annotations");
+                        assert.deepEqual(chain.body, "a response with annotation", "Combined body uses annotations");
+                    });
+                });
+
+                it("integrates all methods via promise semantics", function () {
+                    // Returning a promise is optional, but should be supported if a custom subclass chooses to do so
+                    var basic_source = LocusZoom.subclass(LocusZoom.Data.Source, {
+                        normalizeResponse() { return Q.when( [{a:1}] ); },
+                        annotateData(records) {
+                            return Q.when(records.map(function(item) {
+                                item.b = item.a + 1;
+                                return item;
+                            }));
+                        },
+                        extractFields(data, fields, outnames, trans) {
+                            var rec = data.map(function(item) { return {"bfield": item.b}; });
+                            return Q.when(rec); },
+                        combineChainBody(records) { return Q.when(records); }
+                    });
+                    basic_source.prototype.constructor.SOURCE_NAME = "fake_source";
+
+                    var result = new basic_source().parseResponse({}, {});
+                    var thisBody = [{bfield: 2}];
+                    var expected = { header: {}, discrete: { fake_source: thisBody }, body: thisBody};
+                    return result.then(function (final) {
+                        assert.deepEqual(final.body, expected.body, "Chain produces expected result body");
+                        assert.deepEqual(final.discrete, expected.discrete, "The parsed results from this source are also stored in chain.discrete");
                     });
                 });
             });
@@ -353,4 +568,91 @@ describe("LocusZoom Data", function(){
         });
     });
 
+    describe("LocusZoom Data.ConnectorSource", function() {
+        beforeEach(function () {
+            this.sandbox = sinon.sandbox.create();
+
+            // Create a source that internally looks for data as "first" from the specified
+            this.basic_config = { sources: { first: "a_source", second: "b_source" } };
+            this.basic_source = LocusZoom.subclass(LocusZoom.Data.ConnectorSource, {
+                combineChainBody: function(records, chain) {
+                    // A sample method that uses 2 chain sources + an existing body to build an combined response
+
+                    // Tell the internal method how to find the actual data it relies on internally, regardless of how
+                    //   it is called in the namespaced data chain
+                    var nameFirst = this._source_name_mapping["first"];
+                    var nameSecond = this._source_name_mapping["second"];
+
+                    records.forEach(function(item) {
+                        item.a = chain.discrete[nameFirst].a_field;
+                        item.b = chain.discrete[nameSecond].b_field;
+                    });
+                    return records;
+                }
+            });
+            this.basic_source.prototype.constructor.SOURCE_NAME = "test_connector";
+        });
+
+        afterEach(function() {
+            this.sandbox.restore();
+        });
+
+        it("must specify the data it requires from other sources", function() {
+            var source = LocusZoom.subclass(LocusZoom.Data.ConnectorSource);
+            assert.throws(
+                function() { new source(); },
+                /Connectors must specify the data they require as init.sources = {internal_name: chain_source_id}} pairs/
+            );
+            assert.ok(
+                new source(this.basic_config),
+                "Correctly specifies the namespaces containing data that this connector relies on"
+            );
+        });
+        it("must implement a combineChainBody method", function() {
+            var self = this;
+            var source = LocusZoom.subclass(LocusZoom.Data.ConnectorSource);
+            assert.throws(
+                function() { new source(self.basic_config).combineChainBody(); },
+                /This method must be implemented in a subclass/
+            );
+        });
+        it("should fail if the namespaces it relies on are not present in the chain", function() {
+            var instance = new this.basic_source(this.basic_config);
+            assert.throws(
+                function() {  instance.getRequest({}, { discrete: { } }); },
+                /test_connector cannot be used before loading required data for: a_source/
+            );
+        });
+        it("should not make any network requests", function() {
+            var instance = new this.basic_source(this.basic_config);
+            var fetchSpy = this.sandbox.stub(instance, "fetchRequest");
+
+            return instance.getRequest({}, { discrete: { a_source: 1, b_source: 2 } })
+                .then(function() { assert.ok(fetchSpy.notCalled, "No network request was fired"); });
+        });
+        it("should not return any new data from getRequest", function() {
+            var instance = new this.basic_source(this.basic_config);
+            var expectedBody = { sample: "response data" };
+            return instance.getRequest({}, { discrete: { a_source: 1, b_source: 2 }, body: expectedBody })
+                .then(function(records) { assert.deepEqual(records, expectedBody, "Should return the previous body"); });
+        });
+        it("should build a response by combining data from multiple places", function() {
+            // Should have access to data in both chain.discrete and chain.body. (connectors don't have their own data)
+            // Not every source in chain.discrete has to be an array of records- this tests arbitrary blobs of JSON
+            var rawChain = { a_source: { a_field: "aaa" }, b_source: { b_field: "bbb" } };
+            var expectedBody = [{who: 1, a: "aaa", b: "bbb"}, {what: 2, a: "aaa", b: "bbb"}];
+
+            var instance = new this.basic_source(this.basic_config);
+            return instance.getData()(
+                {
+                    discrete: rawChain,
+                    body: [{ who: 1 }, { what: 2 }]
+                }
+            ).then(function(response) {
+                assert.deepEqual(response.body, expectedBody, "Response body was correctly annotated");
+                assert.deepEqual(response.discrete, rawChain, "The chain of individual sources was not changed");
+            });
+        });
+    });
 });
+

--- a/test/unit/Plot.js
+++ b/test/unit/Plot.js
@@ -543,7 +543,7 @@ describe("LocusZoom.Plot", function(){
             }, 0);
         });
 
-        it.skip("allows subscribing to individual (not combined) sources", function (done) {
+        it("allows subscribing to individual (not combined) sources", function (done) {
             var expectedData = { first: [ {"first:x": 0}, {"first:x": 1} ] };
             var dataCallback = this.sandbox.spy();
 


### PR DESCRIPTION
See #123 for details and notes.

This PR breaks up a long series of changes into more manageable chunks that can move forward independently. 

It includes:

- Refactored data chain (new parseResponse flow, chain.discrete, and connector sources)
- Allows subscribeToData to use chain.discrete
- Allow genes to be colored based on layout configuration
- Various added unit tests

It does not include aggregation tests, so PR #123 will be more focused on specific demo functionality going forward.