### PR TITLE
Expanded and revised conditional analysis feature

### DIFF
--- a/esm/components/data_layer/base.js
+++ b/esm/components/data_layer/base.js
@@ -212,6 +212,7 @@ class BaseDataLayer {
             this.layer_state.extra_fields[id] = {};
         }
         this.layer_state.extra_fields[id][key] = value;
+        this.parent.emit('element_annotation', { element: element, field: key, value }, true);
         return this;
     }
 

--- a/esm/components/panel.js
+++ b/esm/components/panel.js
@@ -222,7 +222,7 @@ class Panel {
         this.zoom_timeout = null;
 
         /**
-         * Known event hooks that the panel can respond to
+         * Known event hooks that the panel can respond to. See documentation of `on` for details.
          * @protected
          * @member {Object}
          */
@@ -232,6 +232,7 @@ class Panel {
             'data_rendered': [],
             'element_clicked': [],
             'element_selection': [],
+            'element_annotation': [],
             'match_requested': [], // A data layer is attempting to highlight matching points (internal use only)
         };
 
@@ -252,6 +253,9 @@ class Panel {
      *   - `element_clicked` - context: panel - A data element in any of the panel's data layers has been clicked.
      *   - `element_selection` - context: panel - Triggered when an element changes "selection" status, and identifies
      *        whether the element is being selected or deselected.
+     *   - `element_annotation` - Triggered when a point is annotated with a user-specified value (information that
+     *      doesn't come from the server, and can modify display in a way that is preserved across re-render).
+     *      Identifies the current value of the annotation.
      *
      * To register a hook for any of these events use `panel.on('event_name', function() {})`.
      *

--- a/esm/components/plot.js
+++ b/esm/components/plot.js
@@ -205,7 +205,7 @@ class Plot {
         this._external_listeners = new Map();
 
         /**
-         * Known event hooks that the panel can respond to
+         * Known event hooks that the panel can respond to. See documentation of `.on` for details.
          * @protected
          * @member {Object}
          */
@@ -214,7 +214,8 @@ class Plot {
             'data_requested': [], // A request has been made for new data from any data source used in the plot
             'data_rendered': [],  // Data from a request has been received and rendered in the plot
             'element_clicked': [], // Select or unselect
-            'element_selection': [], // Element becomes active (only)
+            'element_selection': [],
+            'element_annotation': [],
             'match_requested': [], // A data layer is attempting to highlight matching points (internal use only)
             'panel_removed': [],  // A panel has been removed (eg via the "x" button in plot)
             'region_changed': [], // The viewing region (chr/start/end) has been changed
@@ -256,7 +257,7 @@ class Plot {
      *   - `element_clicked` - context: plot - A data element in any of the plot's data layers has been clicked.
      *   - `element_selection` - context: plot - Triggered when an element changes "selection" status, and identifies
      *        whether the element is being selected or deselected.
-     *
+     *   - `element_annotation` - See description on `panel` (this event is bubbled up)
      * To register a hook for any of these events use `plot.on('event_name', function() {})`.
      *
      * There can be arbitrarily many functions registered to the same event. They will be executed in the order they

--- a/esm/components/toolbar/widgets.js
+++ b/esm/components/toolbar/widgets.js
@@ -311,6 +311,7 @@ class Button {
                 let top;
                 let left;
                 if (this.parent_toolbar.type === 'panel') {
+                    // FIXME: Logic seems to be buggy somewhere
                     top = (page_origin.y + toolbar_client_rect.height + (2 * padding));
                     left = Math.max(page_origin.x + this.parent_svg.layout.width - menu_client_rect.width - padding, page_origin.x + padding);
                 } else {

--- a/esm/components/toolbar/widgets.js
+++ b/esm/components/toolbar/widgets.js
@@ -1055,7 +1055,7 @@ class RemovePanel extends BaseWidget {
 
 /**
  * Button to move panel up relative to other panels (in terms of y-index on the page)
- *   NOTE: Will only work on panel widgets.
+ *   NOTE: Will only work on panel toolbars.
  */
 class MovePanelUp extends BaseWidget {
     update () {
@@ -1079,7 +1079,7 @@ class MovePanelUp extends BaseWidget {
 
 /**
  * Button to move panel down relative to other panels (in terms of y-index on the page)
- *   NOTE: Will only work on panel widgets.
+ *   NOTE: Will only work on panel toolbars.
  */
 class MovePanelDown extends BaseWidget {
     update () {

--- a/esm/ext/lz-widget-addons.js
+++ b/esm/ext/lz-widget-addons.js
@@ -272,26 +272,38 @@ function install(LocusZoom) {
 
     const covariates_model_tooltip = function () {
         const covariates_model_association = LocusZoom.Layouts.get('tooltip', 'standard_association', { unnamespaced: true });
-        covariates_model_association.html += '<a href="javascript:void(0);" onclick="LocusZoom.getToolTipPlot(this).CovariatesModel.add(LocusZoom.getToolTipData(this));">Condition on Variant</a><br>';
+        covariates_model_association.html += `<br><a href="javascript:void(0);" 
+                                              onclick="this.parentNode.__data__.getPlot().CovariatesModel.add(this.parentNode.__data__);">Add to Model</a><br>`;
         return covariates_model_association;
     }();
 
-    const covariates_model_plot = function () {
+    const covariates_model_toolbar = function () {
         const covariates_model_plot_toolbar = LocusZoom.Layouts.get('toolbar', 'standard_association', { unnamespaced: true });
         covariates_model_plot_toolbar.widgets.push({
             type: 'covariates_model',
             button_html: 'Model',
-            button_title: 'Show and edit covariates currently in model',
+            button_title: 'Use this feature to interactively build a model using variants from the data set',
             position: 'left',
         });
         return covariates_model_plot_toolbar;
+    }();
+
+    const covariates_model_plot = function () {
+        // Create a new JSON object based on
+        const base = LocusZoom.Layouts.get('plot', 'standard_association', { unnamespaced: true });
+        base.toolbar = covariates_model_toolbar;
+        const assoc_layer = base.panels[0].data_layers[2];
+        assoc_layer.tooltip = covariates_model_tooltip;
+        return base;
     }();
 
     LocusZoom.Widgets.add('covariates_model', CovariatesModel);
     LocusZoom.Widgets.add('data_layers', DataLayersWidget);
 
     LocusZoom.Layouts.add('tooltip', 'covariates_model_association', covariates_model_tooltip);
-    LocusZoom.Layouts.add('toolbar', 'covariates_model_plot', covariates_model_plot);
+    LocusZoom.Layouts.add('toolbar', 'covariates_model_toolbar', covariates_model_toolbar);
+
+    LocusZoom.Layouts.add('plot', 'covariates_association', covariates_model_plot);
 }
 
 if (typeof LocusZoom !== 'undefined') {

--- a/esm/ext/lz-widget-addons.js
+++ b/esm/ext/lz-widget-addons.js
@@ -116,6 +116,10 @@ function install(LocusZoom) {
                 if (!this._covariates.length) {
                     selector.append('i')
                         .text('no covariates in model');
+                    selector.append('br');
+                    selector.append('button')
+                        .attr('class', `lz-toolbar-button lz-toolbar-button-${this.layout.color}`)
+                        .text('Select top variant');
                 } else {
                     selector.append('h5')
                         .text(`Model Covariates (${this._covariates.length})`);
@@ -126,7 +130,7 @@ function install(LocusZoom) {
                             .attr('class', `lz-toolbar-button lz-toolbar-button-${this.layout.color}`)
                             .style('margin-left', '0em')
                             // TODO : The display name is not the same as the element id- make _covariates a list of data instead of strings
-                            .on('click', () => this._data_layer.setElementAnnotation('lz_is_covariate', covariate_id, false))
+                            .on('click', () => this._data_layer.setElementAnnotation(covariate_id, 'lz_is_covariate', false))
                             .text('×');
                         row.append('td')
                             .text(covariate_id);
@@ -134,12 +138,24 @@ function install(LocusZoom) {
                     selector.append('button')
                         .attr('class', `lz-toolbar-button lz-toolbar-button-${this.layout.color}`)
                         .style('margin-left', '4px')
-                        .html('× Remove All Covariates')
+                        .text('× Remove All Covariates')
                         .on('click', () => {
+                            // FIXME: clear annotations from the plot so that states remain in sync
+                            //  (add and remove covariate methods)
+                            // FIXME: make sure re-rendering happens after annos in a controlled fashion
+                            // FIXME: unlock plot x scroll when cleared
                             this._covariates = [];
                             this.updateWidget();
                         });
                 }
+                const add_variant = selector.append('div');
+                add_variant.append('input')
+                    .attr('placeholder', 'Add a variant');
+                add_variant.append('button')
+                    // FIXME: validation, trigger plot re-render, and clear text field. Possible tie to keyboard events (enter)
+                    // FIXME: Lock plot x-scroll when at least one covariate is selected
+                    .attr('class', `lz-toolbar-button lz-toolbar-button-${this.layout.color}`)
+                    .text('Add');
             });
 
             this.button.preUpdate = () => {

--- a/examples/misc/covariates_model.html
+++ b/examples/misc/covariates_model.html
@@ -48,7 +48,7 @@
           <ul class="top_hits" style="padding-left: 0.2rem; min-width: 110px;"></ul>
         </div>
         <div class="ten columns">
-          <div id="plot" data-region="10:114550452-115067678"></div>
+          <div id="lz-plot" data-region="10:114550452-115067678"></div>
         </div>
       </div>
 
@@ -62,8 +62,7 @@
 
     </div>
 
-    <script type="text/javascript">
-
+  <script type="text/javascript">
     // Define Data Sources
     var apiBase = "https://portaldev.sph.umich.edu/api/v1/";
     var data_sources = new LocusZoom.DataSources()
@@ -73,73 +72,14 @@
       .add("recomb", ["RecombLZ", { url: apiBase + "annotation/recomb/results/", params: { build: 'GRCh37' } }])
       .add("constraint", ["GeneConstraintLZ", { url: "https://gnomad.broadinstitute.org/api/", params: { build: 'GRCh37' } }]);
 
-    // Get the standard assocation plot layout from LocusZoom's built-in layouts
-    var mods = {
-      namespace: {
-        default: "assoc",
-        ld: "ld",
-        gene: "gene",
-        recomb: "recomb"
-      }
-    };
-    layout = LocusZoom.Layouts.get("plot", "standard_association", mods);
-
-    // Update HTML for variant tooltip to include "Add to Model" link
-    layout.panels[0].data_layers[2].tooltip.html = "<strong>{{assoc:variant|htmlescape}}</strong><br>"
-                                                 + "P Value: <strong>{{assoc:log_pvalue|logtoscinotation|htmlescape}}</strong><br>"
-                                                 + "Ref. Allele: <strong>{{assoc:ref_allele|htmlescape}}</strong><br>"
-                                                 + "<a href=\"javascript:void(0);\" onclick=\"this.parentNode.__data__.getPlot().CovariatesModel.add(this.parentNode.__data__);\">Add to Model</a><br>";
-
-    // Add covariates model button/menu to the plot-level toolbar
-    layout.toolbar.widgets.push({
-        type: "covariates_model",
-        button_html: "Model",
-        button_title: "Use this feature to interactively build a model using variants from the data set",
-        position: "left"
-    });
-
     // Generate the LocusZoom plot
-    var plot = LocusZoom.populate("#plot", data_sources, layout);
+    layout = LocusZoom.Layouts.get("plot", "covariates_association");
+    var plot = LocusZoom.populate("#lz-plot", data_sources, layout);
 
     // Add a basic loader to each panel (one that shows when data is requested and hides when one rendering)
     plot.layout.panels.forEach(function(panel){
       plot.panels[panel.id].addBasicLoader();
     });
-
-    // Create a method to parse a region string into a 600Kb genome range and load it
-    function jumpTo(region) {
-      var target = region.split(":");
-      var chr = target[0];
-      var pos = target[1];
-      var start = 0;
-      var end = 0;
-      if (!pos.match(/[-+]/)) {
-        start = +pos - 300000
-        end = +pos + 300000
-      }
-      plot.applyState({ chr: chr, start: start, end: end, ldrefvar: "" });
-      return false;
-    }
-
-    // Populate a list of top hits links for the plot
-    var top_hits = [
-      ["16:53819169", "FTO"],
-      ["9:22051670", "CDKN2A/B"],
-      ["7:28196413", "JAZF1"],
-      ["12:71433293", "TSPAN8"],
-      ["10:114758349", "TCF7L2"],
-      ["8:95937502", "TP53INP1"],
-      ["6:20679709", "CDKAL1"],
-      ["2:161346447", "RBMS1"],
-      ["16:75247245", "BCAR1"],
-      ["15:77832762", "HMG20A"],
-      ["7:15052860", "DGKB"]
-    ];
-    top_hits.forEach(function(hit){
-      d3.select("ul.top_hits").append("li")
-        .html("<a href=\"javascript:void(0);\" onclick=\"javascript:jumpTo('" + hit[0] + "');\">" + hit[1] + "</a>");
-    });
-
   </script>
 
   </body>


### PR DESCRIPTION
## Purpose
We would like to add a way to perform conditional analysis from within locuszoom.

Although an old demonstration existed, it was never fully implemented, and it revealed a number of design limitations in how LZ handles things like annotations. We should unify the demo with new mechanisms, implement calculations, and add several features.

## TODO:
- Add a display options button to toggle to display of results
- Fix various UI and alignment issues
- Lock scroll once model building starts
- Add a "suggest best" option that adds the LD ref var to the covariates list.
- Add a UI button to add user-specified variant, or search by various mechanisms.

## Summary of changes
- New `element_annotation` event allows external widgets to respond to annotations (user selected lists of significant points that are remembered across re-render: eg "use this element in a calculation and redraw it with a custom shape")
- [ ] Consider a "custom event" syntax that allows any event to be sent from custom widgets (no longer limit to pre-set event hooks). Example: "calculation complete" can be used to communicate with a data table, and show results only when some defined step in a UI flow is complete.
- [ ] Improve template syntax to support toggles like "add/remove" (#215)
- [ ] Implement conditional analysis calcs in raremetal.js
- [ ] Implement an LZ data source that uses the selected items to drive the calculation