### PR TITLE
doc: Fix "separation of concern" list display

### DIFF
--- a/assets/docs/index.md
+++ b/assets/docs/index.md
@@ -107,7 +107,8 @@ See the full [developer documentation](../api/global.html#event:baseLZEvent) for
 ## Separation of concerns
 Visualizations are responsible for displaying the information given. Each element is intended to be largely isolated and decoupled: for the most part, pieces can be mixed and matched without needing to know about (or influence) the internal behavior of other pieces.
 
-Operations on data are performed by the following elements,
+Operations on data are performed by the following elements:
+
 * [Adapters](../api/module-LocusZoom_Adapters.html) coordinate the formatting and retrieval of data (see: [guide to working with data](data_retrieval.html))
 * Various function registries provide a way to modify the display or behavior of elements by injecting custom user-defined code into existing reusable elements:  
   * [Matching functions](../api/module-LocusZoom_MatchFunctions.html) coordinate filter and match operations that affect which items are displayed across different panels (see: [guide to interactivity](interactivity.html)).


### PR DESCRIPTION
Add a missing empty line before the beginning of the list

See current display at https://statgen.github.io/locuszoom/docs/guides/index.html

![image](https://user-images.githubusercontent.com/1204125/166207019-ceab46d1-507a-4729-9b21-83433f7951e9.png)
