### PR TITLE
Annotation track improvements

### DIFF
--- a/assets/js/app/DataLayers/annotation_track.js
+++ b/assets/js/app/DataLayers/annotation_track.js
@@ -16,7 +16,9 @@ LocusZoom.DataLayers.add("annotation_track", function(layout) {
     // In the future we may add additional options for controlling marker size/ shape, based on user feedback
     this.DefaultLayout = {
         color: "#000000",
-        filters: []
+        filters: [],
+        tooltip_positioning: "middle", // Allowed values: top, middle, bottom
+        hit_area_width: 8,
     };
 
     layout = LocusZoom.Layouts.merge(layout, this.DefaultLayout);
@@ -33,26 +35,73 @@ LocusZoom.DataLayers.add("annotation_track", function(layout) {
         // Only render points that currently satisfy all provided filter conditions.
         var trackData = this.filter(this.layout.filters, "elements");
 
-        var selection = this.svg.group
-            .selectAll("rect.lz-data_layer-" + self.layout.type)
-            .data(trackData, function(d) { return d[self.layout.id_field]; });
+        // Put the <g> containing visible lines before the one containing hit areas, so that the hit areas will be on top.
+        var visible_lines_group = this.svg.group.select("g.lz-data_layer-" + self.layout.type + "-visible_lines");
+        if (visible_lines_group.size() === 0) {
+            visible_lines_group = this.svg.group.append("g").attr("class", "lz-data_layer-" + self.layout.type + "-visible_lines");
+        }
+        var selection = visible_lines_group.selectAll("rect.lz-data_layer-" + self.layout.type)
+            .data(trackData, function (d) { return d[self.layout.id_field]; });
 
-        // Add new elements as needed
+        // Draw rectangles (visual and tooltip positioning)
         selection.enter()
             .append("rect")
             .attr("class", "lz-data_layer-" + this.layout.type)
             .attr("id", function (d){ return self.getElementId(d); });
-        // Update the set of elements to reflect new data
+
+        var width = 1;
         selection
-            .attr("x", function (d) { return self.parent["x_scale"](d[self.layout.x_axis.field]); })
-            .attr("width", 1)  // TODO autocalc width of track? Based on datarange / pixel width presumably
+            .attr("x", function (d) {return self.parent["x_scale"](d[self.layout.x_axis.field]) - width / 2; })
+            .attr("width", width)
             .attr("height", self.parent.layout.height)
             .attr("fill", function(d){ return self.resolveScalableParameter(self.layout.color, d); });
+
         // Remove unused elements
-        selection.exit().remove();
+        selection.exit()
+            .remove();
+
+        var hit_areas_group = this.svg.group.select("g.lz-data_layer-" + self.layout.type + "-hit_areas");
+        if (hit_areas_group.size() === 0) {
+            hit_areas_group = this.svg.group.append("g").attr("class", "lz-data_layer-" + self.layout.type + "-hit_areas");
+        }
+        var hit_areas_selection = hit_areas_group.selectAll("rect.lz-data_layer-" + self.layout.type)
+            .data(trackData, function (d) { return d[self.layout.id_field]; });
+
+        // Add new elements as needed
+        hit_areas_selection.enter()
+            .append("rect")
+            .attr("class", "lz-data_layer-" + this.layout.type)
+            .attr("id", function (d) { return self.getElementId(d); });
+
+        // Update the set of elements to reflect new data
+
+        var _getX = function (d, i) { // Helper for position calcs below
+            var x_center = self.parent["x_scale"](d[self.layout.x_axis.field]);
+            var x_left = x_center - self.layout.hit_area_width / 2;
+            if (i >= 1) {
+                // This assumes that the data are in sorted order.
+                var left_node = trackData[i - 1];
+                var left_node_x_center = self.parent["x_scale"](left_node[self.layout.x_axis.field]);
+                x_left = Math.max(x_left, (x_center + left_node_x_center) / 2);
+            }
+            return [x_left, x_center];
+        };
+        hit_areas_selection
+            .attr("height", self.parent.layout.height)
+            .attr("opacity", 0)
+            .attr("x", function (d, i) {
+                var crds = _getX(d,i);
+                return crds[0];
+            }).attr("width", function (d, i) {
+                var crds = _getX(d,i);
+                return (crds[1] - crds[0]) + self.layout.hit_area_width / 2;
+            });
+
+        // Remove unused elements
+        hit_areas_selection.exit().remove();
 
         // Set up tooltips and mouse interaction
-        this.applyBehaviors(selection);
+        this.applyBehaviors(hit_areas_selection);
     };
 
     // Reimplement the positionTooltip() method to be annotation-specific
@@ -82,15 +131,36 @@ LocusZoom.DataLayers.add("annotation_track", function(layout) {
         var offset_left = Math.max((tooltip_box.width / 2) + x_center - data_layer_width, 0);
         left = page_origin.x + x_center - (tooltip_box.width / 2) - offset_left + offset_right;
         arrow_left = (tooltip_box.width / 2) - (arrow_width) + offset_left - offset_right - offset;
-        if (tooltip_box.height + stroke_width + arrow_width > data_layer_height - y_center) {
-            top = page_origin.y + y_center - (tooltip_box.height + stroke_width + arrow_width);
+
+        var top_offset = 0;
+        switch(this.layout.tooltip_positioning) {
+        case "top":
             arrow_type = "down";
-            arrow_top = tooltip_box.height - stroke_width;
-        } else {
-            top = page_origin.y + y_center + stroke_width + arrow_width;
+            break;
+        case "bottom":
+            top_offset = data_layer_height;
             arrow_type = "up";
-            arrow_top = 0 - stroke_width - arrow_width;
+            break;
+        case "middle":
+        default:
+            var position = d3.mouse(this.svg.container.node());
+            // Position the tooltip so that it does not overlap the mouse pointer
+            top_offset = y_center;
+            if (position[1] > (data_layer_height / 2)) {
+                arrow_type = "down";
+            } else {
+                arrow_type = "up";
+            }
         }
+
+        if (arrow_type === "up") {
+            top = page_origin.y + top_offset + stroke_width + arrow_width;
+            arrow_top = 0 - stroke_width - arrow_width;
+        } else if (arrow_type === "down") {
+            top = page_origin.y + top_offset - (tooltip_box.height + stroke_width + arrow_width);
+            arrow_top = tooltip_box.height - stroke_width;
+        }
+
         // Apply positions to the main div
         tooltip.selector.style("left", left + "px").style("top", top + "px");
         // Create / update position on arrow connecting tooltip to data

--- a/assets/js/app/Layouts.js
+++ b/assets/js/app/Layouts.js
@@ -383,7 +383,7 @@ LocusZoom.Layouts.add("data_layer", "association_pvalues_catalog", function () {
         fill_opacity: 0.7
     });
 
-    l.tooltip.html += "{{#if {{namespace[catalog]}}rsid}}<a href=\"https://www.ebi.ac.uk/gwas/search?query={{{{namespace[catalog]}}rsid}}\" target=\"_new\">See hits on GWAS catalog</a>{{/if}}";
+    l.tooltip.html += "{{#if {{namespace[catalog]}}rsid}}<br><a href=\"https://www.ebi.ac.uk/gwas/search?query={{{{namespace[catalog]}}rsid}}\" target=\"_new\">See hits in GWAS catalog</a>{{/if}}";
     l.namespace.catalog = "catalog";
     l.fields.push("{{namespace[catalog]}}rsid", "{{namespace[catalog]}}trait", "{{namespace[catalog]}}log_pvalue");
     return l;

--- a/assets/js/app/LocusZoom.js
+++ b/assets/js/app/LocusZoom.js
@@ -2,7 +2,7 @@
  * @namespace
  */
 var LocusZoom = {
-    version: "0.8.2"
+    version: "0.9.0-a1"
 };
 
 /**


### PR DESCRIPTION
References #124 and https://github.com/statgen/pheweb/compare/8cdb7...pull-112-head#diff-007e08bf75bfe53b85b14034803e369c

Expand suggestions by @pjvandehaar and incorporate into core codebase:
- Make it easier to click on 1px-wide annotation lines
 - Configurable `tooltip_positioning` option for annotation track. Supports two fixed positions (`top` and `bottom`) and one dynamic option (`middle`).

## How to test this
The effect of each position option can very quickly be tried in the console: 

`plot.panels["annotationcatalog"].data_layers["annotation_catalog"].layout.tooltip_positioning = 'bottom'`

## Alternatives considered
- Always position above / below: each layout has different needs.
  - The default option ("middle") makes sure that the base layout is reusable without customization. 
- Horizontal tooltips: since all the spread of data is horizontal, this was too likely to overlap with data