### PR TITLE
Improve handling of filled curves

### DIFF
--- a/assets/js/app/DataLayers/line.js
+++ b/assets/js/app/DataLayers/line.js
@@ -2,7 +2,7 @@
 
 /*********************
  * Line Data Layer
- * Implements a standard line plot
+ * Implements a standard line plot, representing either a trace or a filled curve.
  * @class
  * @augments LocusZoom.DataLayer
 */
@@ -191,10 +191,19 @@ LocusZoom.DataLayers.add("line", function(layout){
             .attr("class", "lz-data_layer-line");
 
         // Generate the line
-        this.line = d3.svg.line()
-            .x(function(d) { return parseFloat(panel[x_scale](d[x_field])); })
-            .y(function(d) { return parseFloat(panel[y_scale](d[y_field])); })
-            .interpolate(this.layout.interpolate);
+        if (this.layout.style.fill && this.layout.style.fill !== "none") {
+            // Filled curve: define the line as a filled boundary
+            this.line = d3.svg.area()
+                .x(function(d) { return parseFloat(panel[x_scale](d[x_field])); })
+                .y0(function(d) {return parseFloat(panel[y_scale](0));})
+                .y1(function(d) { return parseFloat(panel[y_scale](d[y_field])); });
+        } else {
+            // Basic line
+            this.line = d3.svg.line()
+                .x(function(d) { return parseFloat(panel[x_scale](d[x_field])); })
+                .y(function(d) { return parseFloat(panel[y_scale](d[y_field])); })
+                .interpolate(this.layout.interpolate);
+        }
 
         // Apply line and style
         if (this.canTransition()){
@@ -251,7 +260,7 @@ LocusZoom.DataLayers.add("line", function(layout){
 
         // Remove old elements as needed
         selection.exit().remove();
-        
+
     };
 
     /**
@@ -403,7 +412,7 @@ LocusZoom.DataLayers.add("orthogonal_line", function(layout){
 
         // Remove old elements as needed
         selection.exit().remove();
-        
+
     };
 
     return this;


### PR DESCRIPTION
References #139

## Purpose
Improves rendering of filled curves when using `style.fill` config option on the existing line layer.

The previous option worked by implicitly closing the path (joining first and last point). This produced undesirable results if the endpoints were not already flat with the y-axis (see example). 

## Summary of changes
The new behavior changes the mechanism by which the `path` is generated to more explicitly fill the area between the data and the y-axis. 

Before:
![screen shot 2018-10-03 at 4 20 28 pm](https://user-images.githubusercontent.com/2957073/46437664-e850dc00-c729-11e8-9e8b-87ae73409a28.png)

After:
![screen shot 2018-10-03 at 4 35 13 pm](https://user-images.githubusercontent.com/2957073/46437842-54334480-c72a-11e8-8b90-21a2aace47af.png)
