### PR TITLE
User-specified genes track filters

### DIFF
--- a/esm/components/data_layer/base.js
+++ b/esm/components/data_layer/base.js
@@ -659,6 +659,8 @@ class BaseDataLayer {
                 '>': (a, b) => a > b,
                 '>=': (a, b) => a >= b,
                 '%': (a, b) => a % b,
+                'in': (a, b) => b && b.includes(a),  // works for strings or arrays
+                'match': (a, b) => a && a.includes(b),
             };
             const extra = this.layer_state.extra_fields[this.getElementId(element)];
             const field_value = (new Field(field)).resolve(element, extra);

--- a/esm/components/data_layer/genes.js
+++ b/esm/components/data_layer/genes.js
@@ -74,7 +74,7 @@ class Genes extends BaseDataLayer {
      *   overlap in the view. A track is a row used to vertically separate overlapping genes.
      * @returns {Genes}
      */
-    assignTracks() {
+    assignTracks(data) {
         /**
          * Function to get the width in pixels of a label given the text and layout attributes
          * @param {String} gene_name
@@ -101,7 +101,7 @@ class Genes extends BaseDataLayer {
         this.tracks = 1;
         this.gene_track_index = { 1: [] };
 
-        this.data.map((item) => {
+        data.map((item) => {
             // If necessary, split combined gene id / version fields into discrete fields.
             // NOTE: this may be an issue with CSG's genes data source that may eventually be solved upstream.
             if (item.gene_id && item.gene_id.indexOf('.')) {
@@ -206,11 +206,9 @@ class Genes extends BaseDataLayer {
      */
     render() {
         const self = this;
-        this.assignTracks();
-
         // Apply filters to only render a specified set of points
         const track_data = this._applyFilters();
-
+        this.assignTracks(track_data);
         let width, height, x, y;
 
         // Render gene groups

--- a/esm/components/toolbar/widgets.js
+++ b/esm/components/toolbar/widgets.js
@@ -1370,7 +1370,8 @@ class DisplayOptions extends BaseWidget {
                     .on('click', () => {
                         // If an option is not specified in these display options, use the original defaults
                         allowed_fields.forEach((field_name) => {
-                            dataLayer.layout[field_name] = display_options[field_name] || defaultConfig[field_name];
+                            const has_option = typeof display_options[field_name] !== 'undefined';
+                            dataLayer.layout[field_name] = has_option ? display_options[field_name] : defaultConfig[field_name];
                         });
 
                         this._selected_item = row_id;

--- a/esm/data/adapters.js
+++ b/esm/data/adapters.js
@@ -651,7 +651,8 @@ class GwasCatalogLZ extends RemoteAdapter {
         //   But there can be more than one GWAS catalog version available in the same API, for the same build- an
         //   explicit config option will always take
         //   precedence.
-        const default_source = (build_option === 'GRCh38') ? 1 : 2;  // EBI GWAS catalog
+        // See: http://portaldev.sph.umich.edu/api/v1/annotation/gwascatalog/?format=objects
+        const default_source = (build_option === 'GRCh38') ? 5 : 6;  // EBI GWAS catalog
         const source = this.params.source || default_source;
         return `${this.url  }?format=objects&sort=pos&filter=id eq ${source} and chrom eq '${state.chr}' and pos ge ${state.start} and pos le ${state.end}`;
     }
@@ -739,8 +740,11 @@ class GeneLZ extends RemoteAdapter {
         let source = this.params.source;
         validateBuildSource(this.constructor.name, build, source);
 
-        if (build) { // If build specified, choose a known Portal API dataset IDs (build 37/38)
-            source = (build === 'GRCh38') ? 1 : 3;
+        if (build) {
+            // If build specified, we auto-select the best current portaldev API dataset for that build
+            // If build is not specified, we use the exact source ID provided by the user.
+            // See: https://portaldev.sph.umich.edu/api/v1/annotation/genes/sources/?format=objects
+            source = (build === 'GRCh38') ? 4 : 5;
         }
         return `${this.url}?filter=source in ${source} and chrom eq '${state.chr}' and start le ${state.end} and end ge ${state.start}`;
     }

--- a/esm/layouts/index.js
+++ b/esm/layouts/index.js
@@ -690,11 +690,13 @@ const genes_panel = {
     },
     toolbar: (function () {
         const base = deepCopy(standard_panel_toolbar);
-        base.widgets.push({
-            type: 'resize_to_data',
-            position: 'right',
-            button_html: 'Show all genes',
-        });
+        base.widgets.push(
+            {
+                type: 'resize_to_data',
+                position: 'right',
+                button_html: 'Fit all genes',
+            }
+        );
         return base;
     })(),
     data_layers: [

--- a/esm/layouts/index.js
+++ b/esm/layouts/index.js
@@ -350,6 +350,22 @@ const genes_layer = {
     id: 'genes',
     type: 'genes',
     fields: ['{{namespace[gene]}}all', '{{namespace[constraint]}}all'],
+    // By default this layer doesn't show everything, but a button is added to set filters to `null`- "show all"
+    filters: [
+        {
+            field: 'gene_type',
+            operator: 'in',
+            // A manually curated subset of Gencode biotypes, based on user suggestions
+            //  See full list: https://www.gencodegenes.org/human/stats.html
+            value: [
+                'protein_coding',
+                'IG_C_gene', 'IG_D_gene', 'IG_J_gene', 'IG_V_gene',
+                'TR_C_gene', 'TR_D_gene', 'TR_J_gene', 'TR_V_gene',
+                'rRNA',
+                'Mt_rRNA', 'Mt_tRNA',
+            ],
+        },
+    ],
     id_field: 'gene_id',
     behaviors: {
         onmouseover: [
@@ -428,6 +444,25 @@ const ldlz2_pop_selector_menu = {
         { display_name: 'EAS', value: 'EAS' },
         { display_name: 'EUR', value: 'EUR' },
         { display_name: 'SAS', value: 'SAS' },
+    ],
+};
+
+const gene_selector_menu = {
+    type: 'display_options',
+    position: 'right',
+    color: 'blue',
+    // Below: special config specific to this widget
+    button_html: 'Select...',
+    button_title: 'Choose which genes to show',
+    layer_name: 'genes',
+    default_config_display_name: 'Protein, RNA, or Immune',
+    options: [
+        {
+            display_name: 'All features',
+            display: {
+                filters: null,
+            },
+        },
     ],
 };
 
@@ -695,7 +730,8 @@ const genes_panel = {
                 type: 'resize_to_data',
                 position: 'right',
                 button_html: 'Fit all genes',
-            }
+            },
+            deepCopy(gene_selector_menu)
         );
         return base;
     })(),
@@ -872,6 +908,7 @@ export const tooltip = {
 
 export const toolbar_widgets = {
     ldlz2_pop_selector: ldlz2_pop_selector_menu,
+    gene_selector_menu,
 };
 
 export const toolbar = {

--- a/esm/layouts/index.js
+++ b/esm/layouts/index.js
@@ -452,10 +452,10 @@ const gene_selector_menu = {
     position: 'right',
     color: 'blue',
     // Below: special config specific to this widget
-    button_html: 'Select...',
+    button_html: 'Filter...',
     button_title: 'Choose which genes to show',
     layer_name: 'genes',
-    default_config_display_name: 'Protein, RNA, or Immune',
+    default_config_display_name: 'Functional elements',
     options: [
         {
             display_name: 'All features',

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
           <div id="lz-plot"></div>
         </div>
       </div>
-      <p>To see other forms of LocusZoom.js in action take a look at <a href="http://locuszoom.org/locuszoomjs.php">locuszoom.org</a> or the <a href="#examples">examples</a> on this page.</p>
+      <p>To see other forms of LocusZoom.js in action take a look at <a href="https://my.locuszoom.org/">https://my.locuszoom.org</a> or the <a href="#examples">examples</a> on this page.</p>
 
       <hr>
 

--- a/test/unit/data/test_adapters.js
+++ b/test/unit/data/test_adapters.js
@@ -318,7 +318,7 @@ describe('Data adapters', function () {
                 // HACK: This is the only part of these tests that differs between sources
                 let pattern;
                 if (source_name === 'GeneLZ') {
-                    pattern = /source in 1/;
+                    pattern = /source in 4/;
                 } else {
                     pattern = /id in 16/;
                 }


### PR DESCRIPTION
# Ticket
#199 

# Summary of changes
- Add new `in` and `match` fields so that genes can be filtered by, eg, text search or allowed matches
- Allow genes track to redo layout on render
- [x] Implement a filter widget on the default genes toolbar, incorporating a subset of interesting gene types'
- [x] Ensure that data sources work with the new field, including changing the default dataset IDs that reference the portaldev api