### PR TITLE
Width-only responsive resize

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ all matching elements for a single selector string use `LocusZoom.populateAll()`
 <div class="plot" id="plot_2"></div>
 <div class="plot" id="plot_3"></div>
 <script type="text/javascript">
-  var plots[] = LocusZoom.populateAll(".plot", data_source, layout);
+  var plots = LocusZoom.populateAll(".plot", data_source, layout);
 </script>
 ```
 

--- a/assets/js/app/Layouts.js
+++ b/assets/js/app/Layouts.js
@@ -1175,12 +1175,11 @@ LocusZoom.Layouts.add('panel', 'intervals', {
 
 LocusZoom.Layouts.add('panel', 'annotation_catalog', {
     id: 'annotationcatalog',
-    title: { text: 'SNPs in GWAS Catalog', x: 50, style: { 'font-size': '14px' } },
     width: 800,
     height: 50,
     min_height: 50,
     proportional_width: 1,
-    margin: { top: 30, right: 50, bottom: 10, left: 50 },
+    margin: { top: 25, right: 50, bottom: 0, left: 50 },
     inner_border: 'rgb(210, 210, 210)',
     dashboard: LocusZoom.Layouts.get('dashboard', 'standard_panel', { unnamespaced: true }),
     interaction: {

--- a/assets/js/app/Layouts.js
+++ b/assets/js/app/Layouts.js
@@ -1177,10 +1177,10 @@ LocusZoom.Layouts.add('panel', 'annotation_catalog', {
     id: 'annotationcatalog',
     title: { text: 'SNPs in GWAS Catalog', x: 50, style: { 'font-size': '14px' } },
     width: 800,
-    height: 100,
-    min_height: 100,
+    height: 50,
+    min_height: 50,
     proportional_width: 1,
-    margin: { top: 35, right: 50, bottom: 40, left: 50 },
+    margin: { top: 30, right: 50, bottom: 10, left: 50 },
     inner_border: 'rgb(210, 210, 210)',
     dashboard: LocusZoom.Layouts.get('dashboard', 'standard_panel', { unnamespaced: true }),
     interaction: {
@@ -1202,7 +1202,7 @@ LocusZoom.Layouts.add('plot', 'standard_association', {
     state: {},
     width: 800,
     height: 450,
-    responsive_resize: true,
+    responsive_resize: 'both',
     min_region_scale: 20000,
     max_region_scale: 1000000,
     dashboard: LocusZoom.Layouts.get('dashboard', 'standard_plot', { unnamespaced: true }),
@@ -1215,15 +1215,15 @@ LocusZoom.Layouts.add('plot', 'standard_association', {
 LocusZoom.Layouts.add('plot', 'association_catalog', {
     state: {},
     width: 800,
-    height: 450,
-    responsive_resize: true,
+    height: 500,
+    responsive_resize: 'width_only',
     min_region_scale: 20000,
     max_region_scale: 1000000,
     dashboard: LocusZoom.Layouts.get('dashboard', 'standard_plot', { unnamespaced: true }),
     panels: [
-        LocusZoom.Layouts.get('panel', 'association_catalog', { unnamespaced: true, proportional_height: 0.5 }),
         LocusZoom.Layouts.get('panel', 'annotation_catalog', { unnamespaced: true }),
-        LocusZoom.Layouts.get('panel', 'genes', { unnamespaced: true, proportional_height: 0.5 })
+        LocusZoom.Layouts.get('panel', 'association_catalog', { unnamespaced: true }),
+        LocusZoom.Layouts.get('panel', 'genes', { unnamespaced: true })
     ]
 });
 
@@ -1235,7 +1235,7 @@ LocusZoom.Layouts.add('plot', 'standard_phewas', {
     height: 600,
     min_width: 800,
     min_height: 600,
-    responsive_resize: true,
+    responsive_resize: 'both',
     dashboard: LocusZoom.Layouts.get('dashboard', 'standard_plot', { unnamespaced: true }),
     panels: [
         LocusZoom.Layouts.get('panel', 'phewas', { unnamespaced: true, proportional_height: 0.45 }),
@@ -1260,7 +1260,7 @@ LocusZoom.Layouts.add('plot', 'interval_association', {
     state: {},
     width: 800,
     height: 550,
-    responsive_resize: true,
+    responsive_resize: 'both',
     min_region_scale: 20000,
     max_region_scale: 1000000,
     dashboard: LocusZoom.Layouts.get('dashboard', 'standard_plot', { unnamespaced: true }),

--- a/assets/js/app/Plot.js
+++ b/assets/js/app/Plot.js
@@ -287,7 +287,6 @@ LocusZoom.Plot = function(id, datasource, layout) {
 
     // Initialize the layout
     this.initializeLayout();
-    // TODO: Possibly superfluous return from constructor
     return this;
 };
 
@@ -304,7 +303,7 @@ LocusZoom.Plot.DefaultLayout = {
     height: 1,
     min_width: 1,
     min_height: 1,
-    responsive_resize: false,
+    responsive_resize: false, // Allowed values: false, "width_only", "both" (synonym for true)
     aspect_ratio: 1,
     panels: [],
     dashboard: {
@@ -351,7 +350,6 @@ LocusZoom.Plot.prototype.rescaleSVG = function() {
 LocusZoom.Plot.prototype.initializeLayout = function() {
 
     // Sanity check layout values
-    // TODO: Find a way to generally abstract this, maybe into an object that models allowed layout values?
     if (isNaN(this.layout.width) || this.layout.width <= 0) {
         throw new Error('Plot layout parameter `width` must be a positive number');
     }
@@ -360,6 +358,11 @@ LocusZoom.Plot.prototype.initializeLayout = function() {
     }
     if (isNaN(this.layout.aspect_ratio) || this.layout.aspect_ratio <= 0) {
         throw new Error('Plot layout parameter `aspect_ratio` must be a positive number');
+    }
+    if (this.layout.responsive_resize === true) {
+        // Backwards compatible support
+        console.warn('"responsive_resize" should specify a mode, not a boolean');
+        this.layout.responsive_resize = 'both';
     }
 
     // If this is a responsive layout then set a namespaced/unique onresize event listener on the window
@@ -419,13 +422,17 @@ LocusZoom.Plot.prototype.setDimensions = function(width, height) {
         this.layout.aspect_ratio = this.layout.width / this.layout.height;
         // Override discrete values if resizing responsively
         if (this.layout.responsive_resize) {
+            // All resize modes will affect width
             if (this.svg) {
                 this.layout.width = Math.max(this.svg.node().parentNode.getBoundingClientRect().width, this.layout.min_width);
             }
-            this.layout.height = this.layout.width / this.layout.aspect_ratio;
-            if (this.layout.height < this.layout.min_height) {
-                this.layout.height = this.layout.min_height;
-                this.layout.width  = this.layout.height * this.layout.aspect_ratio;
+
+            if (this.layout.responsive_resize === 'both') { // Then also change the height
+                this.layout.height = this.layout.width / this.layout.aspect_ratio;
+                if (this.layout.height < this.layout.min_height) {
+                    this.layout.height = this.layout.min_height;
+                    this.layout.width  = this.layout.height * this.layout.aspect_ratio;
+                }
             }
         }
         // Resize/reposition panels to fit, update proportional origins if necessary
@@ -460,7 +467,7 @@ LocusZoom.Plot.prototype.setDimensions = function(width, height) {
 
     // Apply layout width and height as discrete values or viewbox values
     if (this.svg !== null) {
-        if (this.layout.responsive_resize) {
+        if (this.layout.responsive_resize === 'both') {
             this.svg
                 .attr('viewBox', '0 0 ' + this.layout.width + ' ' + this.layout.height)
                 .attr('preserveAspectRatio', 'xMinYMin meet');

--- a/assets/js/app/Plot.js
+++ b/assets/js/app/Plot.js
@@ -116,8 +116,9 @@ LocusZoom.Plot = function(id, datasource, layout) {
         'layout_changed': [],
         'data_requested': [],
         'data_rendered': [],
-        'element_clicked': [],
-        'element_selection': [],
+        'element_clicked': [], // Select or unselect
+        'element_selection': [], // Element becomes active (only)
+        'panel_removed': [],
         'state_changed': []  // Only triggered when a state change causes rerender
     };
 
@@ -623,6 +624,8 @@ LocusZoom.Plot.prototype.removePanel = function(id) {
         // positioning. TODO: make this additional call unnecessary.
         this.setDimensions(this.layout.width, this.layout.height);
     }
+
+    this.emit('panel_removed', id);
 
     return this;
 };

--- a/assets/js/ext/lz-credible-sets.js
+++ b/assets/js/ext/lz-credible-sets.js
@@ -274,7 +274,7 @@ if (typeof gwasCredibleSets === 'undefined') {
         state: {},
         width: 800,
         height: 450,
-        responsive_resize: true,
+        responsive_resize: 'both',
         min_region_scale: 20000,
         max_region_scale: 1000000,
         dashboard: LocusZoom.Layouts.get('dashboard', 'standard_plot', {unnamespaced: true}),

--- a/examples/multiple_phenotypes_layered.html
+++ b/examples/multiple_phenotypes_layered.html
@@ -86,7 +86,7 @@
     layout = {
         width: 800,
         height: 500,
-        responsive_resize: true,
+        responsive_resize: 'both',
         panels: [
             LocusZoom.Layouts.get("panel", "association", association_panel_mods),
             LocusZoom.Layouts.get("panel", "genes", { namespace: { "gene": "gene" } })

--- a/examples/phewas_forest.html
+++ b/examples/phewas_forest.html
@@ -59,7 +59,7 @@
         LocusZoom.Layouts.add("plot", "phewas_forest", {
             width: 800,
             height: 800,
-            responsive_resize: true,
+            responsive_resize: 'both',
             panels: [
                 {
                     id: "phewasforest",


### PR DESCRIPTION
See discussion on #43 .

Adds a new resize mode, "width_only". This is especially useful for dynamic layouts and annotation tracks, where height rescaling can cause panels to change height in inconsistent ways.