### PR TITLE
Helper function to rename fields anywhere in a layout

### DIFF
--- a/assets/docs/rendering_layouts.md
+++ b/assets/docs/rendering_layouts.md
@@ -116,6 +116,25 @@ The other main exception to the `fields` mechanism involves API endpoints that r
   
 Most standard data types use the system of exact field names. A more detailed guide is beyond the scope of this tutorial; this behavior is governed by the `extractFields` method of `BaseAdapter`. (see: [guide to working with data](data_retrieval.html))
 
+### renameFields: resolving tiny differences in naming
+Sometimes, an existing layout is very close to the format of your data, but there are very small cosmetic differences. For example, your API might send a field `variant_name` instead of `variant`.
+
+In this case, a helper function is provided this will recursively rename every usage of a specified field name in a layout:
+
+```javascript
+// For abstract layouts
+layout = LocusZoom.Layouts.renameField(layout, '{{namespace[assoc]}}old_name', '{{namespace[assoc]}}new_name');
+
+// For concrete layouts
+layout = LocusZoom.Layouts.renameField(layout, 'my_assoc:old_name', 'my_assoc:new_name');
+
+// To remove a transformation function that is no longer interesting. (must be done in a separate step; otherwise transforms will be preserved after the rename)
+// The last argument (warn_transforms) suppresses the JS console message that tells you when a rename would affect a field that uses transforms. After all, in this case, that's sort of the point.
+layout = LocusZoom.Layouts.renameField(layout, 'assoc:pvalue|neg_log10', 'assoc:pvalue', false);
+```
+
+> NOTE: Sometimes, the differences in data/field names are more than cosmetic: for example, renaming `pvalue|neg_log10` to `log_pvalue|neg_log10` would not make sense. This helper method will attempt to warn you if template transformation functions are being used on the field you are changing, so that you can ensure that the resulting layouts uses your data in a way that fits the intended meaning.
+
 ## Working with the Registry
 Typically, LocusZoom layouts are loaded via the registry, a set of pre-made reusable layouts. The act of fetching a layout converts it from the abstract definition to one that works with a specific dataset.  
 

--- a/esm/helpers/layouts.js
+++ b/esm/helpers/layouts.js
@@ -137,4 +137,57 @@ function nameToSymbol(shape) {
     return d3[factory_name] || null;
 }
 
-export { applyNamespaces, deepCopy, merge, nameToSymbol };
+/**
+ * A utility helper for customizing one part of a pre-made layout. Whenever a primitive value is found (eg string),
+ *  replaces *exact match*
+ *
+ * This method works by comparing whether strings are a match. As a result, the "old" and "new" names must match
+ *  whatever namespacing is used in the input layout.
+ * Note: this utility *can* replace values with filters, but will not do so by default.
+ *
+ * @alias LayoutRegistry.renameField
+ *
+ * @param {object} layout The layout object to be transformed.
+ * @param {string} old_name The old field name that will be replaced
+ * @param {string} new_name The new field name that will be substituted in
+ * @param {boolean} [warn_transforms=true] Sometimes, a field name is used with transforms appended, eg `label|htmlescape`.
+ *   In some cases a rename could change the meaning of the field, and by default this method will print a warning to
+ *   the console, encouraging the developer to check the relevant usages. This warning can be silenced via an optional function argument.
+ */
+function renameField(layout, old_name, new_name, warn_transforms = true) {
+    const this_type = typeof layout;
+    // Handle nested types by recursion (in which case, `layout` may be something other than an object)
+    if (Array.isArray(layout)) {
+        return layout.map((item) => renameField(item, old_name, new_name, warn_transforms));
+    } else if (this_type === 'object' && layout !== null) {
+        return Object.keys(layout).reduce(
+            (acc, key) => {
+                acc[key] = renameField(layout[key], old_name, new_name, warn_transforms);
+                return acc;
+            }, {}
+        );
+    } else if (this_type !== 'string') {
+        // Field names are always strings. If the value isn't a string, don't even try to change it.
+        return layout;
+    } else {
+        // If we encounter a field we are trying to rename, then do so!
+        // Rules:
+        //  1. Try to avoid renaming part of a field, by checking token boundaries (field1 should not rename field1_displayvalue)
+        //  2. Warn the user if filter functions are being used with the specified field, so they can audit for changes in meaning
+        const escaped = old_name.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&');
+
+        if (warn_transforms) {
+            // Warn the user that they might be renaming, eg, `pvalue|neg_log` to `log_pvalue|neg_log`. Let them decide
+            //   whether the new field name has a meaning that is compatible with the specified transforms.
+            const filter_regex = new RegExp(`${escaped}\\|\\w+`, 'g');
+            const filter_matches = (layout.match(filter_regex) || []);
+            filter_matches.forEach((match_val) => console.warn(`renameFields is renaming a field that uses transform functions: was '${match_val}' . Verify that these transforms are still appropriate.`));
+        }
+
+        // Find and replace any substring, so long as it is at the end of a valid token
+        const regex = new RegExp(`${escaped}(?!\\w+)`, 'g');
+        return layout.replace(regex, new_name);
+    }
+}
+
+export { applyNamespaces, deepCopy, merge, nameToSymbol, renameField };

--- a/esm/registry/layouts.js
+++ b/esm/registry/layouts.js
@@ -1,5 +1,5 @@
 import {RegistryBase} from './base';
-import {applyNamespaces, deepCopy, merge} from '../helpers/layouts';
+import {applyNamespaces, deepCopy, merge, renameField} from '../helpers/layouts';
 import * as layouts from '../layouts';
 
 /**
@@ -90,6 +90,15 @@ class LayoutRegistry extends RegistryBase {
      */
     merge(custom_layout, default_layout) {
         return merge(custom_layout, default_layout);
+    }
+
+    /**
+     * Static alias to a helper method. Allows renaming fields
+     * @static
+     * @private
+     */
+    renameField() {
+        return renameField(...arguments);
     }
 }
 

--- a/test/unit/helpers/test_layouts.js
+++ b/test/unit/helpers/test_layouts.js
@@ -1,0 +1,93 @@
+import {assert} from 'chai';
+import sinon from 'sinon';
+
+import {renameField} from '../../../esm/helpers/layouts';
+
+describe('Layout helper functions', function () {
+    describe('renameFields', function () {
+        beforeEach(function() {
+            this.warn_spy = sinon.spy(console, 'warn');
+        });
+        afterEach(function() {
+            sinon.restore();
+        });
+
+        it('recursively renames the field across objects, arrays, and strings', function () {
+            let base = {
+                id: 'layout',
+                x_axis: { field: 'old_name' },
+                y_axis: { field: 'unrelated_thing' },
+                category_field_name: 'old_name',
+                fields: ['old_name'],
+                no_value: null,
+            };
+            base = renameField(base, 'old_name', 'moon_unit');
+            assert.deepEqual(base, {
+                id: 'layout',
+                x_axis: { field: 'moon_unit' },
+                y_axis: { field: 'unrelated_thing' },
+                category_field_name: 'moon_unit',
+                fields: ['moon_unit'],
+                no_value: null,
+            });
+        });
+
+        it('will handle filters and partial fragments appropriately', function () {
+            let base = {
+                field1: 'old_name',
+                field2: 'old_name|htmlescape',
+                field3: 'old_name_truncated',
+            };
+
+            base = renameField(base, 'old_name', 'moon_unit');
+            assert.deepEqual(base, {
+                field1: 'moon_unit',
+                field2: 'moon_unit|htmlescape',
+                field3: 'old_name_truncated',
+            });
+        });
+
+        it('warns when a value is used with filters', function () {
+            let base = { field1: 'old_name|htmlescape' };
+
+            base = renameField(base, 'old_name', 'moon_unit');
+            assert.deepEqual(base, { field1: 'moon_unit|htmlescape' });
+            assert.ok(this.warn_spy.calledOnce, 'console.warn was called');
+            assert.match(this.warn_spy.firstCall.args[0], /old_name\|htmlescape/, 'Error message specifies the field and filter to check');
+
+            base = renameField(base, 'old_name', 'moon_unit', false);
+            assert.ok(this.warn_spy.calledOnce, 'console.warn output was suppressed on second function call');
+        });
+
+        it('handles field names embedded in template literals', function () {
+            let base = {
+                tooltip_template: '{{old_name}} likes music',
+                label_template: 'Dweezil and {{old_name}} went out for ice cream; {{old_name}} paid the bill',
+            };
+
+            base = renameField(base, 'old_name', 'moon_unit');
+            assert.deepEqual(base, {
+                tooltip_template: '{{moon_unit}} likes music',
+                label_template: 'Dweezil and {{moon_unit}} went out for ice cream; {{moon_unit}} paid the bill',
+            });
+        });
+
+        it('works with abstract layouts and namespace syntax', function () {
+            let base = {
+                field: '{{namespace[family]}}old_name',
+                template: '{{{{namespace[family]}}old_name}} was here',
+            };
+            base = renameField(base, '{{namespace[family]}}old_name', '{{namespace[family]}}moon_unit');
+            assert.deepEqual(base, {
+                field: '{{namespace[family]}}moon_unit',
+                template: '{{{{namespace[family]}}moon_unit}} was here',
+            });
+        });
+
+        it('can also be (ab)used to strip filters from an existing name', function () {
+            let base = { field: 'old_name|afilter' };
+            base = renameField(base, 'old_name|afilter', 'old_name');
+            assert.deepEqual(base, { field: 'old_name' });
+        });
+    });
+});


### PR DESCRIPTION
# Purpose
LocusZoom attempts to support many kinds of data, but in practice, no two usages have the same nomenclature.

This is very annoying when working with reusable layouts- modifying nested objects is not fun. This PR adds a simple helper method to make this process easier.

See unit tests for a full set of example use cases.

 `LocusZoom.Layouts.renameFields(layout, old_name, new_name, warn_transforms = true)`

Tagging: @kbruskiewicz