### PR TITLE
Template enhancements: annotations and if/else blocks

### DIFF
--- a/assets/docs/interactivity.md
+++ b/assets/docs/interactivity.md
@@ -316,7 +316,7 @@ The first interactive feature that most LocusZoom users notice is the *tooltip*:
 
 In addition to showing data associated with a field, tooltips can be customized with interactive action links that modify `plot.state` (eg setting the LD reference variant), or trigger annotations (like showing a label).
 
-A tooltip is defined as an object describing when to display it, as well as the HTML template to render. It responds to the same LocusZoom template syntax supported elsewhere. For example, values can be embedded in the string with curly braces (`{{assoc:fieldname}}`) and a simple conditional syntax is supported to only render text if a value is defined: `{{#if sourcename:field_name}} Conditional text {{/if}}`.
+A tooltip is defined as an object describing when to display it, as well as the HTML template to render. It responds to the same LocusZoom template syntax supported elsewhere. For example, values can be embedded in the string with curly braces (`{{assoc:fieldname}}`) and a simple conditional syntax is supported to only render text if a value is defined: `{{#if sourcename:field_name}} Conditional text {{#else}} Optional else block {{/if}}`.
 
 ```javascript
 {

--- a/esm/components/data_layer/base.js
+++ b/esm/components/data_layer/base.js
@@ -532,7 +532,7 @@ class BaseDataLayer {
                         const f = new Field(option_layout.field);
                         let extra;
                         try {
-                            extra = this.layer_state && this.layer_state.extra_fields[this.getElementId(element_data)];
+                            extra = this.getElementAnnotation(element_data);
                         } catch (e) {
                             extra = null;
                         }
@@ -814,7 +814,7 @@ class BaseDataLayer {
             // Return the field value or annotation. If no `field` is specified, the filter function will operate on
             //  the entire data object. This behavior is only really useful with custom functions, because the
             //  builtin ones expect to receive a scalar value
-            const extra = this.layer_state.extra_fields[this.getElementId(item)];
+            const extra = this.getElementAnnotation(item);
             const field_value = field ? (new Field(field)).resolve(item, extra) : item;
             if (!test_func(field_value, target)) {
                 is_match = false;
@@ -828,13 +828,13 @@ class BaseDataLayer {
      *
      * @protected
      * @param {String|Object} element The data object or ID string for the element
-     * @param {String} key The name of the annotation to track
+     * @param {String} [key] The name of the annotation to track. If omitted, returns all annotations for this element as an object.
      * @return {*}
      */
     getElementAnnotation (element, key) {
         const id = this.getElementId(element);
         const extra = this.layer_state.extra_fields[id];
-        return extra && extra[key];
+        return key ? (extra && extra[key]) : extra;
     }
 
     /****** Private methods: rarely overridden or modified by external usages */

--- a/esm/components/data_layer/base.js
+++ b/esm/components/data_layer/base.js
@@ -990,7 +990,7 @@ class BaseDataLayer {
         this.tooltips[id].arrow = null;
         // Set the new HTML
         if (this.layout.tooltip.html) {
-            this.tooltips[id].selector.html(parseFields(d, this.layout.tooltip.html));
+            this.tooltips[id].selector.html(parseFields(this.layout.tooltip.html, d, this.getElementAnnotation(d)));
         }
         // If the layout allows tool tips on this data layer to be closable then add the close button
         // and add padding to the tooltip to accommodate it
@@ -1399,7 +1399,7 @@ class BaseDataLayer {
                 // Link to a dynamic URL
                 case 'link':
                     if (typeof behavior.href == 'string') {
-                        const url = parseFields(element, behavior.href);
+                        const url = parseFields(behavior.href, element, self.getElementAnnotation(element));
                         if (typeof behavior.target == 'string') {
                             window.open(url, behavior.target);
                         } else {

--- a/esm/components/data_layer/base.js
+++ b/esm/components/data_layer/base.js
@@ -138,11 +138,10 @@ class BaseDataLayer {
      * @param {object} [layout.tooltip.show] Define when to show a tooltip in terms of interaction states, eg, `{ or: ['highlighted', 'selected'] }`
      * @param {object} [layout.tooltip.hide] Define when to hide a tooltip in terms of interaction states, eg, `{ and: ['unhighlighted', 'unselected'] }`
      * @param {boolean} [layout.tooltip.closable] Whether a tool tip should render a "close" button in the upper right corner.
-     * @param {string} [layout.tooltip.html] HTML template to render inside the tool tip. The template syntax is
-     *   inspired by Mustache, including `{{sourcename:fieldname}} to insert a field value from the datum associated with
-     *   the tooltip/element. Conditional tags are also supported using the format:
-     *   `{{#if sourcename:fieldname}}render text here{{/if}}`.
-     *  This only checks if the value is present; it does not check if the value is truthy.
+     * @param {string} [layout.tooltip.html] HTML template to render inside the tool tip. The template syntax uses curly braces to allow simple expressions:
+     *   eg `{{sourcename:fieldname}} to insert a field value from the datum associated with
+     *   the tooltip/element. Conditional tags are supported using the format:
+     *   `{{#if sourcename:fieldname|transforms_can_be_used_too}}render text here{{#else}}Optional else branch{{/if}}`.
      * @param {'horizontal'|'vertical'|'top'|'bottom'|'left'|'right'} [layout.tooltip_positioning='horizontal'] Where to draw the tooltip relative to the datum.
      *  Typically tooltip positions are centered around the midpoint of the data element, subject to overflow off the edge of the plot.
      * @param {object} [layout.behaviors] LocusZoom data layers support the binding of mouse events to one or more

--- a/esm/components/data_layer/scatter.js
+++ b/esm/components/data_layer/scatter.js
@@ -417,7 +417,13 @@ class Scatter extends BaseDataLayer {
             .call(this.applyBehaviors.bind(this));
     }
 
-    // Method to set a passed element as the LD reference in the plot-level state
+    /**
+     * Method to set a passed element as the LD reference variant in the plot-level state. Triggers a re-render
+     *   so that the plot will update with the new LD information.
+     * This is useful in tooltips, eg the "make LD reference" action link for GWAS scatter plots.
+     * @param {object} element The data associated with a particular plot element
+     * @return {Promise}
+      */
     makeLDReference(element) {
         let ref = null;
         if (typeof element == 'undefined') {
@@ -433,7 +439,7 @@ class Scatter extends BaseDataLayer {
         } else {
             ref = element.toString();
         }
-        this.parent_plot.applyState({ ldrefvar: ref });
+        return this.parent_plot.applyState({ ldrefvar: ref });
     }
 }
 

--- a/esm/components/data_layer/scatter.js
+++ b/esm/components/data_layer/scatter.js
@@ -328,7 +328,7 @@ class Scatter extends BaseDataLayer {
 
             this.label_texts = this.label_groups.merge(groups_enter)
                 .append('text')
-                .text((d) => parseFields(d, data_layer.layout.label.text || ''))
+                .text((d) => parseFields(data_layer.layout.label.text || '', d, this.getElementAnnotation(d)))
                 .attr('x', (d) => {
                     return d[xcs]
                         + Math.sqrt(data_layer.resolveScalableParameter(data_layer.layout.point_size, d))

--- a/esm/components/panel.js
+++ b/esm/components/panel.js
@@ -1429,7 +1429,7 @@ class Panel {
             this.svg[`${axis}_axis_label`]
                 .attr('x', axis_params[axis].label_x)
                 .attr('y', axis_params[axis].label_y)
-                .text(parseFields(this.state, label))
+                .text(parseFields(label, this.state))
                 .attr('fill', 'currentColor');
             if (axis_params[axis].label_rotate !== null) {
                 this.svg[`${axis}_axis_label`]

--- a/esm/components/toolbar/widgets.js
+++ b/esm/components/toolbar/widgets.js
@@ -15,17 +15,19 @@ import {deepCopy} from '../../helpers/layouts';
  *
  * A widget is an empty div rendered on a toolbar that can display custom
  * html of user interface elements.
- * @param {('left'|'right')} [layout.position='left']  Whether to float the widget left or right.
- * @param {('start'|'middle'|'end')} [layout.group_position] Buttons can optionally be gathered into a visually
- *  distinctive group whose elements are closer together. If a button is identified as the start or end of a group,
- *  it will be drawn with rounded corners and an extra margin of spacing from any button not part of the group.
- *  For example, the region_nav_plot toolbar is a defined as a group.
- * @param {('gray'|'red'|'orange'|'yellow'|'green'|'blue'|'purple')} [layout.color='gray']  Color scheme for the
- *   widget. Applies to buttons and menus.
- * @param [layout.style] CSS styles that will be applied to the widget
- * @param {Toolbar} parent The toolbar that contains this widget
  */
 class BaseWidget {
+    /**
+     * @param {('left'|'right')} [layout.position='left']  Whether to float the widget left or right.
+     * @param {('start'|'middle'|'end')} [layout.group_position] Buttons can optionally be gathered into a visually
+     *  distinctive group whose elements are closer together. If a button is identified as the start or end of a group,
+     *  it will be drawn with rounded corners and an extra margin of spacing from any button not part of the group.
+     *  For example, the region_nav_plot toolbar is a defined as a group.
+     * @param {('gray'|'red'|'orange'|'yellow'|'green'|'blue'|'purple')} [layout.color='gray']  Color scheme for the
+     *   widget. Applies to buttons and menus.
+     * @param [layout.style] CSS styles that will be applied to the widget
+     * @param {Toolbar} parent The toolbar that contains this widget
+     */
     constructor(layout, parent) {
         /** @member {Object} */
         this.layout = layout || {};

--- a/esm/helpers/display.js
+++ b/esm/helpers/display.js
@@ -139,16 +139,18 @@ function prettyTicks(range, clip_range, target_tick_count) {
  *  Only works on scalar values in data! Will ignore non-scalars. This is useful in, eg, tooltip templates.
  *
  *  NOTE: Trusts content exactly as given. XSS prevention is the responsibility of the implementer.
- * @param {Object} data
  * @param {String} html A placeholder string in which to substitute fields. Supports several template options:
  *   `{{field_name}}` is a variable placeholder for the value of `field_name` from the provided data
  *   `{{#if field_name}} Conditional text {{/if}}` will insert the contents of the tag only if the value exists.
- *     Since this is only an existence check, **variables with a value of 0 will be evaluated as true**.
  *     This can be used with namespaced values, `{{#if assoc:field}}`; any dynamic namespacing will be applied when the
- *     layout is first retrieved.
+ *     layout is first retrieved. For numbers, transforms like `{{#if field|is_numeric}}` can help to ensure that 0
+ *     values are displayed when expected.
+ *     Can optionally take an else block, useful for things like toggle buttons: {{#if field}} ... {{#else}} ... {{/if}}
+ * @param {Object} data The data associated with a particular element. Eg, tooltips often appear over a specific point.
+ * @param {Object|null} extra Any additional fields (eg element annotations) associated with the specified datum
  * @returns {string}
  */
-function parseFields(data, html) {
+function parseFields(html, data, extra) {
     if (typeof data != 'object') {
         throw new Error('invalid arguments: data is not an object');
     }
@@ -218,7 +220,7 @@ function parseFields(data, html) {
 
     const resolve = function (variable) {
         if (!Object.prototype.hasOwnProperty.call(resolve.cache, variable)) {
-            resolve.cache[variable] = (new Field(variable)).resolve(data);
+            resolve.cache[variable] = (new Field(variable)).resolve(data, extra);
         }
         return resolve.cache[variable];
     };

--- a/esm/helpers/display.js
+++ b/esm/helpers/display.js
@@ -242,7 +242,7 @@ function parseFields(data, html) {
         } else if (node.condition) {
             try {
                 const condition = resolve(node.condition);
-                if (condition || condition === 0) {
+                if (condition) {
                     return node.then.map(render_node).join('');
                 } else if (node.else) {
                     return node.else.map(render_node).join('');

--- a/esm/helpers/transforms.js
+++ b/esm/helpers/transforms.js
@@ -126,6 +126,19 @@ export function htmlescape (value) {
 }
 
 /**
+ * Return true if the value is numeric (including 0)
+ *
+ * This is useful in template code, where we might wish to hide a field that is absent, but show numeric values even if they are 0
+ *   Eg, `{{#if value|is_numeric}}...{{/if}}
+ *
+ * @param {Number} value
+ * @return {boolean}
+ */
+export function is_numeric(value) {
+    return typeof value === 'number';
+}
+
+/**
  * URL-encode the provided text, eg for constructing hyperlinks
  * @param {String} value
  * @return {string}

--- a/esm/layouts/index.js
+++ b/esm/layouts/index.js
@@ -30,10 +30,11 @@ const standard_association_tooltip = {
     html: `<strong>{{{{namespace[assoc]}}variant|htmlescape}}</strong><br>
         P Value: <strong>{{{{namespace[assoc]}}log_pvalue|logtoscinotation|htmlescape}}</strong><br>
         Ref. Allele: <strong>{{{{namespace[assoc]}}ref_allele|htmlescape}}</strong><br>
+        {{#if {{namespace[ld]}}isrefvar}}<strong>LD Reference Variant</strong>{{#else}}
         <a href="javascript:void(0);" 
         onclick="var data = this.parentNode.__data__;
                  data.getDataLayer().makeLDReference(data);"
-                 >Make LD Reference</a><br>`,
+                 >Make LD Reference</a><br>{{/if}}`,
 };
 
 const standard_association_tooltip_with_label = function() {

--- a/esm/layouts/index.js
+++ b/esm/layouts/index.js
@@ -34,7 +34,7 @@ const standard_association_tooltip = {
         <a href="javascript:void(0);" 
         onclick="var data = this.parentNode.__data__;
                  data.getDataLayer().makeLDReference(data);"
-                 >Make LD Reference</a><br>{{/if}}`,
+                 >Make LD Reference</a>{{/if}}<br>`,
 };
 
 const standard_association_tooltip_with_label = function() {
@@ -45,7 +45,7 @@ const standard_association_tooltip_with_label = function() {
                   onclick="var item = this.parentNode.__data__, layer = item.getDataLayer(); 
                   var current = layer.getElementAnnotation(item, 'lz_show_label'); 
                   layer.setElementAnnotation(item, 'lz_show_label', !current );
-                  layer.parent_plot.applyState();">Toggle label</a>`;
+                  layer.parent_plot.applyState();">{{#if lz_show_label}}Hide{{#else}}Show{{/if}} label</a>`;
     return base;
 }();
 

--- a/test/unit/components/test_datalayer.js
+++ b/test/unit/components/test_datalayer.js
@@ -998,16 +998,21 @@ describe('LocusZoom.DataLayer', function () {
         it('can store user-defined marks for points that persist across re-renders', function () {
             const data_layer = this.plot.panels.p.data_layers.d;
             // Set the annotation for a point with id value of "a"
-            data_layer.setElementAnnotation({'d:id': 'a'}, 'custom_field', 'some_value');
+            const datum = { 'd:id': 'a' };
+            data_layer.setElementAnnotation(datum, 'custom_field', 'some_value');
 
             // Find the element annotation for this point via several different ways
             assert.equal(data_layer.layer_state.extra_fields['plot_p_d-a']['custom_field'], 'some_value', 'Found in internal storage (as elementID)');
-            assert.equal(data_layer.getElementAnnotation({'d:id': 'a'}, 'custom_field'), 'some_value', 'Found via helper method (from id_field)');
+            assert.equal(data_layer.getElementAnnotation(datum, 'custom_field'), 'some_value', 'Found via helper method (from id_field)');
             assert.equal(data_layer.getElementAnnotation({'d:id': 'b'}, 'custom_field'), null, 'If no annotation found, returns null. Annotation does not return actual field values.');
-            assert.equal(data_layer.getElementAnnotation({'d:id': 'a'}, 'custom_field'), 'some_value', 'Found via helper method (as data object)');
+            assert.equal(data_layer.getElementAnnotation(datum, 'custom_field'), 'some_value', 'Found via helper method (as data object)');
+
+            // If a datum (but no field) is specified, it will return the appropriate result
+            assert.deepEqual(data_layer.getElementAnnotation(datum), {custom_field: 'some_value'}, 'When no key is specified, return object with all annotations');
+            assert.deepEqual(data_layer.getElementAnnotation({'d:id': 'b'}), undefined, 'When no key is specified, and no annotations exist, then return nothing');
 
             return this.plot.applyState().then(function() {
-                assert.equal(data_layer.getElementAnnotation({'d:id': 'a'}, 'custom_field'), 'some_value', 'Annotations persist across renderings');
+                assert.equal(data_layer.getElementAnnotation(datum, 'custom_field'), 'some_value', 'Annotations persist across renderings');
             });
         });
 

--- a/test/unit/helpers/test_display.js
+++ b/test/unit/helpers/test_display.js
@@ -184,14 +184,23 @@ describe('Display and parsing helpers', function () {
 {{foo:field_x}}{{#else}}{{#if foo:field_1}}bar{{/if}} extra_tokens {{bar:field2}}{{/if}}`;
             const expected_value2 = 'bar extra_tokens foo';
             assert.equal(parseFields(data, html2), expected_value2, 'Else blocks follow nesting rules and can contain arbitrary additional tokens');
+
+            const html3 = '{{#if foo:field_x}}{{#else}}bare else{{/if}}';
+            const expected_value3 = 'bare else';
+            assert.equal(parseFields(data, html3), expected_value3, 'Else blocks work with empty if');
         });
-        it('should treat 0 as truthy in conditions', function() {
+        it('should allow filters on values, eg 0 is_numeric', function() {
             const data = {
                 'foo': 0,
             };
+
             const html = 'a{{#if foo}}{{foo}}{{/if}}';
-            const expected_value = 'a0';
-            assert.equal(parseFields(data, html), expected_value);
+            const expected_value = 'a';
+            assert.equal(parseFields(data, html), expected_value, '0 is falsy under normal circumstances');
+
+            const html2 = 'a{{#if foo|is_numeric}}{{foo}}{{/if}}';
+            const expected_value2 = 'a0';
+            assert.equal(parseFields(data, html2), expected_value2, 'A filter can modify the value to be truthy');
         });
         it('should treat broken/non-existent conditions as false', function() {
             const data = {

--- a/test/unit/helpers/test_display.js
+++ b/test/unit/helpers/test_display.js
@@ -171,6 +171,20 @@ describe('Display and parsing helpers', function () {
             const expected_value2 = 'A2<br>B2<br>';
             assert.equal(parseFields(data2, html2), expected_value2);
         });
+        it('should handle else in conditions', function () {
+            const data = {
+                'foo:field_1': 1234,
+                'bar:field2': 'foo',
+            };
+            const html = '{{#if foo:field_2}}{{foo:field_2}}{{#else}}{{bar:field2}}{{/if}}';
+            const expected_value = 'foo';
+            assert.equal(parseFields(data, html), expected_value, 'Else block is rendered');
+
+            const html2 = `{{#if foo:field_x}}
+{{foo:field_x}}{{#else}}{{#if foo:field_1}}bar{{/if}} extra_tokens {{bar:field2}}{{/if}}`;
+            const expected_value2 = 'bar extra_tokens foo';
+            assert.equal(parseFields(data, html2), expected_value2, 'Else blocks follow nesting rules and can contain arbitrary additional tokens');
+        });
         it('should treat 0 as truthy in conditions', function() {
             const data = {
                 'foo': 0,
@@ -179,7 +193,7 @@ describe('Display and parsing helpers', function () {
             const expected_value = 'a0';
             assert.equal(parseFields(data, html), expected_value);
         });
-        it('should treat broken/non-existant conditions as false', function() {
+        it('should treat broken/non-existent conditions as false', function() {
             const data = {
                 'foo:field_1': 12345,
                 'bar:field2': 'foo',

--- a/test/unit/helpers/test_display.js
+++ b/test/unit/helpers/test_display.js
@@ -93,10 +93,10 @@ describe('Display and parsing helpers', function () {
         });
         it('should require that data be present and be an object', function() {
             assert.throws(function() {
-                parseFields('foo', 'html');
+                parseFields('html', 'foo');
             });
             assert.throws(function() {
-                parseFields(123, 'html');
+                parseFields('html', 123);
             });
         });
         it('should require that html be present and be a string', function() {
@@ -104,32 +104,40 @@ describe('Display and parsing helpers', function () {
                 parseFields({}, {});
             });
             assert.throws(function() {
-                parseFields({}, 123);
+                parseFields(123, {});
             });
             assert.throws(function() {
-                parseFields({}, null);
+                parseFields(null, {});
             });
         });
         it('should return html untouched if passed a null or empty data object', function() {
-            assert.equal(parseFields(null, 'foo'), 'foo');
-            assert.equal(parseFields({}, 'foo'), 'foo');
+            assert.equal(parseFields('foo', null), 'foo');
+            assert.equal(parseFields('foo', {}), 'foo');
         });
         it('should parse every matching scalar field from a data object into the html string', function() {
             let data, html, expected_value;
             data = { field1: 123, field2: 'foo' };
             html = '<strong>{{field1}} and {{field2}}</strong>';
             expected_value = '<strong>123 and foo</strong>';
-            assert.equal(parseFields(data, html), expected_value);
+            assert.equal(parseFields(html, data), expected_value);
             html = '<strong>{{field1}} and {{field2}} or {{field1}}{{field1}}</strong>';
             expected_value = '<strong>123 and foo or 123123</strong>';
-            assert.equal(parseFields(data, html), expected_value);
+            assert.equal(parseFields(html, data), expected_value);
+        });
+        it('should consider fields in both data and annotations where appropriate', function() {
+            const data = { field1: 123, field2: 'fire' };
+            const annotations = { field3: 'squid' };
+
+            const template = '<strong>{{field2}} {{field3}} {{no_match}}</strong>';
+            const expected_value = '<strong>fire squid </strong>';
+            assert.equal(parseFields(template, data, annotations), expected_value, 'Uses fields from annotations and hides nonexistent fields');
         });
         it('should skip parsing of non-scalar fields but not throw an error', function() {
             let data, html, expected_value;
             data = { field1: 123, field2: 'foo', field3: { foo: 'bar' }, field4: [ 4, 5, 6 ], field5: true, field6: NaN };
             html = '<strong>{{field1}}, {{field2}}, {{field3}}, {{field4}}, {{field5}}, {{field6}}</strong>';
             expected_value = '<strong>123, foo, {{field3}}, {{field4}}, true, NaN</strong>';
-            assert.equal(parseFields(data, html), expected_value);
+            assert.equal(parseFields(html, data), expected_value);
         });
         it('should parse all fields that match the general field pattern whether explicitly present in the data object or not', function() {
             const data = {
@@ -138,7 +146,7 @@ describe('Display and parsing helpers', function () {
             };
             const html = '<strong>{{foo:field_1}} and {{bar:field2}}, {{bar:field2|herp|derp}}; {{field3}}</strong>';
             const expected_value = '<strong>123 and foo, fooherpderp; </strong>';
-            assert.equal(parseFields(data, html), expected_value);
+            assert.equal(parseFields(html, data), expected_value);
         });
         it('should hide non-existent fields but show broken ones', function() {
             const data = {
@@ -147,7 +155,7 @@ describe('Display and parsing helpers', function () {
             };
             const html = '{{bar:field2||nope|}}{{wat}}{{bar:field2|herp||derp}}';
             const expected_value = '{{bar:field2||nope|}}{{bar:field2|herp||derp}}';
-            assert.equal(parseFields(data, html), expected_value);
+            assert.equal(parseFields(html, data), expected_value);
         });
         it('should handle conditional blocks', function() {
             const data = {
@@ -159,7 +167,7 @@ describe('Display and parsing helpers', function () {
                 + '{{#if nope}}wat{{/if}}'
                 + '{{bar:field2|herp|derp}}; {{field3}}</strong>{{/if}}';
             const expected_value = '<strong>1234 and foo, fooherpderp; </strong>';
-            assert.equal(parseFields(data, html), expected_value);
+            assert.equal(parseFields(html, data), expected_value);
             const data2 = {
                 'fieldA': '',
                 'fieldB': '',
@@ -169,7 +177,7 @@ describe('Display and parsing helpers', function () {
                 + '{{#if foo:fieldB}}B1<br>{{/if}}'
                 + '{{#if foo:fieldB|derp}}B2<br>{{/if}}';
             const expected_value2 = 'A2<br>B2<br>';
-            assert.equal(parseFields(data2, html2), expected_value2);
+            assert.equal(parseFields(html2, data2), expected_value2);
         });
         it('should handle else in conditions', function () {
             const data = {
@@ -178,16 +186,16 @@ describe('Display and parsing helpers', function () {
             };
             const html = '{{#if foo:field_2}}{{foo:field_2}}{{#else}}{{bar:field2}}{{/if}}';
             const expected_value = 'foo';
-            assert.equal(parseFields(data, html), expected_value, 'Else block is rendered');
+            assert.equal(parseFields(html, data), expected_value, 'Else block is rendered');
 
             const html2 = `{{#if foo:field_x}}
 {{foo:field_x}}{{#else}}{{#if foo:field_1}}bar{{/if}} extra_tokens {{bar:field2}}{{/if}}`;
             const expected_value2 = 'bar extra_tokens foo';
-            assert.equal(parseFields(data, html2), expected_value2, 'Else blocks follow nesting rules and can contain arbitrary additional tokens');
+            assert.equal(parseFields(html2, data), expected_value2, 'Else blocks follow nesting rules and can contain arbitrary additional tokens');
 
             const html3 = '{{#if foo:field_x}}{{#else}}bare else{{/if}}';
             const expected_value3 = 'bare else';
-            assert.equal(parseFields(data, html3), expected_value3, 'Else blocks work with empty if');
+            assert.equal(parseFields(html3, data), expected_value3, 'Else blocks work with empty if');
         });
         it('should allow filters on values, eg 0 is_numeric', function() {
             const data = {
@@ -196,11 +204,11 @@ describe('Display and parsing helpers', function () {
 
             const html = 'a{{#if foo}}{{foo}}{{/if}}';
             const expected_value = 'a';
-            assert.equal(parseFields(data, html), expected_value, '0 is falsy under normal circumstances');
+            assert.equal(parseFields(html, data), expected_value, '0 is falsy under normal circumstances');
 
             const html2 = 'a{{#if foo|is_numeric}}{{foo}}{{/if}}';
             const expected_value2 = 'a0';
-            assert.equal(parseFields(data, html2), expected_value2, 'A filter can modify the value to be truthy');
+            assert.equal(parseFields(html2, data), expected_value2, 'A filter can modify the value to be truthy');
         });
         it('should treat broken/non-existent conditions as false', function() {
             const data = {
@@ -209,9 +217,9 @@ describe('Display and parsing helpers', function () {
             };
             const html = 'a{{#if foo:field_3}}b{{/if}}c';
             const expected_value = 'ac';
-            assert.equal(parseFields(data, html), expected_value);
+            assert.equal(parseFields(html, data), expected_value);
             const html2 = 'a{{#if foo:field_1|nope}}b{{/if}}c';
-            assert.equal(parseFields(data, html2), expected_value);
+            assert.equal(parseFields(html2, data), expected_value);
         });
         it('should handle nasty input', function() {
             const data = {
@@ -225,7 +233,7 @@ describe('Display and parsing helpers', function () {
             const expected_value = '{{#iff foo:field_1}}<strong>{{12345}}'
                 + ' and {{bar:field2||nope|}}, '
                 + '{{#if }}';
-            assert.equal(parseFields(data, html), expected_value);
+            assert.equal(parseFields(html, data), expected_value);
         });
     });
 

--- a/test/unit/test_transforms.js
+++ b/test/unit/test_transforms.js
@@ -48,12 +48,15 @@ describe('Transformation Functions', function() {
     });
 
     describe('is_numeric', function () {
-        it('should special-case zero as a truthy value, so that numbers display in tables', function () {
+        it('should return true for numbers and false for strings that look like numbers', function () {
             const scenarios = [
                 [12, true],
                 [0, true],
                 [1.23, true],
+                [Infinity, true],
+                [NaN, true], // On the fence about this one, but it *is* a float value...
                 ['12', false],
+                ['aaa', false],
             ];
 
             for ( let [value, expected] of scenarios) {

--- a/test/unit/test_transforms.js
+++ b/test/unit/test_transforms.js
@@ -1,5 +1,5 @@
 import {assert} from 'chai';
-import {htmlescape, neglog10, scinotation} from '../../esm/helpers/transforms';
+import {htmlescape, is_numeric, neglog10, scinotation} from '../../esm/helpers/transforms';
 
 describe('Transformation Functions', function() {
 
@@ -44,6 +44,21 @@ describe('Transformation Functions', function() {
                 htmlescape("<script type=\"application/javascript\">alert('yo & ' + `I`)</script>"),
                 '&lt;script type=&quot;application/javascript&quot;&gt;alert(&#039;yo &amp; &#039; + &#x60;I&#x60;)&lt;/script&gt;'
             );
+        });
+    });
+
+    describe('is_numeric', function () {
+        it('should special-case zero as a truthy value, so that numbers display in tables', function () {
+            const scenarios = [
+                [12, true],
+                [0, true],
+                [1.23, true],
+                ['12', false],
+            ];
+
+            for ( let [value, expected] of scenarios) {
+                assert.equal(is_numeric(value), expected, `${value} should yield ${expected}`);
+            }
         });
     });
 });


### PR DESCRIPTION
Ticket: #215

# Purpose
Many tooltips provide interactive controls (make LD reference, show/hide label, etc). 

We would like these controls to better reflect the current state of the system. This consists of three pieces:

* Rendering annotations (like "show label for this point") can now be used as fields in tooltips. Previously, tooltips could only use data sent from the adapter.
* `{{#if}}` blocks now support an `{{#else}}` branch. This makes it easier to write toggles like "show/hide".
* 0 values are no longer treated as truthy. This is because some adapters used 0 in the boolean sense and others in the numeric sense. The new `is_numeric` template function can be used for cases where meaning needs to be expressed more clearly.

# Breaking changes
Numeric values (0) are no longer special-cased to be truthy; this subtly bent the rules of javascript in ways that were not always the best choice for all use cases.

Instead, numeric fields should use `{{#if value|is_numeric}}` as a truthiness test, when they want to show an optional field whose value might be 0.