### PR TITLE
[WIP] Multi-LD

### DIFF
--- a/esm/data/adapters.js
+++ b/esm/data/adapters.js
@@ -530,16 +530,14 @@ class LDServer extends BaseApiAdapter {
 
         // Since LD information may be shared across multiple assoc sources with different namespaces,
         //   we use regex to find columns to join on, rather than requiring exact matches
-        const exactMatch = function (arr) {
+        const exactMatch = function (field_names) {
             return function () {
                 const regexes = arguments;
                 for (let i = 0; i < regexes.length; i++) {
                     const regex = regexes[i];
-                    const m = arr.filter(function (x) {
-                        return x.match(regex);
-                    });
-                    if (m.length) {
-                        return m[0];
+                    const m = field_names.find((x) => x.match(regex));
+                    if (m) {
+                        return m;
                     }
                 }
                 return null;
@@ -549,7 +547,7 @@ class LDServer extends BaseApiAdapter {
             id: this.params.id_field,
             position: this.params.position_field,
             pvalue: this.params.pvalue_field,
-            _names_:null,
+            _names_: null,
         };
         if (chain && chain.body && chain.body.length > 0) {
             const names = Object.keys(chain.body[0]);
@@ -766,7 +764,7 @@ class LDServer extends BaseApiAdapter {
         let url = this.getURL(state, chain, fields);
         let combined = { data: {} };
         let chainRequests = function (url) {
-            return fetch(url).then().then((response) => {
+            return fetch(url).then((response) => {
                 if (!response.ok) {
                     throw new Error(response.statusText);
                 }
@@ -785,6 +783,15 @@ class LDServer extends BaseApiAdapter {
         return chainRequests(url);
     }
 }
+
+//
+// class LDServerMulti extends LDServer {
+//     // getURL is relative to refvar
+//     // One fetchRequest per variant....
+//     //  So essentially fetchRequest needs to return one or more items, and combineChainBody needs to combine one or more items
+//     // Parsing also needs to handle a series of promises, not just one
+// }
+
 
 /**
  * Fetch GWAS catalog data for a list of known variants, and align the data with previously fetched association data.

--- a/esm/ext/lz-multi-ld.js
+++ b/esm/ext/lz-multi-ld.js
@@ -1,0 +1,104 @@
+/**
+ * Widgets and layouts for showing LD relative to more than one variant
+ *
+ *
+ * ### Features provided
+ * * TODO: Write this
+ *
+ * ### Loading and usage
+ * The page must incorporate and load all libraries before this file can be used, including:
+ * - Vendor assets
+ * - LocusZoom
+ *
+ * To use in an environment without special JS build tooling, simply load the extension file as JS from a CDN (after any dependencies):
+ * ```
+ * <script src="https://cdn.jsdelivr.net/npm/locuszoom@INSERT_VERSION_HERE/dist/ext/lz-multi-ld.min.js" type="application/javascript"></script>
+ * ```
+ *
+ * To use with ES6 modules, the plugin must be loaded and registered explicitly before use:
+ * ```
+ * import LocusZoom from 'locuszoom';
+ * import LzMultiLD from 'locuszoom/esm/ext/lz-multi-ld';
+ * LocusZoom.use(LzMultiLD);
+ * ```
+ *
+ * Then use the widgets and layouts provided by this extension
+ *
+ * @module
+ */
+
+function install(LocusZoom) {
+    const assoc_pvalues_multi_ld_layer = LocusZoom.Layouts.get('data_layer', 'association_pvalues', {
+        unnamespaced:true,
+        legend: [
+            {
+                shape: 'ribbon',
+                label: 'One SNP',
+                width: 30,
+                height: 5,
+                color_stops: ['#357ebd', '#46b8da', '#5cb85c', '#eea236', '#d43f3a'],
+                tick_labels: [0, 0.2, 0.4, 0.6, 0.8, 1.0],
+                label_size: 10,
+            },
+            {
+                shape: 'ribbon',
+                label: 'SNP Blue',
+                width: 30,
+                height: 5,
+                // color_stops: ['#357ebd', '#46b8da', '#5cb85c', '#eea236', '#d43f3a'],
+                color_stops: ['#eff3ff', '#bdd7e7', '#6baed6', '#3182bd', '#08519c'],
+                tick_labels: [0, 0.2, 0.4, 0.6, 0.8, 1.0],
+                label_size: 10,
+            },
+            {
+                shape: 'ribbon',
+                label: 'SNP Green',
+                width: 30,
+                height: 5,
+                color_stops: ['#edf8e9', '#bae4b3', '#74c476', '#31a354', '#006d2c'],
+                label_size: 10,
+            },
+            {
+                shape: 'ribbon',
+                label: 'SNP Red',
+                width: 30,
+                height: 5,
+                color_stops: ['#feedde', '#fdbe85', '#fd8d3c', '#e6550d', '#a63603'],
+                label_size: 10,
+            },
+            {
+                shape: 'ribbon',
+                label: 'SNP Purple',
+                width: 30,
+                height: 5,
+                color_stops: ['#f2f0f7', '#cbc9e2', '#9e9ac8', '#756bb1', '#54278f'],
+                label_size: 10,
+            },
+            { shape: 'diamond', color: '#9632b8', size: 40, label: 'LD Ref Var', label_size: 10, class: 'lz-data_layer-scatter' },
+            { shape: 'circle', color: '#B8B8B8', size: 40, label: 'no r² data', label_size: 10, class: 'lz-data_layer-scatter' },
+        ],
+    });
+
+    const assoc_pvalues_multi_ld_panel = function () {
+        const base = LocusZoom.Layouts.get('panel', 'association', {
+            height: 300,
+            legend: { padding: 4, hidden: false },
+        });
+        // Replace standard assoc panel with multi LD version.
+        base.data_layers[2] = assoc_pvalues_multi_ld_layer;
+        return base;
+    }();
+
+    LocusZoom.Layouts.add('data_layer', 'assoc_pvalues_multi_ld', assoc_pvalues_multi_ld_layer);
+    LocusZoom.Layouts.add('panel', 'association_multi_ld', assoc_pvalues_multi_ld_panel);
+}
+
+if (typeof LocusZoom !== 'undefined') {
+    // Auto-register the plugin when included as a script tag. ES6 module users must register via LocusZoom.use()
+    // eslint-disable-next-line no-undef
+    LocusZoom.use(install);
+}
+
+
+export default install;
+

--- a/esm/ext/lz-multi-ld.js
+++ b/esm/ext/lz-multi-ld.js
@@ -27,26 +27,77 @@
  * @module
  */
 
+import * as d3 from 'd3';
+
+
 function install(LocusZoom) {
+
+
+    /**
+     * (**extension**) Color an LD reference variant based on two fields: LD refvar, and correlation value
+     *
+     * @alias module:LocusZoom_ScaleFunctions~multi_ld_bins
+     * @param {Object} parameters This function has no defined configuration options
+     * @param {Array} parameters.categories  Array of possible category names, eg "variant1, variant2"
+     *   Each category has its own set of possible output `values`
+     * @param {Number[]} parameters.breaks Array of numerical breakpoints against which to evaluate the input value
+     *    Must be of equal length as each possible set of options in values (eg, values[0].length)
+     * @param {Array} parameters.values  Array of possible sets of return values: each category has its own set of values.
+     *   Once category is determined, the set of options is evaluated relative to breakpoints.
+     *   "Values" must be a nested array with the same number of entries as `categories`, and each array in values should be an array with the same number of entries as `breaks`.
+     *   Each entry n represents the value to return if the input value is greater than
+     *   or equal to break n and less than or equal to break n+1 (or break n+1 doesn't exist).
+     *
+     * @param {Array} item_data An array containing two field values that will be resolved into an output: [category_name, numerical_value]
+     * @see {@link module:ext/lz-multi-ld} for required extension and installation instructions
+     */
+    const ld_multi_bin = function (parameters, item_data) {
+        const [category_field, value_field] = item_data;
+        if (!category_field) {
+            // In multi-LD, some variants won't have LD info, and thus they won't match any category
+            return null;
+        }
+
+        const categories = parameters.categories;
+        const breaks = parameters.breaks;
+        const category_to_use = categories.indexOf(category_field);
+        if (category_to_use === -1) {
+            return null;
+        }
+        const values = parameters.values[category_to_use];
+
+        if (typeof value_field == 'undefined' || value_field === null || isNaN(+value_field)) {
+            return null;
+        }
+        const threshold = breaks.reduce(function (prev, curr) {
+            if (+value_field < prev || (+value_field >= prev && +value_field < curr)) {
+                return prev;
+            } else {
+                return curr;
+            }
+        });
+        return values[breaks.indexOf(threshold)];
+    };
+
     const assoc_pvalues_multi_ld_layer = LocusZoom.Layouts.get('data_layer', 'association_pvalues', {
         unnamespaced:true,
         legend: [
-            {
-                shape: 'ribbon',
-                label: 'One SNP',
-                width: 30,
-                height: 5,
-                color_stops: ['#357ebd', '#46b8da', '#5cb85c', '#eea236', '#d43f3a'],
-                tick_labels: [0, 0.2, 0.4, 0.6, 0.8, 1.0],
-                label_size: 10,
-            },
+            // {
+            //     shape: 'ribbon',
+            //     label: 'One SNP',
+            //     width: 30,
+            //     height: 5,
+            //     color_stops: ['#357ebd', '#46b8da', '#5cb85c', '#eea236', '#d43f3a'],
+            //     tick_labels: [0, 0.2, 0.4, 0.6, 0.8, 1.0],
+            //     label_size: 10,
+            // },
             {
                 shape: 'ribbon',
                 label: 'SNP Blue',
                 width: 30,
                 height: 5,
                 // color_stops: ['#357ebd', '#46b8da', '#5cb85c', '#eea236', '#d43f3a'],
-                color_stops: ['#eff3ff', '#bdd7e7', '#6baed6', '#3182bd', '#08519c'],
+                color_stops: d3.schemeBlues[9].slice(2, 7),
                 tick_labels: [0, 0.2, 0.4, 0.6, 0.8, 1.0],
                 label_size: 10,
             },
@@ -55,7 +106,7 @@ function install(LocusZoom) {
                 label: 'SNP Green',
                 width: 30,
                 height: 5,
-                color_stops: ['#edf8e9', '#bae4b3', '#74c476', '#31a354', '#006d2c'],
+                color_stops: d3.schemeGreens[9].slice(2, 7),
                 label_size: 10,
             },
             {
@@ -63,7 +114,7 @@ function install(LocusZoom) {
                 label: 'SNP Red',
                 width: 30,
                 height: 5,
-                color_stops: ['#feedde', '#fdbe85', '#fd8d3c', '#e6550d', '#a63603'],
+                color_stops: d3.schemeOranges[9].slice(2, 7),
                 label_size: 10,
             },
             {
@@ -71,11 +122,36 @@ function install(LocusZoom) {
                 label: 'SNP Purple',
                 width: 30,
                 height: 5,
-                color_stops: ['#f2f0f7', '#cbc9e2', '#9e9ac8', '#756bb1', '#54278f'],
+                color_stops: d3.schemePurples[9].slice(2, 7),
                 label_size: 10,
             },
             { shape: 'diamond', color: '#9632b8', size: 40, label: 'LD Ref Var', label_size: 10, class: 'lz-data_layer-scatter' },
             { shape: 'circle', color: '#B8B8B8', size: 40, label: 'no r² data', label_size: 10, class: 'lz-data_layer-scatter' },
+        ],
+        color: [
+            {
+                scale_function: 'if',
+                field: '{{namespace[ld]}}isrefvar',
+                parameters: {
+                    field_value: 1,
+                    then: '#9632b8',
+                },
+            },
+            {
+                scale_function: 'ld_multi_bin',
+                field: ['{{namespace[ld]}}refvarname', '{{namespace[ld]}}state'],
+                parameters: {
+                    categories: ['10:114734096_A/G', '10:114758349_C/T', '10:114788436_C/T', '10:114861304_A/G'],
+                    breaks: [0, 0.2, 0.4, 0.6, 0.8, 1.0],
+                    values: [
+                        d3.schemeBlues[9].slice(2, 7),
+                        d3.schemeGreens[9].slice(2, 7),
+                        d3.schemeOranges[9].slice(2, 7),
+                        d3.schemePurples[9].slice(2, 7),
+                    ],
+                },
+            },
+            '#B8B8B8',
         ],
     });
 
@@ -89,6 +165,7 @@ function install(LocusZoom) {
         return base;
     }();
 
+    LocusZoom.ScaleFunctions.add('ld_multi_bin', ld_multi_bin);
     LocusZoom.Layouts.add('data_layer', 'assoc_pvalues_multi_ld', assoc_pvalues_multi_ld_layer);
     LocusZoom.Layouts.add('panel', 'association_multi_ld', assoc_pvalues_multi_ld_panel);
 }

--- a/esm/layouts/index.js
+++ b/esm/layouts/index.js
@@ -695,7 +695,6 @@ const association_panel = {
     legend: {
         orientation: 'vertical',
         origin: { x: 55, y: 40 },
-        hidden: true,
     },
     interaction: {
         drag_background_to_pan: true,

--- a/examples/misc/ext-multi_ld.html
+++ b/examples/misc/ext-multi_ld.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="//fonts.googleapis.com/css?family=Raleway:400,300,600" rel="stylesheet" type="text/css">
+    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/skeleton/2.0.4/skeleton.css"/>
+
+    <!-- Necessary includes for LocusZoom.js -->
+    <link rel="stylesheet" href="../../dist/locuszoom.css" type="text/css"/>
+    <script src="https://cdn.jsdelivr.net/npm/d3@^5.16.0" type="text/javascript"></script>
+    <script src="../../dist/locuszoom.app.min.js" type="text/javascript"></script>
+    <script type="application/javascript" src="../../dist/ext/lz-dynamic-urls.min.js"></script>
+    <script type="application/javascript" src="../../dist/ext/lz-multi-ld.min.js"></script>
+
+    <title>LocusZoom.js ~ Multiple LD Reference Variants</title>
+
+    <style>
+      body {
+        background-color: #FAFAFA;
+        margin: 0px 20px;
+      }
+      img {
+        max-width: 100%;
+        box-sizing: border-box;
+      }
+    </style>
+
+  </head>
+
+  <body>
+    <div>
+
+      <h1 style="margin-top: 1em;"><strong>LocusZoom.js</strong></h1>
+
+      <h3 style="float: left; color: #777">Multiple LD Reference Variants</h3>
+      <h6 style="float: right;"><a href="../../index.html">&lt; return home</a></h6>
+
+      <hr style="clear: both;">
+
+      <p>Users can choose to calculate LD based on more than one reference variant. This is very
+        useful when there are multiple (independent) signals in the same region.</p>
+      <div id="lz-plot" class="lz-container-responsive"></div>
+
+      <hr>
+
+      <div class="row">
+        <footer style="text-align: center;">
+          &copy; Copyright <script>document.write(new Date().getFullYear())</script> <a href="https://github.com/statgen">The University of Michigan Center for Statistical Genetics</a><br>
+        </footer>
+      </div>
+
+      <script type="text/javascript">
+        // Determine if we're online, based on browser state or presence of an optional query parameter
+        var online = !(typeof navigator != "undefined" && !navigator.onLine);
+        if (window.location.search.indexOf("offline") != -1){ online = false; }
+
+        // Define LocusZoom Data Sources object differently depending on online status
+        var apiBase, data_sources;
+        if (online) {
+          apiBase = "https://portaldev.sph.umich.edu/api/v1/";
+          data_sources = new LocusZoom.DataSources()
+            .add("assoc", ["AssociationLZ", {url: apiBase + "statistic/single/", params: { source: 45, id_field: "variant" }}])
+            .add("ld", ["LDServer", { url: "https://portaldev.sph.umich.edu/ld/", params: { source: '1000G', build: 'GRCh37', population: 'ALL' } }])
+            .add("gene", ["GeneLZ", { url: apiBase + "annotation/genes/", params: { build: 'GRCh37' } }])
+            .add("recomb", ["RecombLZ", { url: apiBase + "annotation/recomb/results/", params: { build: 'GRCh37' } }])
+            .add("constraint", ["GeneConstraintLZ", { url: "https://gnomad.broadinstitute.org/api/", params: { build: 'GRCh37' } }]);
+        } else {
+          apiBase = window.location.origin + window.location.pathname.substr(0, window.location.pathname.lastIndexOf("/") + 1) + "examples/data/";
+          data_sources = new LocusZoom.DataSources()
+            .add("assoc", ["AssociationLZ", {url: apiBase + "assoc_10_114550452-115067678.json?", params: { source: 45, id_field: "variant" }}])
+            .add("ld", ["LDServer", { url: apiBase + "ld_10_114550452-115067678.json?" , params: { build: 'GRCh37' }}])
+            .add("gene", ["GeneLZ", { url: apiBase + "genes_10_114550452-115067678.json?", params: { build: 'GRCh37' } }])
+            .add("recomb", ["RecombLZ", { url: apiBase + "recomb_10_114550452-115067678.json?", params: { build: 'GRCh37' } }])
+            .add("constraint", ["GeneConstraintLZ", {  url: apiBase + "constraint_10_114550452-115067678.json?", params: { build: 'GRCh37' } }]);
+        }
+
+        // Get the standard association plot layout from LocusZoom's built-in layouts
+        var stateUrlMapping = {chr: "chrom", start: "start", end: "end"};
+        // Fetch initial position from the URL, or use some defaults
+        var initialState = LzDynamicUrls.paramsFromUrl(stateUrlMapping);
+        if (!Object.keys(initialState).length) {
+            initialState = {chr: 10, start: 114550452, end: 115067678};
+        }
+        layout = LocusZoom.Layouts.get("plot", "standard_association", {state: initialState});
+        // Replace the standard association panel with the "multi LD" asociation panel
+        layout.panels[0] = LocusZoom.Layouts.get("panel", "association_multi_ld");
+
+        // Generate the LocusZoom plot, and reflect the initial plot state in url
+        window.plot = LocusZoom.populate("#lz-plot", data_sources, layout);
+
+        // Changes in the plot can be reflected in the URL, and vice versa (eg browser back button can go back to
+        //   a previously viewed region)
+        LzDynamicUrls.plotUpdatesUrl(plot, stateUrlMapping);
+        LzDynamicUrls.plotWatchesUrl(plot, stateUrlMapping);
+      </script>
+
+    </div>
+
+  </body>
+</html>

--- a/examples/misc/ext-multi_ld.html
+++ b/examples/misc/ext-multi_ld.html
@@ -82,6 +82,8 @@
         if (!Object.keys(initialState).length) {
             initialState = {chr: 10, start: 114550452, end: 115067678};
         }
+        initialState.ldrefvar = ['10:114734096_A/G', '10:114758349_C/T', '10:114788436_C/T', '10:114861304_A/G'];
+
         layout = LocusZoom.Layouts.get("plot", "standard_association", {state: initialState});
         // Replace the standard association panel with the "multi LD" asociation panel
         layout.panels[0] = LocusZoom.Layouts.get("panel", "association_multi_ld");

--- a/test/unit/data/test_adapters.js
+++ b/test/unit/data/test_adapters.js
@@ -479,17 +479,18 @@ describe('Data adapters', function () {
 
         it('will prefer a refvar in plot.state if one is provided', function () {
             const source = new LDServer({ url: 'www.fake.test', params: { build: 'GRCh37' } });
-            const [ref, _] = source.getRefvar(
+            const urls = source.getRefvar(
                 { ldrefvar: '12:100_A/C' },
                 { header: {}, body: [{ id: 'a', pvalue: 0 }] },
                 ['ldrefvar', 'state']
             );
+            const [ref, _] = urls[0];
             assert.equal(ref, '12:100_A/C');
         });
 
         it('auto-selects the best reference variant (lowest pvalue)', function () {
             const source = new LDServer({ url: 'www.fake.test', params: { build: 'GRCh37' } });
-            const [ref, _] = source.getRefvar(
+            const allRefVars = source.getRefvar(
                 {},
                 {
                     header: {},
@@ -501,12 +502,14 @@ describe('Data adapters', function () {
                 },
                 ['isrefvar', 'state']
             );
+
+            const [ref, _] = allRefVars[0];
             assert.equal(ref, '12:100_A/B');
         });
 
         it('auto-selects the best reference variant (largest nlog_pvalue)', function () {
             const source = new LDServer({ url: 'www.fake.test', params: { build: 'GRCh37' } });
-            const [ref, _] = source.getRefvar(
+            const allRefVars = source.getRefvar(
                 {},
                 {
                     header: {},
@@ -518,6 +521,7 @@ describe('Data adapters', function () {
                 },
                 ['isrefvar', 'state']
             );
+            const [ref, _] = allRefVars[0];
             assert.equal(ref, '12:100_A/B');
         });
 
@@ -557,10 +561,10 @@ describe('Data adapters', function () {
             const request_url = source.getURL({ ldrefvar: portal_format }, {
                 header: {},
                 body: [],
-            }, ['isrefvar', 'state']);
+            }, ['isrefvar', 'state'])[0];
             assert.equal(
                 request_url,
-                source.getURL({ ldrefvar: ldserver_format }, { header: {}, body: [] }, ['isrefvar', 'state'])
+                source.getURL({ ldrefvar: ldserver_format }, { header: {}, body: [] }, ['isrefvar', 'state'])[0]
             );
             assert.ok(request_url.includes(encodeURIComponent(ldserver_format)));
         });
@@ -572,10 +576,10 @@ describe('Data adapters', function () {
             const request_url = source.getURL({ ldrefvar: norefvar_topmed }, {
                 header: {},
                 body: [],
-            }, ['isrefvar', 'state']);
+            }, ['isrefvar', 'state'])[0];
             assert.equal(
                 request_url,
-                source.getURL({ ldrefvar: ldserver_format }, { header: {}, body: [] }, ['isrefvar', 'state'])
+                source.getURL({ ldrefvar: ldserver_format }, { header: {}, body: [] }, ['isrefvar', 'state'])[0]
             );
             assert.ok(request_url.includes(encodeURIComponent(ldserver_format)));
         });

--- a/test/unit/ext/test_multi_ld.js
+++ b/test/unit/ext/test_multi_ld.js
@@ -1,0 +1,29 @@
+import {assert} from 'chai';
+
+import LocusZoom from 'locuszoom';
+import {SCALABLE} from '../../../esm/registry';
+
+import ld_plugin from '../../../esm/ext/lz-multi-ld';
+
+LocusZoom.use(ld_plugin);
+
+describe('Multi LD plugin', function () {
+    describe('ld_multi_bin scale function', function () {
+        it('assigns LD by category', function () {
+            const options = {
+                categories: ['a', 'b', 'c'],
+                breaks: [1, 2, 3],
+                values: [
+                    ['a', 'aa', 'aaa'],
+                    ['b', 'bb', 'bbb'],
+                    ['c', 'cc', 'ccc'],
+                ],
+            };
+
+            const func = SCALABLE.get('ld_multi_bin');
+            assert.equal(func(options, ['b', 2.2]), 'bb', 'Finds a value based on matching category');
+            assert.equal(func(options, ['squid', 2.2]), null, 'Returns null if category is not a match');
+            assert.equal(func(options, [null, 2.2]), null, 'Returns null if category is not provided');
+        });
+    });
+});

--- a/webpack.common.cjs
+++ b/webpack.common.cjs
@@ -15,14 +15,15 @@ const outputPath = path.resolve(__dirname, 'dist');
 const FILENAMES = {
     // For legacy reasons, the filenames that people expect are different than the "library" name
     LocusZoom: 'locuszoom.app.min.js',
-    LzDynamicUrls: 'ext/lz-dynamic-urls.min.js',
-    LzWidgetAddons: 'ext/lz-widget-addons.min.js',
-    LzForestTrack: 'ext/lz-forest-track.min.js',
-    LzIntervalsTrack: 'ext/lz-intervals-track.min.js',
-    LzIntervalsEnrichment: 'ext/lz-intervals-enrichment.min.js',
-    LzCredibleSets: 'ext/lz-credible-sets.min.js',
-    LzTabix: 'ext/lz-tabix-source.min.js',
     LzAggregationTests: 'ext/lz-aggregation-tests.min.js',
+    LzCredibleSets: 'ext/lz-credible-sets.min.js',
+    LzDynamicUrls: 'ext/lz-dynamic-urls.min.js',
+    LzForestTrack: 'ext/lz-forest-track.min.js',
+    LzIntervalsEnrichment: 'ext/lz-intervals-enrichment.min.js',
+    LzIntervalsTrack: 'ext/lz-intervals-track.min.js',
+    LzMultiLD: 'ext/lz-multi-ld.min.js',
+    LzTabix: 'ext/lz-tabix-source.min.js',
+    LzWidgetAddons: 'ext/lz-widget-addons.min.js',
 };
 
 module.exports = {
@@ -30,14 +31,15 @@ module.exports = {
     entry: {
         // When a <script> is included in the page, entrypoint name = variable with content
         LocusZoom: path.resolve(srcPath, 'index.js'),
-        LzDynamicUrls: path.resolve(srcPath, 'ext', 'lz-dynamic-urls.js'),
-        LzWidgetAddons: path.resolve(srcPath, 'ext', 'lz-widget-addons.js'),
-        LzForestTrack: path.resolve(srcPath, 'ext', 'lz-forest-track.js'),
-        LzIntervalsTrack: path.resolve(srcPath, 'ext', 'lz-intervals-track.js'),
-        LzIntervalsEnrichment: path.resolve(srcPath, 'ext', 'lz-intervals-enrichment.js'),
-        LzCredibleSets: path.resolve(srcPath, 'ext', 'lz-credible-sets.js'),
-        LzTabix: path.resolve(srcPath, 'ext', 'lz-tabix-source.js'),
         LzAggregationTests: path.resolve(srcPath, 'ext', 'lz-aggregation-tests.js'),
+        LzCredibleSets: path.resolve(srcPath, 'ext', 'lz-credible-sets.js'),
+        LzDynamicUrls: path.resolve(srcPath, 'ext', 'lz-dynamic-urls.js'),
+        LzForestTrack: path.resolve(srcPath, 'ext', 'lz-forest-track.js'),
+        LzIntervalsEnrichment: path.resolve(srcPath, 'ext', 'lz-intervals-enrichment.js'),
+        LzIntervalsTrack: path.resolve(srcPath, 'ext', 'lz-intervals-track.js'),
+        LzMultiLD: path.resolve(srcPath, 'ext', 'lz-multi-ld.js'),
+        LzTabix: path.resolve(srcPath, 'ext', 'lz-tabix-source.js'),
+        LzWidgetAddons: path.resolve(srcPath, 'ext', 'lz-widget-addons.js'),
     },
     plugins: [
         new CleanWebpackPlugin({


### PR DESCRIPTION
# Ticket
#213 

# Purpose

This should also serve as a proof-of-concept for using widgets to encapsulate complex calculate logic:
- Layout rewrites (dynamically updating panel legends to show color schemes for 1..4 variants)
  - Should respect alternate layouts, eg if the `display_options` widget has overridden default behavior, then only rewrite legend when the legend is showing LD
- Clearing old LD reference variants as user scrolls to a new region (`region_changed` event)
- 

# Summary of changes
- [x] Allow scalable parameters to request/receive more than one field in the same custom scaling function
- [x] Legends now support new "shape: ribbon" option describing LD palette
- [ ] LDServer adapter now allows requesting more than one LDRefvar, and provides additional fields of info, eg which refvar is the best match
- [ ] Allow scatter plots to configure stroke color (one value for all points)- move from SCSS to d3 root element
- [ ] New toolbar button that encapsulates layer-layout rewrite logic when multiple ld refvars are selected
- [ ] Identify best way to set multiple ld refvars
