### PR TITLE
[rfr] Forest plot improvements

### DIFF
--- a/assets/js/app/Data.js
+++ b/assets/js/app/Data.js
@@ -231,7 +231,7 @@ LocusZoom.Data.Requester = function(sources) {
         });
         //assume the fields are requested in dependent order
         //TODO: better manage dependencies
-        var ret = Q.when({header:{}, body:{}, discrete: {}});
+        var ret = Q.when({header:{}, body: [], discrete: {}});
         for(var i=0; i < request_handles.length; i++) {
             // If a single datalayer uses multiple sources, perform the next request when the previous one completes
             ret = ret.then(request_handles[i]);

--- a/examples/phewas_forest.html
+++ b/examples/phewas_forest.html
@@ -62,12 +62,18 @@
             responsive_resize: true,
             panels: [
                 {
-                    id: "phewas",
+                    id: "phewasforest",
                     width: 800,
                     height: 800,
                     proportional_width: 1,
-                    margin: { top: 20, right: 220, bottom: 50, left: 20 },
+                    margin: { top: 35, right: 220, bottom: 50, left: 20 },
                     inner_border: "rgba(210, 210, 210, 0.85)",
+                    dashboard: {
+                        components: [{
+                            type: "toggle_legend",
+                            position: "left"
+                        }]
+                    },
                     axes: {
                         x: {
                             label: "Beta",
@@ -83,7 +89,7 @@
                         }
                     },
                     legend: {
-                        origin: { x: 30, y: 30 },
+                        origin: { x: 30, y: 45 },
                         orientation: "vertical"
                     },
                     data_layers: [
@@ -124,8 +130,8 @@
                             fields: ["{{namespace[phewas]}}phenotype", "{{namespace[phewas]}}log_pvalue", "{{namespace[phewas]}}log_pvalue|logtoscinotation", "{{namespace[phewas]}}beta", "{{namespace[phewas]}}ci_start", "{{namespace[phewas]}}ci_end"],
                             x_axis: {
                                 field: "{{namespace[phewas]}}beta",
-                                floor: -0.2,
-                                ceiling: 0.2
+                                lower_buffer: 0.1,
+                                upper_buffer: 0.1
                             },
                             y_axis: {
                                 axis: 2,
@@ -151,6 +157,7 @@
                                 ]
                             },
                             tooltip: {
+                                namespace: { "phewas": "phewas" },
                                 closable: true,
                                 show: { or: ["highlighted", "selected"] },
                                 hide: { and: ["unhighlighted", "unselected"] },

--- a/examples/phewas_forest.html
+++ b/examples/phewas_forest.html
@@ -5,12 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="//fonts.googleapis.com/css?family=Raleway:400,300,600" rel="stylesheet" type="text/css">
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/skeleton/2.0.4/skeleton.css"/>
-    
+
     <!-- Necessary includes for LocusZoom.js -->
     <script src="../dist/locuszoom.vendor.min.js" type="text/javascript"></script>
     <script src="../dist/locuszoom.app.min.js" type="text/javascript"></script>
     <link rel="stylesheet" href="../dist/locuszoom.css" type="text/css"/>
-    
+
     <title>LocusZoom.js ~ PheWAS (Forest) Example</title>
 
     <style>
@@ -130,21 +130,25 @@
                             y_axis: {
                                 axis: 2,
                                 category_field: "{{namespace[phewas]}}phenotype",  // Labels
-                                field: "{{namespace[phewas]}}y_offset",  // Positions (dynamicaly added)
-                                floor: 0,
-                                ceiling: 0
+                                field: "{{namespace[phewas]}}y_offset",  // Positions (dynamically added)
                             },
                             confidence_intervals: {
                                 start_field: "{{namespace[phewas]}}ci_start",
                                 end_field: "{{namespace[phewas]}}ci_end"
                             },
-                            highlighted: {
-                                onmouseover: "on",
-                                onmouseout: "off"
-                            },
-                            selected: {
-                                onclick: "toggle_exclusive",
-                                onshiftclick: "toggle"
+                            behaviors: {
+                                onmouseover: [
+                                    { action: "set", status: "highlighted" }
+                                ],
+                                onmouseout: [
+                                    { action: "unset", status: "highlighted" }
+                                ],
+                                onclick: [
+                                    { action: "toggle", status: "selected", exclusive: true }
+                                ],
+                                onshiftclick: [
+                                    { action: "toggle", status: "selected" }
+                                ]
                             },
                             tooltip: {
                                 closable: true,
@@ -173,7 +177,7 @@
         var layout = LocusZoom.Layouts.get("plot", "phewas_forest");
 
         window.plot = LocusZoom.populate("#plot", data_sources, layout);
-        
+
       </script>
 
     </div>


### PR DESCRIPTION
References: #144 

# Purpose
Further improvements to forest plot display based on portal usage. (h/t @benralexander)

# Summary of changes
- Autoscale `category_forest` x axis to data (including confidence intervals). Add new `_getDataExtent` hook for the case where axis extent depends on more than one field.
- Fix tooltip highlight/selection bugs in forest plots (related to generated element IDs)
- Restore broken tooltips to forest plot example layout
- Add show/hide legend button to forest plot example layout

# TODO
- [ ] Investigate a mouse wheel zoom feature (currently very buggy in this plot type)