### PR TITLE
Fix plot rendering in tab/collapsible widgets

### DIFF
--- a/esm/components/plot.js
+++ b/esm/components/plot.js
@@ -1119,16 +1119,17 @@ class Plot {
             this.trackExternalListener(window, 'resize', resize_listener);
 
             // Many libraries collapse/hide tab widgets using display:none, which doesn't trigger the resize listener
-            // To fix a plot display issue, use a newer browser feature. IntersectionObservers are (in theory)
-            //  cleaned up when all nodes referencing them are removed, without a separate window-level listener cleanup step
             //   High threshold: Don't fire listeners on every 1px change, but allow this to work if the plot position is a bit cockeyed
-            const options = { root: document.documentElement, threshold: 0.9 };
-            const observer = new IntersectionObserver((entries, observer) => {
-                if (entries.some((entry) => entry.intersectionRatio > 0)) {
-                    this.rescaleSVG();
-                }
-            }, options);
-            observer.observe(this.container);
+            if (typeof IntersectionObserver !== 'undefined') { // don't do this in old browsers
+                const options = { root: document.documentElement, threshold: 0.9 };
+                const observer = new IntersectionObserver((entries, observer) => {
+                    if (entries.some((entry) => entry.intersectionRatio > 0)) {
+                        this.rescaleSVG();
+                    }
+                }, options);
+                // IntersectionObservers will be cleaned up when DOM node removed; no need to track them for manual cleanup
+                observer.observe(this.container);
+            }
 
             // Forcing one additional setDimensions() call after the page is loaded clears up
             // any disagreements between the initial layout and the loaded responsive container's size

--- a/test/unit/components/test_plot.js
+++ b/test/unit/components/test_plot.js
@@ -7,8 +7,6 @@ import DataSources from '../../../esm/data';
 import {populate} from '../../../esm/helpers/display';
 
 describe('LocusZoom.Plot', function() {
-    // Tests
-
     describe('Geometry and Panels', function() {
         beforeEach(function() {
             const layout = {
@@ -99,6 +97,22 @@ describe('LocusZoom.Plot', function() {
 
             assert.equal(panelA.layout.height, 50, 'Panel A does not shrink below the minimum size');
             assert.equal(panelB.layout.height, 100, 'Panel B does not shrink below the minimum size');
+        });
+
+        it.skip('resizes to the full container size when toggling display:none --> visible', function () {
+            // TODO: JSDOM doesn't implement intersectionobserver, making it hard to unit test this feature without extensive mocking.
+            const plot = this.plot;
+            plot.layout.responsive_resize = true;
+            plot.layout.min_width = 50;
+            plot.initialize();
+
+            d3.select('body').style('display', 'none');
+            plot.rescaleSVG();
+            assert.equal(plot.layout.width, 50, 'When parent element is hidden, plot renders to the minimum dimensions');
+
+            d3.select('body').style('display', 'block');
+            plot.rescaleSVG();
+            assert.equal(plot.layout.width, 100, 'When parent element is shown, plot renders to the desired width');
         });
 
         it('should enforce consistent data layer widths and x-offsets across x-linked panels', function() {


### PR DESCRIPTION
Many collapsible/tab widgets hide content using `display:none`. This can lead to plot dimension issues when the LZ plot is first drawn, because changing display mode doesn't trigger the resize listener on a window.

Use a relatively new (2017) browser API to handle this scenario. This should be performance tested in our own sites (like LocalZoom) so that we can monitor errors before shipping as part of a formal release.

Also moved resize listener to after the plot container/svg is defined, to reduce some spurious item undefined errors. (initializeLayout --> initialize)

TODO:
1. [x] Performance test; identify if listener is firing too often
2. [x] Handle older browser (check if api is available)
3. [~] Add unit tests for size behavior
3. [~] Implement in LocalZoom and collect error monitoring/reports
